### PR TITLE
Add blank webpage to gui

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Piper Draw</title>
+</head>
+<body>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds a blank `index.html` page with basic HTML boilerplate to the `gui/` directory

## Test plan
- [ ] Open `gui/index.html` in a browser and confirm it loads as an empty page

🤖 Generated with [Claude Code](https://claude.com/claude-code)