### PR TITLE
Add TQEC color-matching validation for block placement

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -118,6 +118,32 @@ function CheckerboardGrid() {
   );
 }
 
+function PlacementWarning() {
+  const reason = useBlockStore((s) => s.hoveredInvalidReason);
+  if (!reason) return null;
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 24,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1,
+        background: "rgba(180, 40, 40, 0.92)",
+        color: "#fff",
+        padding: "8px 18px",
+        borderRadius: "8px",
+        fontSize: "14px",
+        fontWeight: 500,
+        pointerEvents: "none",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+      }}
+    >
+      {reason}
+    </div>
+  );
+}
+
 export default function App() {
   const fpsRef = useRef<HTMLSpanElement>(null);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -162,6 +188,7 @@ export default function App() {
       >
         <FpsDisplay spanRef={fpsRef} />
       </div>
+      <PlacementWarning />
       <Canvas
         camera={{ position: [10, 10, -10], fov: 35 }}
         gl={{ logarithmicDepthBuffer: true, toneMapping: THREE.ACESFilmicToneMapping }}

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -10,6 +10,7 @@ import {
   hasBlockOverlap,
   hasCubeColorConflict,
   hasPipeColorConflict,
+  isValidPipePos,
   isValidPos,
   isPipeType,
   resolvePipeType,
@@ -38,6 +39,7 @@ function resolvePipeTypeFromFace(
 ): BlockType | null {
   for (const candidateType of VARIANT_AXIS_MAP[variant]) {
     const probe = getAdjacentPos(srcPos, srcType, normal, candidateType);
+    if (!isValidPipePos(probe)) continue;
     const resolved = resolvePipeType(variant, probe);
     if (resolved) return resolved;
   }

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -207,13 +207,12 @@ function TypedInstances({
 
       const adj = getAdjacentPos(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, dstType);
 
-      if (
-        !isValidPos(adj, dstType) ||
-        hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex) ||
-        (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) ||
-        (!isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks))
-      ) {
+      if (!isValidPos(adj, dstType) || hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex)) {
         store.setHoveredGridPos(adj, dstType, true);
+      } else if (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
+        store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube");
+      } else if (!isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks)) {
+        store.setHoveredGridPos(adj, dstType, true, "Cube colors don't match the adjacent pipe");
       } else {
         store.setHoveredGridPos(adj, dstType);
       }

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -8,6 +8,8 @@ import {
   createBlockEdges,
   blockThreeSize,
   hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
   isValidPos,
   isPipeType,
   resolvePipeType,
@@ -15,7 +17,7 @@ import {
   posKey,
   VARIANT_AXIS_MAP,
 } from "../types";
-import type { BlockType, Block, FaceMask, Position3D, PipeVariant } from "../types";
+import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant } from "../types";
 
 const MIN_CAPACITY = 64;
 
@@ -205,7 +207,12 @@ function TypedInstances({
 
       const adj = getAdjacentPos(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, dstType);
 
-      if (!isValidPos(adj, dstType) || hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex)) {
+      if (
+        !isValidPos(adj, dstType) ||
+        hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex) ||
+        (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) ||
+        (!isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks))
+      ) {
         store.setHoveredGridPos(adj, dstType, true);
       } else {
         store.setHoveredGridPos(adj, dstType);

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -3,7 +3,8 @@ import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { snapGroundPos, hasBlockOverlap, isValidPos, resolvePipeType } from "../types";
+import { snapGroundPos, hasBlockOverlap, hasCubeColorConflict, hasPipeColorConflict, isValidPos, isPipeType, resolvePipeType } from "../types";
+import type { CubeType } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
 
 const PLANE_SIZE = 1000;
@@ -41,7 +42,12 @@ export function GridPlane() {
       blockType = resolved;
     }
 
-    if (!isValidPos(pos, blockType) || hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex)) {
+    if (
+      !isValidPos(pos, blockType) ||
+      hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex) ||
+      (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) ||
+      (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks))
+    ) {
       setHoveredGridPos(pos, blockType, true);
     } else {
       setHoveredGridPos(pos, blockType);

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -42,13 +42,12 @@ export function GridPlane() {
       blockType = resolved;
     }
 
-    if (
-      !isValidPos(pos, blockType) ||
-      hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex) ||
-      (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) ||
-      (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks))
-    ) {
+    if (!isValidPos(pos, blockType) || hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex)) {
       setHoveredGridPos(pos, blockType, true);
+    } else if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) {
+      setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube");
+    } else if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
+      setHoveredGridPos(pos, blockType, true, "Cube colors don't match the adjacent pipe");
     } else {
       setHoveredGridPos(pos, blockType);
     }

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -45,11 +45,12 @@ interface BlockStore {
   hoveredGridPos: Position3D | null;
   hoveredBlockType: BlockType | null;
   hoveredInvalid: boolean;
+  hoveredInvalidReason: string | null;
 
   setMode: (mode: Mode) => void;
   setCubeType: (cubeType: BlockType) => void;
   setPipeVariant: (variant: PipeVariant) => void;
-  setHoveredGridPos: (pos: Position3D | null, blockType?: BlockType, invalid?: boolean) => void;
+  setHoveredGridPos: (pos: Position3D | null, blockType?: BlockType, invalid?: boolean, reason?: string) => void;
   addBlock: (pos: Position3D) => void;
   removeBlock: (pos: Position3D) => void;
   undo: () => void;
@@ -110,22 +111,25 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   hoveredGridPos: null,
   hoveredBlockType: null,
   hoveredInvalid: false,
+  hoveredInvalidReason: null,
 
-  setMode: (mode) => set({ mode, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false }),
+  setMode: (mode) => set({ mode, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null }),
   setCubeType: (cubeType) => set({ cubeType, pipeVariant: null }),
   setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant] }),
