### PR TITLE
Block Y cube placement next to X/Y-open pipes

### DIFF
--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -10,6 +10,7 @@ import {
   hasBlockOverlap,
   hasCubeColorConflict,
   hasPipeColorConflict,
+  hasYCubePipeAxisConflict,
   isValidPipePos,
   isValidPos,
   isPipeType,
@@ -215,6 +216,8 @@ function TypedInstances({
         store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube");
       } else if (!isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks)) {
         store.setHoveredGridPos(adj, dstType, true, "Cube colors don't match the adjacent pipe");
+      } else if (hasYCubePipeAxisConflict(dstType, adj, store.blocks)) {
+        store.setHoveredGridPos(adj, dstType, true, "Y cube cannot be next to an X-open or Y-open pipe");
       } else {
         store.setHoveredGridPos(adj, dstType);
       }

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { snapGroundPos, hasBlockOverlap, hasCubeColorConflict, hasPipeColorConflict, isValidPos, isPipeType, resolvePipeType } from "../types";
+import { snapGroundPos, hasBlockOverlap, hasCubeColorConflict, hasPipeColorConflict, hasYCubePipeAxisConflict, isValidPos, isPipeType, resolvePipeType } from "../types";
 import type { CubeType } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
 
@@ -48,6 +48,8 @@ export function GridPlane() {
       setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube");
     } else if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Cube colors don't match the adjacent pipe");
+    } else if (hasYCubePipeAxisConflict(blockType, pos, store.blocks)) {
+      setHoveredGridPos(pos, blockType, true, "Y cube cannot be next to an X-open or Y-open pipe");
     } else {
       setHoveredGridPos(pos, blockType);
     }

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -5,6 +5,7 @@ import {
   hasBlockOverlap,
   hasCubeColorConflict,
   hasPipeColorConflict,
+  hasYCubePipeAxisConflict,
   isPipeType,
   isValidPos,
   resolvePipeType,
@@ -153,6 +154,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex)) return state;
       if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
       if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
+      if (hasYCubePipeAxisConflict(blockType, pos, state.blocks)) return state;
 
       const key = posKey(pos);
       const block: Block = { pos, type: blockType };

--- a/piper_draw/gui/src/types/index.test.ts
+++ b/piper_draw/gui/src/types/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict } from "./index";
+import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict } from "./index";
 import type { PipeType, CubeType } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
@@ -258,6 +258,63 @@ describe("hasCubeColorConflict", () => {
     // Pipe "ZOX" (open Y) at (1,0,0): openAxis=1 but offset axis=0 → skip
     const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "ZOX" as BlockType }]);
     expect(hasCubeColorConflict("XZZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+});
+
+describe("hasYCubePipeAxisConflict", () => {
+  it("rejects Y cube next to an X-open pipe", () => {
+    // X-open pipe "OZX" at (1,0,0), Y cube at (0,0,0)
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" as BlockType }]);
+    expect(hasYCubePipeAxisConflict("Y", { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("rejects Y cube next to a Y-open pipe", () => {
+    // Y-open pipe "ZOX" at (0,1,0), Y cube at (0,0,0)
+    const blocks = makeBlocks([{ x: 0, y: 1, z: 0, type: "ZOX" as BlockType }]);
+    expect(hasYCubePipeAxisConflict("Y", { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("allows Y cube next to a Z-open pipe", () => {
+    // Z-open pipe "ZXO" at (0,0,1), Y cube at (0,0,0)
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 1, type: "ZXO" as BlockType }]);
+    expect(hasYCubePipeAxisConflict("Y", { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("rejects Y cube next to an X-open Hadamard pipe", () => {
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZXH" as BlockType }]);
+    expect(hasYCubePipeAxisConflict("Y", { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("allows Y cube with no adjacent pipes", () => {
+    const blocks = makeBlocks([]);
+    expect(hasYCubePipeAxisConflict("Y", { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("rejects Y cube on the far side (-2 offset) of an X-open pipe", () => {
+    // X-open pipe at (1,0,0), Y cube at (3,0,0) — far endpoint
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OXZ" as BlockType }]);
+    expect(hasYCubePipeAxisConflict("Y", { x: 3, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("rejects X-open pipe when Y cube is at endpoint", () => {
+    // Y cube at (0,0,0), placing X-open pipe "OZX" at (1,0,0)
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "Y" }]);
+    expect(hasYCubePipeAxisConflict("OZX" as BlockType, { x: 1, y: 0, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("rejects Y-open pipe when Y cube is at endpoint", () => {
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "Y" }]);
+    expect(hasYCubePipeAxisConflict("ZOX" as BlockType, { x: 0, y: 1, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("allows Z-open pipe next to a Y cube", () => {
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "Y" }]);
+    expect(hasYCubePipeAxisConflict("ZXO" as BlockType, { x: 0, y: 0, z: 1 }, blocks)).toBe(false);
+  });
+
+  it("does not affect regular cube placement", () => {
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" as BlockType }]);
+    expect(hasYCubePipeAxisConflict("XZZ" as BlockType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
   });
 });
 

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -841,6 +841,47 @@ export function hasCubeColorConflict(
   return false;
 }
 
+/**
+ * Check whether a Y cube is being placed next to an X-open or Y-open pipe,
+ * or an X/Y-open pipe is being placed next to a Y cube.
+ * Only Z-open pipes (axis 2) are allowed adjacent to Y cubes.
+ * Returns true if there IS a conflict (placement should be rejected).
+ */
+export function hasYCubePipeAxisConflict(
+  blockType: BlockType,
+  pos: Position3D,
+  blocks: Map<string, Block>,
+): boolean {
+  if (blockType === "Y") {
+    const coords: [number, number, number] = [pos.x, pos.y, pos.z];
+    for (let axis = 0; axis < 3; axis++) {
+      for (const offset of [1, -2]) {
+        const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+        nCoords[axis] += offset;
+        const neighbor = blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
+        if (!neighbor || !isPipeType(neighbor.type)) continue;
+        const openAxis = neighbor.type.replace("H", "").indexOf("O");
+        if (openAxis === 0 || openAxis === 1) return true;
+      }
+    }
+    return false;
+  }
+
+  if (isPipeType(blockType)) {
+    const openAxis = blockType.replace("H", "").indexOf("O");
+    if (openAxis !== 0 && openAxis !== 1) return false;
+    const coords: [number, number, number] = [pos.x, pos.y, pos.z];
+    for (const offset of [-1, 2]) {
+      const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+      nCoords[openAxis] += offset;
+      const neighbor = blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
+      if (neighbor?.type === "Y") return true;
+    }
+  }
+
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Adjacency
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds validation preventing Y cubes from being placed adjacent to X-open or Y-open pipes (and vice versa)
- Y cubes remain allowed next to Z-open pipes
- Invalid placements show a red ghost with error message during hover

## Test plan
- [x] 10 new unit tests covering all cases (Y cube next to X/Y/Z-open pipes, pipe next to Y cube, regular cubes unaffected)
- [x] All 103 tests pass
- [x] Manual: place a Z-open pipe → Y cube adjacent should succeed
- [x] Manual: place an X-open or Y-open pipe → Y cube adjacent should be rejected (red ghost)
- [x] Manual: place a Y cube → X/Y-open pipe next to it should be rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)