### PR TITLE
Toolbar previews follow camera rotation

### DIFF
--- a/piper_draw/gui/src/components/PreviewRenderer.tsx
+++ b/piper_draw/gui/src/components/PreviewRenderer.tsx
@@ -39,13 +39,10 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
   const lastQuatRef = useRef(new THREE.Quaternion());
   const rafRef = useRef(0);
   const lastRenderRef = useRef(0);
-
-  // Build the offscreen renderer and scenes once
-  const initRef = useRef(false);
+  const dirVec = useRef(new THREE.Vector3());
 
   const init = useCallback(() => {
-    if (initRef.current) return;
-    initRef.current = true;
+    if (rendererRef.current) return;
 
     const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
     renderer.setSize(RENDER_SIZE, RENDER_SIZE);
@@ -104,15 +101,18 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
       const camera = cameraRef.current!;
 
       // Compute camera direction from main camera's quaternion
-      const dir = new THREE.Vector3(0, 0, 1).applyQuaternion(quat);
+      const dir = dirVec.current.set(0, 0, 1).applyQuaternion(quat);
 
       const newImages = new Map<string, string>();
 
       for (const { key } of PREVIEW_TYPES) {
         const entry = meshesRef.current.get(key)!;
 
-        // Clear scene children except lights
-        while (scene.children.length > 2) scene.remove(scene.children[2]);
+        // Swap preview mesh: remove previous, add current
+        if (scene.children.length > 2) {
+          scene.remove(scene.children[scene.children.length - 1]);
+          scene.remove(scene.children[scene.children.length - 1]);
+        }
         scene.add(entry.mesh);
         scene.add(entry.edges);
 
@@ -132,7 +132,15 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
 
     return () => {
       cancelAnimationFrame(rafRef.current);
+      for (const entry of meshesRef.current.values()) {
+        entry.mesh.geometry.dispose();
+        entry.edges.geometry.dispose();
+      }
+      meshesRef.current.clear();
       rendererRef.current?.dispose();
+      rendererRef.current = null;
+      sceneRef.current = null;
+      cameraRef.current = null;
     };
   }, [controlsRef, init]);
 

--- a/piper_draw/gui/src/components/PreviewRenderer.tsx
+++ b/piper_draw/gui/src/components/PreviewRenderer.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef, useState, useCallback } from "react";
+import * as THREE from "three";
+import {
+  CUBE_TYPES,
+  createBlockGeometry,
+  createBlockEdges,
+  blockThreeSize,
+} from "../types";
+import type { BlockType } from "../types";
+
+/** All block types to render previews for, including pipe canonical forms. */
+const PREVIEW_TYPES: { key: string; blockType: BlockType }[] = [
+  ...CUBE_TYPES.map((ct) => ({ key: ct, blockType: ct as BlockType })),
+  { key: "Y", blockType: "Y" as BlockType },
+  { key: "ZX", blockType: "ZXO" as BlockType },
+  { key: "XZ", blockType: "XZO" as BlockType },
+  { key: "ZXH", blockType: "ZXOH" as BlockType },
+  { key: "XZH", blockType: "XZOH" as BlockType },
+];
+
+const RENDER_SIZE = 128; // high-res for crisp previews at any display size
+const FOV = 35;
+const THROTTLE_MS = 66; // ~15fps
+
+const vertexColorMaterial = new THREE.MeshBasicMaterial({ vertexColors: true, side: THREE.DoubleSide });
+const edgeMaterial = new THREE.LineBasicMaterial({ color: 0x000000 });
+
+/**
+ * Hook that renders 3D preview images for all toolbar block/pipe types,
+ * synced to the main camera's orientation via controlsRef.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function usePreviewImages(controlsRef: React.RefObject<any>) {
+  const [images, setImages] = useState<Map<string, string>>(new Map());
+  const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
+  const sceneRef = useRef<THREE.Scene | null>(null);
+  const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
+  const meshesRef = useRef<Map<string, { mesh: THREE.Mesh; edges: THREE.LineSegments; center: THREE.Vector3; radius: number }>>(new Map());
+  const lastQuatRef = useRef(new THREE.Quaternion());
+  const rafRef = useRef(0);
+  const lastRenderRef = useRef(0);
+
+  // Build the offscreen renderer and scenes once
+  const initRef = useRef(false);
+
+  const init = useCallback(() => {
+    if (initRef.current) return;
+    initRef.current = true;
+
+    const renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+    renderer.setSize(RENDER_SIZE, RENDER_SIZE);
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+    renderer.setClearColor(0x000000, 0);
+    rendererRef.current = renderer;
+
+    const scene = new THREE.Scene();
+    scene.add(new THREE.AmbientLight(0xffffff, 1.4));
+    const dirLight = new THREE.DirectionalLight(0xffffff, 1.0);
+    dirLight.position.set(10, 10, 10);
+    scene.add(dirLight);
+    sceneRef.current = scene;
+
+    const camera = new THREE.PerspectiveCamera(FOV, 1, 0.1, 100);
+    cameraRef.current = camera;
+
+    // Pre-build meshes
+    for (const { key, blockType } of PREVIEW_TYPES) {
+      const geo = createBlockGeometry(blockType, 0);
+      const mesh = new THREE.Mesh(geo, vertexColorMaterial);
+
+      const edgeGeo = createBlockEdges(blockType, 0);
+      const edges = new THREE.LineSegments(edgeGeo, edgeMaterial);
+
+      const [sx, sy, sz] = blockThreeSize(blockType);
+      const center = new THREE.Vector3(0, 0, 0);
+      const radius = Math.sqrt(sx * sx + sy * sy + sz * sz) / 2;
+
+      meshesRef.current.set(key, { mesh, edges, center, radius });
+    }
+  }, []);
+
+  useEffect(() => {
+    init();
+
+    const loop = () => {
+      rafRef.current = requestAnimationFrame(loop);
+
+      const now = performance.now();
+      if (now - lastRenderRef.current < THROTTLE_MS) return;
+
+      const controls = controlsRef.current;
+      if (!controls) return;
+      const mainCamera = controls.object as THREE.PerspectiveCamera;
+      if (!mainCamera) return;
+
+      // Check if camera orientation changed
+      const quat = mainCamera.quaternion;
+      if (lastQuatRef.current.angleTo(quat) < 0.005) return;
+      lastQuatRef.current.copy(quat);
+      lastRenderRef.current = now;
+
+      const renderer = rendererRef.current!;
+      const scene = sceneRef.current!;
+      const camera = cameraRef.current!;
+
+      // Compute camera direction from main camera's quaternion
+      const dir = new THREE.Vector3(0, 0, 1).applyQuaternion(quat);
+
+      const newImages = new Map<string, string>();
+
+      for (const { key } of PREVIEW_TYPES) {
+        const entry = meshesRef.current.get(key)!;
+
+        // Clear scene children except lights
+        while (scene.children.length > 2) scene.remove(scene.children[2]);
+        scene.add(entry.mesh);
+        scene.add(entry.edges);
+
+        // Position camera to frame the block
+        const dist = entry.radius / Math.tan((FOV * Math.PI) / 360) * 1.3;
+        camera.position.copy(entry.center).addScaledVector(dir, dist);
+        camera.quaternion.copy(quat);
+
+        renderer.render(scene, camera);
+        newImages.set(key, renderer.domElement.toDataURL());
+      }
+
+      setImages(newImages);
+    };
+
+    rafRef.current = requestAnimationFrame(loop);
+
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+      rendererRef.current?.dispose();
+    };
+  }, [controlsRef, init]);
+
+  return images;
+}

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -1,300 +1,8 @@
 import { useBlockStore } from "../stores/blockStore";
-import { CUBE_TYPES, PIPE_VARIANTS, X_HEX, Z_HEX, Y_HEX, H_HEX } from "../types";
-import type { BlockType, PipeVariant } from "../types";
+import { CUBE_TYPES, PIPE_VARIANTS } from "../types";
+import type { BlockType } from "../types";
 import * as THREE from "three";
-
-function basisHex(ch: string): string {
-  return ch === "X" ? X_HEX : Z_HEX;
-}
-
-// ---------------------------------------------------------------------------
-// Isometric SVG previews
-// ---------------------------------------------------------------------------
-
-/**
- * Isometric cube SVG matching the default camera at [10, 10, -10].
- * Camera screen-right is (-1,0,-1), so:
- *   Top   = +Y Three.js = TQEC Z-axis
- *   Left  = +X Three.js = TQEC X-axis
- *   Right = -Z Three.js = TQEC Y-axis
- */
-function CubePreview({ cubeType }: { cubeType: string }) {
-  const xColor = basisHex(cubeType[0]);
-  const yColor = basisHex(cubeType[1]);
-  const zColor = basisHex(cubeType[2]);
-  // True isometric proportions: edge=10, dx=8.66, top_h=5, side_h=10
-  const dx = 9, topH = 5, sideH = 10;
-  const cx = 11, cy = 7;
-  const svgW = cx * 2, svgH = cy + topH + sideH + 1;
-  return (
-    <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} style={{ display: "block", margin: "2px auto 0" }}>
-      {/* Top face (TQEC Z-axis) */}
-      <polygon
-        points={`${cx},${cy - topH} ${cx + dx},${cy} ${cx},${cy + topH} ${cx - dx},${cy}`}
-        fill={zColor}
-        stroke="#000"
-        strokeWidth={0.7}
-      />
-      {/* Left face (TQEC X-axis) — slightly darkened */}
-      <polygon
-        points={`${cx - dx},${cy} ${cx},${cy + topH} ${cx},${cy + topH + sideH} ${cx - dx},${cy + sideH}`}
-        fill={xColor}
-        stroke="#000"
-        strokeWidth={0.7}
-        opacity={0.85}
-      />
-      {/* Right face (TQEC Y-axis) — slightly more darkened */}
-      <polygon
-        points={`${cx + dx},${cy} ${cx},${cy + topH} ${cx},${cy + topH + sideH} ${cx + dx},${cy + sideH}`}
-        fill={yColor}
-        stroke="#000"
-        strokeWidth={0.7}
-        opacity={0.7}
-      />
-    </svg>
-  );
-}
-
-/** Isometric half-cube (half-height in Z/temporal) preview, all green. */
-function YHalfCubePreview() {
-  // Same isometric angles as CubePreview but sideH halved; same total SVG height
-  const dx = 9, topH = 5, sideH = 5;
-  const fullSideH = 10;
-  const cx = 11;
-  const svgH = 7 + topH + fullSideH + 1; // match CubePreview height (23)
-  const svgW = cx * 2;
-  // Shift down so the half-cube sits at the bottom of the same viewport
-  const cy = 7 + (fullSideH - sideH);
-  return (
-    <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} style={{ display: "block", margin: "2px auto 0" }}>
-      <polygon
-        points={`${cx},${cy - topH} ${cx + dx},${cy} ${cx},${cy + topH} ${cx - dx},${cy}`}
-        fill={Y_HEX}
-        stroke="#000"
-        strokeWidth={0.7}
-      />
-      <polygon
-        points={`${cx - dx},${cy} ${cx},${cy + topH} ${cx},${cy + topH + sideH} ${cx - dx},${cy + sideH}`}
-        fill={Y_HEX}
-        stroke="#000"
-        strokeWidth={0.7}
-        opacity={0.85}
-      />
-      <polygon
-        points={`${cx + dx},${cy} ${cx},${cy + topH} ${cx},${cy + topH + sideH} ${cx + dx},${cy + sideH}`}
-        fill={Y_HEX}
-        stroke="#000"
-        strokeWidth={0.7}
-        opacity={0.7}
-      />
-    </svg>
-  );
-}
-
-/**
- * Pipe preview colors mapped to isometric faces.
- * left = TQEC X-axis, right = TQEC Y-axis, top = TQEC Z-axis.
- * openDir indicates which TQEC axis is open (z = top open, y = right open).
- */
-const PIPE_COLORS: Record<string, { left: string; right: string; top: string; openDir: "z" | "y" | "x"; hadamard?: boolean }> = {
-  ZXO:  { left: Z_HEX, right: X_HEX, top: "",     openDir: "z" },
-  XZO:  { left: X_HEX, right: Z_HEX, top: "",     openDir: "z" },
-  ZXOH: { left: Z_HEX, right: X_HEX, top: "",     openDir: "z", hadamard: true },
-  XZOH: { left: X_HEX, right: Z_HEX, top: "",     openDir: "z", hadamard: true },
-  ZOX:  { left: Z_HEX, right: "",    top: X_HEX,  openDir: "y" },
-  XOZ:  { left: X_HEX, right: "",    top: Z_HEX,  openDir: "y" },
-  ZOXH: { left: Z_HEX, right: "",    top: X_HEX,  openDir: "y", hadamard: true },
-  XOZH: { left: X_HEX, right: "",    top: Z_HEX,  openDir: "y", hadamard: true },
-  OZX:  { left: "",     right: Z_HEX, top: X_HEX, openDir: "x" },
-  OXZ:  { left: "",     right: X_HEX, top: Z_HEX, openDir: "x" },
-  OZXH: { left: "",     right: Z_HEX, top: X_HEX, openDir: "x", hadamard: true },
-  OXZH: { left: "",     right: X_HEX, top: Z_HEX, openDir: "x", hadamard: true },
-};
-
-/** Isometric pipe preview — cuboid with one open face. */
-function PipePreview({ pipeType }: { pipeType: string }) {
-  const { left, right, top, openDir, hadamard } = PIPE_COLORS[pipeType];
-
-  if (openDir === "z") return <ZPipePreviewSvg left={left} right={right} hadamard={hadamard} />;
-  if (openDir === "y") return <YPipePreviewSvg left={left} top={top} hadamard={hadamard} />;
-  return <XPipePreviewSvg right={right} top={top} hadamard={hadamard} />;
-}
-
-/** Z-open pipe preview: tall cuboid, top face open. */
-function ZPipePreviewSvg({ left, right, hadamard }: { left: string; right: string; hadamard?: boolean }) {
-  const dx = 9, topH = 5, sideH = 20;
-  const cx = 11, cy = 7;
-  const svgW = cx * 2, svgH = cy + topH + sideH + 1;
-  const leftAbove = hadamard ? right : left;
-  const rightAbove = hadamard ? left : right;
-  const bandH = 2;
-  const midL = cy + sideH / 2;
-  const midR = cy + topH + sideH / 2;
-
-  return (
-    <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} style={{ display: "block", margin: "2px auto 0" }}>
-      {/* Inner walls visible through open top */}
-      <polygon points={`${cx - dx},${cy} ${cx},${cy - topH} ${cx},${cy + topH + sideH} ${cx - dx},${cy + sideH}`}
-        fill={rightAbove} stroke="#000" strokeWidth={0.7} opacity={0.5} />
-      <polygon points={`${cx + dx},${cy} ${cx},${cy - topH} ${cx},${cy + topH + sideH} ${cx + dx},${cy + sideH}`}
-        fill={leftAbove} stroke="#000" strokeWidth={0.7} opacity={0.6} />
-      {/* Top face — dashed outline */}
-      <polygon points={`${cx},${cy - topH} ${cx + dx},${cy} ${cx},${cy + topH} ${cx - dx},${cy}`}
-        fill="none" stroke="#000" strokeWidth={0.7} strokeDasharray="2 1.5" />
-      {hadamard ? (
-        <>
-          <polygon points={`${cx - dx},${cy} ${cx},${cy + topH} ${cx},${midR - bandH} ${cx - dx},${midL - bandH}`}
-            fill={leftAbove} stroke="#000" strokeWidth={0.7} opacity={0.85} />
-          <polygon points={`${cx - dx},${midL - bandH} ${cx},${midR - bandH} ${cx},${midR + bandH} ${cx - dx},${midL + bandH}`}
-            fill={H_HEX} stroke="#000" strokeWidth={0.5} opacity={0.9} />
-          <polygon points={`${cx - dx},${midL + bandH} ${cx},${midR + bandH} ${cx},${cy + topH + sideH} ${cx - dx},${cy + sideH}`}
-            fill={left} stroke="#000" strokeWidth={0.7} opacity={0.85} />
-          <polygon points={`${cx + dx},${cy} ${cx},${cy + topH} ${cx},${midR - bandH} ${cx + dx},${midL - bandH}`}
-            fill={rightAbove} stroke="#000" strokeWidth={0.7} opacity={0.7} />
-          <polygon points={`${cx + dx},${midL - bandH} ${cx},${midR - bandH} ${cx},${midR + bandH} ${cx + dx},${midL + bandH}`}
-            fill={H_HEX} stroke="#000" strokeWidth={0.5} opacity={0.8} />
-          <polygon points={`${cx + dx},${midL + bandH} ${cx},${midR + bandH} ${cx},${cy + topH + sideH} ${cx + dx},${cy + sideH}`}
-            fill={right} stroke="#000" strokeWidth={0.7} opacity={0.7} />
-        </>
-      ) : (
-        <>
-          <polygon points={`${cx - dx},${cy} ${cx},${cy + topH} ${cx},${cy + topH + sideH} ${cx - dx},${cy + sideH}`}
-            fill={left} stroke="#000" strokeWidth={0.7} opacity={0.85} />
-          <polygon points={`${cx + dx},${cy} ${cx},${cy + topH} ${cx},${cy + topH + sideH} ${cx + dx},${cy + sideH}`}
-            fill={right} stroke="#000" strokeWidth={0.7} opacity={0.7} />
-        </>
-      )}
-    </svg>
-  );
-}
-
-/** Y-open pipe preview: wide cuboid, right face open. */
-function YPipePreviewSvg({ left, top, hadamard }: { left: string; top: string; hadamard?: boolean }) {
-  const dxL = 9, topHL = 5;
-  const dxR = 18, topHR = 10;
-  const sideH = 10;
-  const cx = 10, cy = 7;
-
-  const bk = [cx, cy];
-  const rt = [cx + dxR, cy + topHR];
-  const fr = [cx - dxL + dxR, cy + topHL + topHR];
-  const lt = [cx - dxL, cy + topHL];
-
-  const leftAbove = hadamard ? top : left;
-  const topAbove = hadamard ? left : top;
-
-  const bandW = 2;
-  const yLen = Math.sqrt(dxR * dxR + topHR * topHR);
-  const ybx = bandW * dxR / yLen;
-  const yby = bandW * topHR / yLen;
-
-  const lf_midT = [(lt[0] + fr[0]) / 2, (lt[1] + fr[1]) / 2];
-  const lf_midB = [lf_midT[0], lf_midT[1] + sideH];
-
-  const tf_bkrt_mid = [(bk[0] + rt[0]) / 2, (bk[1] + rt[1]) / 2];
-  const tf_ltfr_mid = [(lt[0] + fr[0]) / 2, (lt[1] + fr[1]) / 2];
-
-  const svgW = rt[0] + 1;
-  const svgH = fr[1] + sideH + 1;
-
-  return (
-    <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} style={{ display: "block", margin: "2px auto 0" }}>
-      <polygon points={`${bk[0]},${bk[1]} ${rt[0]},${rt[1]} ${rt[0]},${rt[1] + sideH} ${bk[0]},${bk[1] + sideH}`}
-        fill={leftAbove} stroke="#000" strokeWidth={0.7} opacity={0.5} />
-      <polygon points={`${bk[0]},${bk[1] + sideH} ${rt[0]},${rt[1] + sideH} ${fr[0]},${fr[1] + sideH} ${lt[0]},${lt[1] + sideH}`}
-        fill={top} stroke="#000" strokeWidth={0.7} opacity={0.6} />
-      <polygon points={`${bk[0]},${bk[1]} ${rt[0]},${rt[1]} ${fr[0]},${fr[1]} ${lt[0]},${lt[1]}`}
-        fill={hadamard ? undefined : top} stroke="#000" strokeWidth={0.7} />
-      {hadamard ? (
-        <>
-          <polygon points={`${bk[0]},${bk[1]} ${tf_bkrt_mid[0] - ybx},${tf_bkrt_mid[1] - yby} ${tf_ltfr_mid[0] - ybx},${tf_ltfr_mid[1] - yby} ${lt[0]},${lt[1]}`}
-            fill={top} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${tf_bkrt_mid[0] - ybx},${tf_bkrt_mid[1] - yby} ${tf_bkrt_mid[0] + ybx},${tf_bkrt_mid[1] + yby} ${tf_ltfr_mid[0] + ybx},${tf_ltfr_mid[1] + yby} ${tf_ltfr_mid[0] - ybx},${tf_ltfr_mid[1] - yby}`}
-            fill={H_HEX} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${tf_bkrt_mid[0] + ybx},${tf_bkrt_mid[1] + yby} ${rt[0]},${rt[1]} ${fr[0]},${fr[1]} ${tf_ltfr_mid[0] + ybx},${tf_ltfr_mid[1] + yby}`}
-            fill={topAbove} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${lt[0]},${lt[1]} ${lf_midT[0] - ybx},${lf_midT[1] - yby} ${lf_midB[0] - ybx},${lf_midB[1] - yby} ${lt[0]},${lt[1] + sideH}`}
-            fill={left} stroke="#000" strokeWidth={0.7} />
-          <polygon points={`${lf_midT[0] - ybx},${lf_midT[1] - yby} ${lf_midT[0] + ybx},${lf_midT[1] + yby} ${lf_midB[0] + ybx},${lf_midB[1] + yby} ${lf_midB[0] - ybx},${lf_midB[1] - yby}`}
-            fill={H_HEX} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${lf_midT[0] + ybx},${lf_midT[1] + yby} ${fr[0]},${fr[1]} ${fr[0]},${fr[1] + sideH} ${lf_midB[0] + ybx},${lf_midB[1] + yby}`}
-            fill={leftAbove} stroke="#000" strokeWidth={0.7} />
-        </>
-      ) : (
-        <>
-          <polygon points={`${lt[0]},${lt[1]} ${fr[0]},${fr[1]} ${fr[0]},${fr[1] + sideH} ${lt[0]},${lt[1] + sideH}`}
-            fill={left} stroke="#000" strokeWidth={0.7} />
-        </>
-      )}
-      <polygon points={`${rt[0]},${rt[1]} ${fr[0]},${fr[1]} ${fr[0]},${fr[1] + sideH} ${rt[0]},${rt[1] + sideH}`}
-        fill="none" stroke="#000" strokeWidth={0.7} strokeDasharray="2 1.5" />
-    </svg>
-  );
-}
-
-/** X-open pipe preview: wide cuboid extended left, left face open. */
-function XPipePreviewSvg({ right, top, hadamard }: { right: string; top: string; hadamard?: boolean }) {
-  const dxL = 18, topHL = 10;
-  const dxR = 9, topHR = 5;
-  const sideH = 10;
-  const cx = 19, cy = 7;
-
-  const bk = [cx, cy];
-  const rt = [cx + dxR, cy + topHR];
-  const fr = [cx - dxL + dxR, cy + topHL + topHR];
-  const lt = [cx - dxL, cy + topHL];
-
-  const rightAbove = hadamard ? top : right;
-  const topAbove = hadamard ? right : top;
-
-  const bandW = 2;
-  const xLen = Math.sqrt(dxL * dxL + topHL * topHL);
-  const bx = bandW * dxL / xLen;
-  const by = bandW * topHL / xLen;
-
-  const tf_bklt_mid = [(bk[0] + lt[0]) / 2, (bk[1] + lt[1]) / 2];
-  const tf_rtfr_mid = [(rt[0] + fr[0]) / 2, (rt[1] + fr[1]) / 2];
-
-  const rf_midTR = [(rt[0] + fr[0]) / 2, (rt[1] + fr[1]) / 2];
-  const rf_midBR = [rf_midTR[0], rf_midTR[1] + sideH];
-
-  const svgW = rt[0] + 1;
-  const svgH = Math.max(lt[1], fr[1]) + sideH + 1;
-
-  return (
-    <svg width={svgW} height={svgH} viewBox={`0 0 ${svgW} ${svgH}`} style={{ display: "block", margin: "2px auto 0" }}>
-      <polygon points={`${bk[0]},${bk[1]} ${lt[0]},${lt[1]} ${lt[0]},${lt[1] + sideH} ${bk[0]},${bk[1] + sideH}`}
-        fill={rightAbove} stroke="#000" strokeWidth={0.7} opacity={0.5} />
-      <polygon points={`${bk[0]},${bk[1] + sideH} ${rt[0]},${rt[1] + sideH} ${fr[0]},${fr[1] + sideH} ${lt[0]},${lt[1] + sideH}`}
-        fill={top} stroke="#000" strokeWidth={0.7} opacity={0.6} />
-      <polygon points={`${bk[0]},${bk[1]} ${rt[0]},${rt[1]} ${fr[0]},${fr[1]} ${lt[0]},${lt[1]}`}
-        fill={hadamard ? undefined : top} stroke="#000" strokeWidth={0.7} />
-      {hadamard ? (
-        <>
-          <polygon points={`${bk[0]},${bk[1]} ${rt[0]},${rt[1]} ${tf_rtfr_mid[0] + bx},${tf_rtfr_mid[1] - by} ${tf_bklt_mid[0] + bx},${tf_bklt_mid[1] - by}`}
-            fill={top} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${tf_bklt_mid[0] + bx},${tf_bklt_mid[1] - by} ${tf_rtfr_mid[0] + bx},${tf_rtfr_mid[1] - by} ${tf_rtfr_mid[0] - bx},${tf_rtfr_mid[1] + by} ${tf_bklt_mid[0] - bx},${tf_bklt_mid[1] + by}`}
-            fill={H_HEX} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${tf_bklt_mid[0] - bx},${tf_bklt_mid[1] + by} ${tf_rtfr_mid[0] - bx},${tf_rtfr_mid[1] + by} ${fr[0]},${fr[1]} ${lt[0]},${lt[1]}`}
-            fill={topAbove} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${rt[0]},${rt[1]} ${rf_midTR[0] + bx},${rf_midTR[1] - by} ${rf_midBR[0] + bx},${rf_midBR[1] - by} ${rt[0]},${rt[1] + sideH}`}
-            fill={right} stroke="#000" strokeWidth={0.7} />
-          <polygon points={`${rf_midTR[0] + bx},${rf_midTR[1] - by} ${rf_midTR[0] - bx},${rf_midTR[1] + by} ${rf_midBR[0] - bx},${rf_midBR[1] + by} ${rf_midBR[0] + bx},${rf_midBR[1] - by}`}
-            fill={H_HEX} stroke="#000" strokeWidth={0.5} />
-          <polygon points={`${rf_midTR[0] - bx},${rf_midTR[1] + by} ${fr[0]},${fr[1]} ${fr[0]},${fr[1] + sideH} ${rf_midBR[0] - bx},${rf_midBR[1] + by}`}
-            fill={rightAbove} stroke="#000" strokeWidth={0.7} />
-        </>
-      ) : (
-        <>
-          <polygon points={`${rt[0]},${rt[1]} ${fr[0]},${fr[1]} ${fr[0]},${fr[1] + sideH} ${rt[0]},${rt[1] + sideH}`}
-            fill={right} stroke="#000" strokeWidth={0.7} />
-        </>
-      )}
-      <polygon points={`${lt[0]},${lt[1]} ${fr[0]},${fr[1]} ${fr[0]},${fr[1] + sideH} ${lt[0]},${lt[1] + sideH}`}
-        fill="none" stroke="#000" strokeWidth={0.7} strokeDasharray="2 1.5" />
-    </svg>
-  );
-}
+import { usePreviewImages } from "./PreviewRenderer";
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -314,6 +22,8 @@ const previewWrapStyle: React.CSSProperties = {
   display: "flex",
   alignItems: "center",
   justifyContent: "center",
+  width: 44,
+  minHeight: 44,
 };
 
 const btnStyle = (active: boolean) => ({
@@ -355,6 +65,8 @@ export function Toolbar({ onResetCamera, controlsRef }: { onResetCamera: () => v
   const clearAll = useBlockStore((s) => s.clearAll);
   const blocksEmpty = useBlockStore((s) => s.blocks.size === 0);
 
+  const previewImages = usePreviewImages(controlsRef);
+
   const setCameraPreset = (position: [number, number, number]) => {
     const controls = controlsRef.current;
     if (!controls) return;
@@ -362,6 +74,13 @@ export function Toolbar({ onResetCamera, controlsRef }: { onResetCamera: () => v
     camera.position.set(...position);
     controls.target.set(0, 0, 0);
     controls.update();
+  };
+
+  const previewImg = (key: string) => {
+    const src = previewImages.get(key);
+    return src ? (
+      <img src={src} style={{ display: "block", width: "100%", height: "100%", objectFit: "contain" }} />
+    ) : null;
   };
 
   return (
@@ -451,7 +170,7 @@ export function Toolbar({ onResetCamera, controlsRef }: { onResetCamera: () => v
               style={blockBtnStyle(cubeType === ct && mode === "place")}
             >
               {ct}
-              <div style={previewWrapStyle}><CubePreview cubeType={ct} /></div>
+              <div style={previewWrapStyle}>{previewImg(ct)}</div>
             </button>
           ))}
           <button
@@ -462,7 +181,7 @@ export function Toolbar({ onResetCamera, controlsRef }: { onResetCamera: () => v
             style={blockBtnStyle(cubeType === "Y" && mode === "place")}
           >
             Y
-            <div style={previewWrapStyle}><YHalfCubePreview /></div>
+            <div style={previewWrapStyle}>{previewImg("Y")}</div>
           </button>
         </div>
       </div>
@@ -470,27 +189,23 @@ export function Toolbar({ onResetCamera, controlsRef }: { onResetCamera: () => v
       {/* Separator */}
       <div style={{ width: 1, background: "#ddd" }} />
 
-      {/* Pipes group (4 variants — open axis determined by position) */}
+      {/* Pipes group */}
       <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
         <span style={groupLabelStyle}>Pipes</span>
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
-          {PIPE_VARIANTS.map((v) => {
-            // Use Z-open canonical form for preview
-            const previewType: Record<PipeVariant, string> = { ZX: "ZXO", XZ: "XZO", ZXH: "ZXOH", XZH: "XZOH" };
-            return (
-              <button
-                key={v}
-                onClick={() => {
-                  setPipeVariant(v);
-                  setMode("place");
-                }}
-                style={blockBtnStyle(pipeVariant === v && mode === "place")}
-              >
-                {v}
-                <div style={previewWrapStyle}><PipePreview pipeType={previewType[v]} /></div>
-              </button>
-            );
-          })}
+          {PIPE_VARIANTS.map((v) => (
+            <button
+              key={v}
+              onClick={() => {
+                setPipeVariant(v);
+                setMode("place");
+              }}
+              style={blockBtnStyle(pipeVariant === v && mode === "place")}
+            >
+              {v}
+              <div style={previewWrapStyle}>{previewImg(v)}</div>
+            </button>
+          ))}
         </div>
       </div>
     </div>

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -79,7 +79,7 @@ export function Toolbar({ onResetCamera, controlsRef }: { onResetCamera: () => v
   const previewImg = (key: string) => {
     const src = previewImages.get(key);
     return src ? (
-      <img src={src} style={{ display: "block", width: "100%", height: "100%", objectFit: "contain" }} />
+      <img src={src} alt={key} style={{ display: "block", width: "100%", height: "100%", objectFit: "contain" }} />
     ) : null;
   };
 


### PR DESCRIPTION
## Summary
- Replace static 2D SVG isometric previews with live 3D renders that sync to the main camera orientation
- Uses a single offscreen `WebGLRenderer` (not 11 separate Canvas elements) to avoid hitting browser WebGL context limits
- Renders all 11 block/pipe types at 128px resolution, throttled to ~15fps, only when camera quaternion changes

## Test plan
- [x] Run `npm run dev` from `piper_draw/gui` and open in browser
- [x] Orbit the main view — toolbar block/pipe previews should rotate to match
- [x] Verify all 11 block types render with correct face colors
- [x] Verify pipe inner walls are visible and colored
- [x] Check FPS counter for no performance regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)