-  setHoveredGridPos: (pos, blockType, invalid) => set((state) => {
+  setHoveredGridPos: (pos, blockType, invalid, reason) => set((state) => {
     const bt = blockType ?? null;
     const inv = invalid ?? false;
+    const rsn = reason ?? null;
     // Skip no-op updates to avoid unnecessary re-renders
     if (
       state.hoveredGridPos?.x === pos?.x &&
       state.hoveredGridPos?.y === pos?.y &&
       state.hoveredGridPos?.z === pos?.z &&
       state.hoveredBlockType === bt &&
-      state.hoveredInvalid === inv
+      state.hoveredInvalid === inv &&
+      state.hoveredInvalidReason === rsn
     ) return state;
-    return { hoveredGridPos: pos, hoveredBlockType: bt, hoveredInvalid: inv };
+    return { hoveredGridPos: pos, hoveredBlockType: bt, hoveredInvalid: inv, hoveredInvalidReason: rsn };
   }),
 
   addBlock: (pos) =>

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1,8 +1,11 @@
 import { create } from "zustand";
-import type { Position3D, Block, BlockType, PipeVariant, SpatialIndex, FaceMask } from "../types";
+import type { Position3D, Block, BlockType, CubeType, PipeVariant, SpatialIndex, FaceMask } from "../types";
 import {
   posKey,
   hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
+  isPipeType,
   isValidPos,
   resolvePipeType,
   buildSpatialIndex,
@@ -140,6 +143,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       // Validate position parity
       if (!isValidPos(pos, blockType)) return state;
       if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex)) return state;
+      if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
+      if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
 
       const key = posKey(pos);
       const block: Block = { pos, type: blockType };

--- a/piper_draw/gui/src/types/index.test.ts
+++ b/piper_draw/gui/src/types/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos } from "./index";
+import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict } from "./index";
+import type { PipeType, CubeType } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
 
