### PR TITLE
Fix pipe grid snapping on face click

### DIFF
--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -201,7 +201,7 @@ function TypedInstances({
       if (store.pipeVariant) {
         const resolved = resolvePipeTypeFromFace(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, store.pipeVariant);
         if (!resolved) {
-          store.setHoveredGridPos(b[e.instanceId].pos, undefined, true);
+          store.setHoveredGridPos(null);
           return;
         }
         dstType = resolved;

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -105,7 +105,8 @@ export function isValidBlockPos(pos: Position3D): boolean {
 export function isValidPipePos(pos: Position3D): boolean {
   const mx = mod(pos.x, 3), my = mod(pos.y, 3), mz = mod(pos.z, 3);
   const slots = (mx === 1 ? 1 : 0) + (my === 1 ? 1 : 0) + (mz === 1 ? 1 : 0);
-  return slots === 1;
+  const zeros = (mx === 0 ? 1 : 0) + (my === 0 ? 1 : 0) + (mz === 0 ? 1 : 0);
+  return slots === 1 && zeros === 2;
 }
 
 export function isValidPos(pos: Position3D, blockType: BlockType): boolean {


### PR DESCRIPTION
## Summary
- Fix `isValidPipePos` to reject positions where non-slot coordinates are ≡ 2 (mod 3), not just check that one coord is ≡ 1 (mod 3)
- Clear ghost block when no valid pipe placement exists from a face click, instead of rendering it at the wrong position/type which caused visual overlap

## Test plan
- [x] Place a Y-direction pipe and hover over its faces — ghost should disappear (not overlap)
- [x] Place a cube, then a pipe from the cube's face — should still work correctly
- [x] Run `npx vitest run` in `piper_draw/gui`

🤖 Generated with [Claude Code](https://claude.com/claude-code)