### PR TITLE
Fix Y-open Hadamard pipe validation mismatch

### DIFF
--- a/piper_draw/gui/src/types/index.test.ts
+++ b/piper_draw/gui/src/types/index.test.ts
@@ -192,26 +192,24 @@ describe("hasPipeColorConflict — Hadamard", () => {
     expect(hasPipeColorConflict("OZXH" as PipeType, { x: 1, y: 0, z: 0 }, blocks)).toBe(true);
   });
 
-  it("reverses swap direction for Y-open Hadamard pipes", () => {
-    // Pipe "XOZH" (open Y): base "XOZ", axis 0='X', axis 2='Z'
-    // Y-open: swap is at START end (offset -1, cube at y=0)
-    // Start end swapped: axis 0='Z', axis 2='X'
-    // Cube "XZZ" at (0,0,0): axis 0='X' → mismatch with swapped 'Z'
+  it("allows Y-open Hadamard when start-end cube matches head colors", () => {
+    // Pipe "XOZH" (open Y): base "XOZ", head at y=0 (not swapped): axis 0='X', axis 2='Z'
+    // Cube "XZZ" at (0,0,0): axis 0='X', axis 2='Z' → match
     const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "XZZ" }]);
-    expect(hasPipeColorConflict("XOZH" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(true);
-  });
-
-  it("allows Y-open Hadamard when start-end cube matches swapped colors", () => {
-    // Pipe "XOZH" start end swapped: axis 0='Z', axis 2='X'
-    // Cube "ZZX" at (0,0,0): axis 0='Z', axis 2='X' → match
-    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "ZZX" }]);
     expect(hasPipeColorConflict("XOZH" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(false);
   });
 