@@ -129,6 +130,134 @@ describe("pipe snapping and adjacency consistency", () => {
     expect(isValidPipePos(northSnap)).toBe(true);
     expect(southSnap.x === south.x || southSnap.y === south.y).toBe(true);
     expect(northSnap.x === north.x || northSnap.y === north.y).toBe(true);
+  });
+});
+
+describe("hasPipeColorConflict", () => {
+  it("allows pipe when closed-axis colors match the adjacent cube", () => {
+    // Pipe "OXZ" (open X): axis 1='X', axis 2='Z'
+    // Cube "ZXZ": axis 1='X', axis 2='Z' → match
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "ZXZ" }]);
+    expect(hasPipeColorConflict("OXZ" as PipeType, { x: 1, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("rejects pipe when closed-axis colors don't match", () => {
+    // Pipe "OZX" (open X): axis 1='Z', axis 2='X'
+    // Cube "XZZ": axis 1='Z', axis 2='Z' → mismatch on axis 2
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "XZZ" }]);
+    expect(hasPipeColorConflict("OZX" as PipeType, { x: 1, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("allows pipe with no adjacent cubes", () => {
+    const blocks = makeBlocks([]);
+    expect(hasPipeColorConflict("OZX" as PipeType, { x: 1, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("skips Y-type neighbors", () => {
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "Y" }]);
+    expect(hasPipeColorConflict("OZX" as PipeType, { x: 1, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("checks both ends of the pipe", () => {
+    // Pipe "ZOX" (open Y) at (0,1,0): start neighbor at (0,0,0), far neighbor at (0,3,0)
+    // Both cubes must match axis 0='Z', axis 2='X'
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "ZZX" },
+      { x: 0, y: 3, z: 0, type: "ZZX" },
+    ]);
+    expect(hasPipeColorConflict("ZOX" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("rejects when far-end cube doesn't match", () => {
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "ZZX" },  // matches
+      { x: 0, y: 3, z: 0, type: "XZZ" },  // axis 0: 'X' vs 'Z' → mismatch
+    ]);
+    expect(hasPipeColorConflict("ZOX" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(true);
+  });
+});
+
+describe("hasPipeColorConflict — Hadamard", () => {
+  it("uses swapped colors at the far end for X-open pipes", () => {
+    // Pipe "OZXH" (open X): base "OZX", axis 1='Z', axis 2='X'
+    // Far end (+2 offset, x=3): swapped → axis 1='X', axis 2='Z'
+    // Cube at x=3 with axis 1='X', axis 2='Z' should match
+    const blocks = makeBlocks([{ x: 3, y: 0, z: 0, type: "ZXZ" }]);
+    expect(hasPipeColorConflict("OZXH" as PipeType, { x: 1, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("rejects far-end cube with unswapped colors for X-open Hadamard", () => {
+    // Same pipe, but cube has original (unswapped) colors
+    const blocks = makeBlocks([{ x: 3, y: 0, z: 0, type: "ZZX" }]);
+    expect(hasPipeColorConflict("OZXH" as PipeType, { x: 1, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("reverses swap direction for Y-open Hadamard pipes", () => {
+    // Pipe "XOZH" (open Y): base "XOZ", axis 0='X', axis 2='Z'
+    // Y-open: swap is at START end (offset -1, cube at y=0)
+    // Start end swapped: axis 0='Z', axis 2='X'
+    // Cube "XZZ" at (0,0,0): axis 0='X' → mismatch with swapped 'Z'
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "XZZ" }]);
+    expect(hasPipeColorConflict("XOZH" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("allows Y-open Hadamard when start-end cube matches swapped colors", () => {
+    // Pipe "XOZH" start end swapped: axis 0='Z', axis 2='X'
+    // Cube "ZZX" at (0,0,0): axis 0='Z', axis 2='X' → match
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "ZZX" }]);
+    expect(hasPipeColorConflict("XOZH" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("uses original colors at far end for Y-open Hadamard", () => {
+    // Pipe "XOZH" far end (y=3): NOT swapped → axis 0='X', axis 2='Z'
+    // Cube "XZZ" at (0,3,0): axis 0='X', axis 2='Z' → match
+    const blocks = makeBlocks([{ x: 0, y: 3, z: 0, type: "XZZ" }]);
+    expect(hasPipeColorConflict("XOZH" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(false);
+  });
+});
+
+describe("hasCubeColorConflict", () => {
+  it("allows cube when adjacent pipe colors match", () => {
+    // Pipe "OXZ" at (1,0,0): axis 1='X', axis 2='Z'
+    // Cube "ZXZ": axis 1='X', axis 2='Z' → match
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OXZ" as BlockType }]);
+    expect(hasCubeColorConflict("ZXZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("rejects cube when adjacent pipe colors don't match", () => {
+    // Pipe "OZX" at (1,0,0): axis 1='Z', axis 2='X'
+    // Cube "XZZ": axis 1='Z' ✓, axis 2='Z' vs pipe 'X' → mismatch
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" as BlockType }]);
+    expect(hasCubeColorConflict("XZZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("rejects cube when pipe on the -2 side doesn't match", () => {
+    // Pipe "OZX" at (-2,0,0) (open X): far end faces cube at (0,0,0)
+    // axis 1='Z', axis 2='X'. Cube "XZZ": axis 1='Z' ✓, axis 2='Z' vs 'X' → mismatch
+    const blocks = makeBlocks([{ x: -2, y: 0, z: 0, type: "OZX" as BlockType }]);
+    expect(hasCubeColorConflict("XZZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("uses swapped colors for Hadamard pipe's far end facing cube", () => {
+    // Pipe "OZXH" at (-2,0,0): far end (+2 = x=0) faces the cube
+    // base "OZX", swapped at far end: axis 1='X', axis 2='Z'
+    // Cube "ZXZ": axis 1='X', axis 2='Z' → match
+    const blocks = makeBlocks([{ x: -2, y: 0, z: 0, type: "OZXH" as BlockType }]);
+    expect(hasCubeColorConflict("ZXZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("reverses Hadamard swap for Y-open pipe facing cube", () => {
+    // Pipe "XOZH" at (0,1,0): cube at (0,0,0) is on start side
+    // Y-open: swapped at start → axis 0='Z', axis 2='X'
+    // Cube "XZZ": axis 0='X' vs 'Z' → mismatch
+    const blocks = makeBlocks([{ x: 0, y: 1, z: 0, type: "XOZH" as BlockType }]);
+    expect(hasCubeColorConflict("XZZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("skips pipes not oriented toward the cube", () => {
+    // Pipe "ZOX" (open Y) at (1,0,0): openAxis=1 but offset axis=0 → skip
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "ZOX" as BlockType }]);
+    expect(hasCubeColorConflict("XZZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
   });
 });
 

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -745,9 +745,26 @@ export function hasBlockOverlap(pos: Position3D, type: BlockType, blocks: Map<st
 }
 
 /**
+ * Get the effective basis character for a pipe on a given TQEC axis at one end.
+ * Hadamard pipes swap their two closed-axis colors above the band.
+ * Because TQEC Y maps to -Three.js Z, the "above band" end is at:
+ *   - offset +2 (far end) for X-open and Z-open pipes
+ *   - offset -1 (start end) for Y-open pipes (axis direction is reversed)
+ * `swapped` = true means this end sees the swapped colors.
+ */
+function pipeEndBasis(base: string, hadamard: boolean, openAxis: number, axis: number, swapped: boolean): string {
+  if (!hadamard || !swapped) return base[axis];
+  // Swap: return the other closed axis's character
+  const closedAxes = [0, 1, 2].filter(a => a !== openAxis);
+  const otherAxis = closedAxes[0] === axis ? closedAxes[1] : closedAxes[0];
+  return base[otherAxis];
+}
+
+/**
  * Check whether a pipe placement conflicts with adjacent cube colors.
  * For each of the pipe's two closed TQEC axes, the pipe's basis character
  * must match any adjacent cube's basis character on the same axis.
+ * For Hadamard pipes, the far end (offset +2) uses swapped colors.
  * Returns true if there IS a conflict (placement should be rejected).
  */
 export function hasPipeColorConflict(
@@ -756,6 +773,7 @@ export function hasPipeColorConflict(
   blocks: Map<string, Block>,
 ): boolean {
   const base = pipeType.replace("H", "");
+  const hadamard = pipeType.length > 3;
   const openAxis = base.indexOf("O"); // 0, 1, or 2
 
   const coords: [number, number, number] = [pipePos.x, pipePos.y, pipePos.z];
@@ -763,16 +781,18 @@ export function hasPipeColorConflict(
   for (const offset of [-1, 2]) {
     const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
     nCoords[openAxis] += offset;
-    const neighborKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
-    const neighbor = blocks.get(neighborKey);
+    const neighbor = blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
 
     if (!neighbor) continue;
     if (neighbor.type === "Y") continue;
     if (isPipeType(neighbor.type)) continue;
 
+    // Y-open pipes reverse direction (TQEC Y → -Three.js Z), so the
+    // "above band" (swapped) end is at offset -1 instead of +2.
+    const swapped = openAxis === 1 ? offset === -1 : offset === 2;
     for (let axis = 0; axis < 3; axis++) {
       if (axis === openAxis) continue;
-      if (base[axis] !== neighbor.type[axis]) return true;
+      if (pipeEndBasis(base, hadamard, openAxis, axis, swapped) !== neighbor.type[axis]) return true;
     }
   }
 
@@ -782,6 +802,7 @@ export function hasPipeColorConflict(
 /**
  * Check whether a cube placement conflicts with adjacent pipe colors.
  * For each of the 3 TQEC axes, checks both possible neighboring pipe positions.
+ * For Hadamard pipes, determines which end faces the cube and uses the right colors.
  * Returns true if there IS a conflict (placement should be rejected).
  */
 export function hasCubeColorConflict(
@@ -802,12 +823,17 @@ export function hasCubeColorConflict(
       if (!isPipeType(neighbor.type)) continue;
 
       const base = neighbor.type.replace("H", "");
+      const hadamard = neighbor.type.length > 3;
       const openAxis = base.indexOf("O");
-      if (openAxis !== axis) continue; // pipe isn't oriented toward this cube
+      if (openAxis !== axis) continue;
 
+      // offset +1: cube is at pipe's start (-1 neighbor)
+      // offset -2: cube is at pipe's far end (+2 neighbor)
+      // Y-open pipes reverse: swapped end is at start (offset +1 from cube = -1 from pipe)
+      const swapped = openAxis === 1 ? offset === 1 : offset === -2;
       for (let i = 0; i < 3; i++) {
         if (i === openAxis) continue;
-        if (base[i] !== cubeType[i]) return true;
+        if (pipeEndBasis(base, hadamard, openAxis, i, swapped) !== cubeType[i]) return true;
       }
     }
   }

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -744,6 +744,77 @@ export function hasBlockOverlap(pos: Position3D, type: BlockType, blocks: Map<st
   return false;
 }
 
+/**
+ * Check whether a pipe placement conflicts with adjacent cube colors.
+ * For each of the pipe's two closed TQEC axes, the pipe's basis character
+ * must match any adjacent cube's basis character on the same axis.
+ * Returns true if there IS a conflict (placement should be rejected).
+ */
+export function hasPipeColorConflict(
+  pipeType: PipeType,
+  pipePos: Position3D,
+  blocks: Map<string, Block>,
+): boolean {
+  const base = pipeType.replace("H", "");
+  const openAxis = base.indexOf("O"); // 0, 1, or 2
+
+  const coords: [number, number, number] = [pipePos.x, pipePos.y, pipePos.z];
+
+  for (const offset of [-1, 2]) {
+    const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+    nCoords[openAxis] += offset;
+    const neighborKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
+    const neighbor = blocks.get(neighborKey);
+
+    if (!neighbor) continue;
+    if (neighbor.type === "Y") continue;
+    if (isPipeType(neighbor.type)) continue;
+
+    for (let axis = 0; axis < 3; axis++) {
+      if (axis === openAxis) continue;
+      if (base[axis] !== neighbor.type[axis]) return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Check whether a cube placement conflicts with adjacent pipe colors.
+ * For each of the 3 TQEC axes, checks both possible neighboring pipe positions.
+ * Returns true if there IS a conflict (placement should be rejected).
+ */
+export function hasCubeColorConflict(
+  cubeType: CubeType,
+  cubePos: Position3D,
+  blocks: Map<string, Block>,
+): boolean {
+  const coords: [number, number, number] = [cubePos.x, cubePos.y, cubePos.z];
+
+  for (let axis = 0; axis < 3; axis++) {
+    // Two pipe positions along this axis: pos[axis]+1 and pos[axis]-2
+    for (const offset of [1, -2]) {
+      const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+      nCoords[axis] += offset;
+      const neighbor = blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
+
+      if (!neighbor) continue;
+      if (!isPipeType(neighbor.type)) continue;
+
+      const base = neighbor.type.replace("H", "");
+      const openAxis = base.indexOf("O");
+      if (openAxis !== axis) continue; // pipe isn't oriented toward this cube
+
+      for (let i = 0; i < 3; i++) {
+        if (i === openAxis) continue;
+        if (base[i] !== cubeType[i]) return true;
+      }
+    }
+  }
+
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Adjacency
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `hasPipeColorConflict()` and `hasCubeColorConflict()` validation functions that enforce TQEC basis color consistency at pipe-cube boundaries
- When placing a pipe next to a cube (or vice versa), the closed-axis colors must match on shared TQEC axes — mismatches are rejected
- Ghost preview shows red for invalid placements in both face-click and ground-plane placement modes

## Test plan
- [ ] Place a cube, then try placing a pipe next to it with matching colors — should succeed
- [ ] Place a cube, then try placing a pipe with mismatching closed-axis colors — ghost should turn red, placement blocked
- [ ] Place a pipe, then try placing a cube next to it with mismatching colors — same rejection behavior
- [ ] Hadamard pipe variants follow the same validation rules
- [ ] Existing tests pass (`npm test` — 32/32)

🤖 Generated with [Claude Code](https://claude.com/claude-code)