### PR TITLE
Show keyboard shortcut hints in select mode

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -121,6 +121,63 @@ function CheckerboardGrid() {
   );
 }
 
+const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
+const modKey = isMac ? "\u2318" : "Ctrl+";
+
+function SelectModeHints() {
+  const mode = useBlockStore((s) => s.mode);
+  if (mode !== "select") return null;
+
+  const hints = [
+    ["Click", "Select"],
+    ["Shift+Click", "Add/remove"],
+    [`${modKey}A`, "Select all"],
+    ["Delete", "Delete selected"],
+    ["Esc", "Clear selection"],
+  ];
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 60,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1,
+        display: "flex",
+        gap: "6px",
+        alignItems: "center",
+        background: "rgba(0,0,0,0.7)",
+        color: "#fff",
+        padding: "6px 14px",
+        borderRadius: "8px",
+        fontSize: "12px",
+        fontFamily: "sans-serif",
+        pointerEvents: "none",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {hints.map(([key, action], i) => (
+        <span key={key} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+          {i > 0 && <span style={{ color: "rgba(255,255,255,0.3)" }}>|</span>}
+          <kbd
+            style={{
+              background: "rgba(255,255,255,0.15)",
+              padding: "1px 5px",
+              borderRadius: "3px",
+              fontSize: "11px",
+            }}
+          >
+            {key}
+          </kbd>
+          <span style={{ color: "rgba(255,255,255,0.7)" }}>{action}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
 function PlacementWarning() {
   const reason = useBlockStore((s) => s.hoveredInvalidReason);
   if (!reason) return null;
@@ -217,6 +274,7 @@ export default function App() {
       >
         <FpsDisplay spanRef={fpsRef} />
       </div>
+      <SelectModeHints />
       <PlacementWarning />
       <Canvas
         camera={{ position: [10, 10, -10], fov: 35 }}


### PR DESCRIPTION
## Summary
- Adds a compact hint bar at the bottom of the screen when in select mode, showing available shortcuts (Click, Shift+Click, ⌘A/Ctrl+A, Delete, Esc)
- Auto-detects Mac vs other platforms for modifier key display
- Uses `pointerEvents: "none"` so it never blocks interaction

## Test plan
- [ ] Switch to select mode — hint bar appears at bottom center
- [ ] Switch to place/delete mode — hint bar disappears
- [ ] Verify hints don't overlap with placement warning toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)