-  it("uses original colors at far end for Y-open Hadamard", () => {
-    // Pipe "XOZH" far end (y=3): NOT swapped → axis 0='X', axis 2='Z'
-    // Cube "XZZ" at (0,3,0): axis 0='X', axis 2='Z' → match
-    const blocks = makeBlocks([{ x: 0, y: 3, z: 0, type: "XZZ" }]);
+  it("rejects Y-open Hadamard when start-end cube doesn't match head colors", () => {
+    // Pipe "XOZH" head at y=0 (not swapped): axis 0='X', axis 2='Z'
+    // Cube "ZZX" at (0,0,0): axis 0='Z' → mismatch
+    const blocks = makeBlocks([{ x: 0, y: 0, z: 0, type: "ZZX" }]);
+    expect(hasPipeColorConflict("XOZH" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(true);
+  });
+
+  it("uses swapped colors at far end for Y-open Hadamard", () => {
+    // Pipe "XOZH" far end (y=3, swapped): axis 0='Z', axis 2='X'
+    // Cube "ZZX" at (0,3,0): axis 0='Z', axis 2='X' → match
+    const blocks = makeBlocks([{ x: 0, y: 3, z: 0, type: "ZZX" }]);
     expect(hasPipeColorConflict("XOZH" as PipeType, { x: 0, y: 1, z: 0 }, blocks)).toBe(false);
   });
 });
@@ -246,12 +244,20 @@ describe("hasCubeColorConflict", () => {
     expect(hasCubeColorConflict("ZXZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
   });
 
-  it("reverses Hadamard swap for Y-open pipe facing cube", () => {
-    // Pipe "XOZH" at (0,1,0): cube at (0,0,0) is on start side
-    // Y-open: swapped at start → axis 0='Z', axis 2='X'
-    // Cube "XZZ": axis 0='X' vs 'Z' → mismatch
+  it("allows cube when Y-open Hadamard pipe head colors match", () => {
+    // Pipe "XOZH" at (0,1,0): cube at (0,0,0) is at head (not swapped)
+    // Head: axis 0='X', axis 2='Z'
+    // Cube "XZZ": axis 0='X', axis 2='Z' → match
     const blocks = makeBlocks([{ x: 0, y: 1, z: 0, type: "XOZH" as BlockType }]);
-    expect(hasCubeColorConflict("XZZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
+    expect(hasCubeColorConflict("XZZ" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+
+  it("rejects cube when Y-open Hadamard pipe head colors don't match", () => {
+    // Pipe "XOZH" at (0,1,0): cube at (0,0,0) is at head (not swapped)
+    // Head: axis 0='X', axis 2='Z'
+    // Cube "ZZX": axis 0='Z' → mismatch
+    const blocks = makeBlocks([{ x: 0, y: 1, z: 0, type: "XOZH" as BlockType }]);
+    expect(hasCubeColorConflict("ZZX" as CubeType, { x: 0, y: 0, z: 0 }, blocks)).toBe(true);
   });
 
   it("skips pipes not oriented toward the cube", () => {

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -130,8 +130,8 @@ export function pipeAxisFromPos(pos: Position3D): 0 | 1 | 2 | null {
 export const VARIANT_AXIS_MAP: Record<PipeVariant, [PipeType, PipeType, PipeType]> = {
   ZX:  ["OZX",  "ZOX",  "ZXO"],
   XZ:  ["OXZ",  "XOZ",  "XZO"],
-  ZXH: ["OZXH", "ZOXH", "ZXOH"],
-  XZH: ["OXZH", "XOZH", "XZOH"],
+  ZXH: ["OZXH", "XOZH", "ZXOH"],
+  XZH: ["OXZH", "ZOXH", "XZOH"],
 };
 
 export function resolvePipeType(variant: PipeVariant, pos: Position3D): PipeType | null {
@@ -391,7 +391,13 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
     const tqecOpenAxis = base.indexOf("O") as 0 | 1 | 2;
     const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpenAxis];
     const closedAxes = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
-    const wallColors = closedAxes.map(ta => basisColor(base[THREE_TO_TQEC_AXIS[ta]])) as [THREE.Color, THREE.Color];
+    let wallColors = closedAxes.map(ta => basisColor(base[THREE_TO_TQEC_AXIS[ta]])) as [THREE.Color, THREE.Color];
+    // For Y-open Hadamard pipes, the geometry "below band" end (negative Three.js Z)
+    // corresponds to the tail (higher TQEC Y). Pre-swap so below-band shows tail
+    // (flipped) colors and above-band shows head (original) colors.
+    if (hadamard && tqecOpenAxis === 1) {
+      wallColors = [wallColors[1], wallColors[0]];
+    }
     return createPipeGeometry(threeOpenAxis, wallColors, hadamard, hiddenFaces);
   }
 
@@ -747,11 +753,9 @@ export function hasBlockOverlap(pos: Position3D, type: BlockType, blocks: Map<st
 
 /**
  * Get the effective basis character for a pipe on a given TQEC axis at one end.
- * Hadamard pipes swap their two closed-axis colors above the band.
- * Because TQEC Y maps to -Three.js Z, the "above band" end is at:
- *   - offset +2 (far end) for X-open and Z-open pipes
- *   - offset -1 (start end) for Y-open pipes (axis direction is reversed)
- * `swapped` = true means this end sees the swapped colors.
+ * Hadamard pipes swap their two closed-axis colors at the far end (offset +2,
+ * higher position = tail in TQEC). `swapped` = true means this end sees the
+ * swapped colors.
  */
 function pipeEndBasis(base: string, hadamard: boolean, openAxis: number, axis: number, swapped: boolean): string {
   if (!hadamard || !swapped) return base[axis];
@@ -788,9 +792,7 @@ export function hasPipeColorConflict(
     if (neighbor.type === "Y") continue;
     if (isPipeType(neighbor.type)) continue;
 
-    // Y-open pipes reverse direction (TQEC Y → -Three.js Z), so the
-    // "above band" (swapped) end is at offset -1 instead of +2.
-    const swapped = openAxis === 1 ? offset === -1 : offset === 2;
+    const swapped = offset === 2;
     for (let axis = 0; axis < 3; axis++) {
       if (axis === openAxis) continue;
       if (pipeEndBasis(base, hadamard, openAxis, axis, swapped) !== neighbor.type[axis]) return true;
@@ -828,10 +830,9 @@ export function hasCubeColorConflict(
       const openAxis = base.indexOf("O");
       if (openAxis !== axis) continue;
 
-      // offset +1: cube is at pipe's start (-1 neighbor)
-      // offset -2: cube is at pipe's far end (+2 neighbor)
-      // Y-open pipes reverse: swapped end is at start (offset +1 from cube = -1 from pipe)
-      const swapped = openAxis === 1 ? offset === 1 : offset === -2;
+      // offset +1: cube is at pipe's start (-1 neighbor = head)
+      // offset -2: cube is at pipe's far end (+2 neighbor = tail, swapped for Hadamard)
+      const swapped = offset === -2;
       for (let i = 0; i < 3; i++) {
         if (i === openAxis) continue;
         if (pipeEndBasis(base, hadamard, openAxis, i, swapped) !== cubeType[i]) return true;

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -215,6 +215,15 @@ class TestValidateEndpoint:
         ])
         assert result["valid"] is True
 
+    def test_y_open_hadamard_pipe_validation(self):
+        # Y-open Hadamard pipe connecting XZZ to ZZX should be valid
+        result = self._run([
+            BlockInput(pos=[0, 0, 0], type="XZZ"),
+            BlockInput(pos=[0, 3, 0], type="ZZX"),
+            BlockInput(pos=[0, 1, 0], type="XOZH"),
+        ])
+        assert result["valid"] is True
+
     def test_collects_all_errors(self):
         # Two cubes with mismatched pipes -> should collect errors from both cubes
         result = self._run([


### PR DESCRIPTION
## Summary
- Fix false validation errors for diagrams containing Y-open Hadamard pipes (e.g., `ZOXH`, `XOZH`)
- Root cause: the frontend encoded Y-open Hadamard pipe kind strings with the basis at the tail, while TQEC expects the head — causing every Y-open Hadamard pipe to fail server validation
- Align the frontend's pipe kind encoding with TQEC convention for all axes (no more Y-axis special case)

## Changes
- **`VARIANT_AXIS_MAP`**: Swap Y-open entries for Hadamard variants so the string encodes head basis
- **`hasPipeColorConflict` / `hasCubeColorConflict`**: Remove Y-reversal special case — swapped end is uniformly at offset +2 (tail)
- **`createBlockGeometry`**: Pre-swap wall colors for Y-open Hadamard pipes to preserve identical visual rendering
- **Tests**: Update frontend tests for new convention, add server validation test for Y-open Hadamard

## Test plan
- [x] All 121 frontend tests pass (`npx vitest run`)
- [x] All 33 server tests pass (`pytest tests/test_server.py`)
- [ ] Manual: place Y-open Hadamard pipe between two cubes, verify rendering and validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)