### PR TITLE
Add TQEC color-matching validation for block placement

### DIFF
--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -8,6 +8,8 @@ import {
   createBlockEdges,
   blockThreeSize,
   hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
   isValidPos,
   isPipeType,
   resolvePipeType,
@@ -15,7 +17,7 @@ import {
   posKey,
   VARIANT_AXIS_MAP,
 } from "../types";
-import type { BlockType, Block, FaceMask, Position3D, PipeVariant } from "../types";
+import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant } from "../types";
 
 const MIN_CAPACITY = 64;
 
@@ -205,7 +207,12 @@ function TypedInstances({
 
       const adj = getAdjacentPos(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, dstType);
 
-      if (!isValidPos(adj, dstType) || hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex)) {
+      if (
+        !isValidPos(adj, dstType) ||
+        hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex) ||
+        (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) ||
+        (!isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks))
+      ) {
         store.setHoveredGridPos(adj, dstType, true);
       } else {
         store.setHoveredGridPos(adj, dstType);

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -3,7 +3,8 @@ import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { snapGroundPos, hasBlockOverlap, isValidPos, resolvePipeType } from "../types";
+import { snapGroundPos, hasBlockOverlap, hasCubeColorConflict, hasPipeColorConflict, isValidPos, isPipeType, resolvePipeType } from "../types";
+import type { CubeType } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
 
 const PLANE_SIZE = 1000;
@@ -41,7 +42,12 @@ export function GridPlane() {
       blockType = resolved;
     }
 
-    if (!isValidPos(pos, blockType) || hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex)) {
+    if (
+      !isValidPos(pos, blockType) ||
+      hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex) ||
+      (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) ||
+      (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks))
+    ) {
       setHoveredGridPos(pos, blockType, true);
     } else {
       setHoveredGridPos(pos, blockType);

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1,8 +1,11 @@
 import { create } from "zustand";
-import type { Position3D, Block, BlockType, PipeVariant, SpatialIndex, FaceMask } from "../types";
+import type { Position3D, Block, BlockType, CubeType, PipeVariant, SpatialIndex, FaceMask } from "../types";
 import {
   posKey,
   hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
+  isPipeType,
   isValidPos,
   resolvePipeType,
   buildSpatialIndex,
@@ -140,6 +143,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       // Validate position parity
       if (!isValidPos(pos, blockType)) return state;
       if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex)) return state;
+      if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
+      if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
 
       const key = posKey(pos);
       const block: Block = { pos, type: blockType };

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -744,6 +744,77 @@ export function hasBlockOverlap(pos: Position3D, type: BlockType, blocks: Map<st
   return false;
 }
 
+/**
+ * Check whether a pipe placement conflicts with adjacent cube colors.
+ * For each of the pipe's two closed TQEC axes, the pipe's basis character
+ * must match any adjacent cube's basis character on the same axis.
+ * Returns true if there IS a conflict (placement should be rejected).
+ */
+export function hasPipeColorConflict(
+  pipeType: PipeType,
+  pipePos: Position3D,
+  blocks: Map<string, Block>,
+): boolean {
+  const base = pipeType.replace("H", "");
+  const openAxis = base.indexOf("O"); // 0, 1, or 2
+
+  const coords: [number, number, number] = [pipePos.x, pipePos.y, pipePos.z];
+
+  for (const offset of [-1, 2]) {
+    const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+    nCoords[openAxis] += offset;
+    const neighborKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
+    const neighbor = blocks.get(neighborKey);
+
+    if (!neighbor) continue;
+    if (neighbor.type === "Y") continue;
+    if (isPipeType(neighbor.type)) continue;
+
+    for (let axis = 0; axis < 3; axis++) {
+      if (axis === openAxis) continue;
+      if (base[axis] !== neighbor.type[axis]) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check whether a cube placement conflicts with adjacent pipe colors.
+ * For each of the 3 TQEC axes, checks both possible neighboring pipe positions.
+ * Returns true if there IS a conflict (placement should be rejected).
+ */
+export function hasCubeColorConflict(
+  cubeType: CubeType,
+  cubePos: Position3D,
+  blocks: Map<string, Block>,
+): boolean {
+  const coords: [number, number, number] = [cubePos.x, cubePos.y, cubePos.z];
+
+  for (let axis = 0; axis < 3; axis++) {
+    // Two pipe positions along this axis: pos[axis]+1 and pos[axis]-2
+    for (const offset of [1, -2]) {
+      const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+      nCoords[axis] += offset;
+      const neighbor = blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
+
+      if (!neighbor) continue;
+      if (!isPipeType(neighbor.type)) continue;
+
+      const base = neighbor.type.replace("H", "");
+      const openAxis = base.indexOf("O");
+      if (openAxis !== axis) continue; // pipe isn't oriented toward this cube
+
+      for (let i = 0; i < 3; i++) {
+        if (i === openAxis) continue;
+        if (base[i] !== cubeType[i]) return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Adjacency
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `hasPipeColorConflict()` and `hasCubeColorConflict()` validation functions that enforce TQEC basis color consistency at pipe-cube boundaries
- When placing a pipe next to a cube (or vice versa), the closed-axis colors must match on shared TQEC axes — mismatches are rejected
- Ghost preview shows red for invalid placements in both face-click and ground-plane placement modes

## Test plan
- [ ] Place a cube, then try placing a pipe next to it with matching colors — should succeed
- [ ] Place a cube, then try placing a pipe with mismatching closed-axis colors — ghost should turn red, placement blocked
- [ ] Place a pipe, then try placing a cube next to it with mismatching colors — same rejection behavior
- [ ] Hadamard pipe variants follow the same validation rules
- [ ] Existing tests pass (`npm test` — 32/32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)