### PR TITLE
Add keyboard build mode for pipe diagrams

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { Canvas, useFrame } from "@react-three/fiber";
+import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
 
 // Disable color management to match tqec's Three.js v0.138.0 pipeline:
@@ -19,7 +19,9 @@ import { Toolbar } from "./components/Toolbar";
 import { ValidationToast } from "./components/ValidationToast";
 import { InvalidBlockHighlights } from "./components/InvalidBlockHighlights";
 import { SelectionHighlights } from "./components/SelectionHighlights";
+import { BuildCursor } from "./components/BuildCursor";
 import { useBlockStore } from "./stores/blockStore";
+import { wasdToBuildDirection, tqecToThree } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 
 const GRID_SNAP = 3;
@@ -178,6 +180,58 @@ function SelectModeHints() {
   );
 }
 
+/**
+ * Snaps the camera to the build direction target when cameraSnapTarget changes.
+ * Uses OrbitControls to set azimuthal angle and target position.
+ */
+function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> }) {
+  const cameraSnapTarget = useBlockStore((s) => s.cameraSnapTarget);
+  const clearCameraSnap = useBlockStore((s) => s.clearCameraSnap);
+  const { camera } = useThree();
+  const prevTarget = useRef<{ azimuth: number | null; targetPos: { x: number; y: number; z: number } } | null>(null);
+
+  useFrame(() => {
+    if (!cameraSnapTarget || !controlsRef.current) return;
+    if (prevTarget.current === cameraSnapTarget) return;
+    prevTarget.current = cameraSnapTarget;
+
+    const controls = controlsRef.current;
+    const [tx, ty, tz] = tqecToThree(cameraSnapTarget.targetPos, "XZZ");
+
+    if (cameraSnapTarget.azimuth !== null) {
+      // Compute distance BEFORE moving target so it stays constant
+      const currentDistance = camera.position.distanceTo(controls.target);
+      const dist = Math.max(currentDistance, 15);
+      // Update orbit target to follow cursor
+      controls.target.set(tx, ty, tz);
+      // Clamp polar angle to at most ~55° from horizontal (1.2 rad from vertical)
+      // so the camera looks slightly down rather than from above
+      const polar = Math.min(controls.getPolarAngle(), 1.2);
+      const az = cameraSnapTarget.azimuth;
+
+      camera.position.set(
+        tx + dist * Math.sin(polar) * Math.sin(az),
+        ty + dist * Math.cos(polar),
+        tz + dist * Math.sin(polar) * Math.cos(az),
+      );
+    } else {
+      // Z movement — translate camera + slight rotation to reveal vertical build
+      const offset = new THREE.Vector3().subVectors(camera.position, controls.target);
+      const nudge = 0.08; // ~5° rotation around Y axis
+      const cos = Math.cos(nudge), sin = Math.sin(nudge);
+      const rx = offset.x * cos - offset.z * sin;
+      const rz = offset.x * sin + offset.z * cos;
+      controls.target.set(tx, ty, tz);
+      camera.position.set(tx + rx, ty + offset.y, tz + rz);
+    }
+
+    controls.update();
+    clearCameraSnap();
+  });
+
+  return null;
+}
+
 function PlacementWarning() {
   const reason = useBlockStore((s) => s.hoveredInvalidReason);
   if (!reason) return null;
@@ -214,11 +268,45 @@ export default function App() {
     const handler = (e: KeyboardEvent) => {
       const key = e.key.toLowerCase();
       const ctrl = e.ctrlKey || e.metaKey;
+      const store = useBlockStore.getState();
+
+      // Build mode keys (no modifier)
+      if (!ctrl && store.mode === "build") {
+        if (["w", "a", "s", "d"].includes(key) || key === "arrowup" || key === "arrowdown") {
+          e.preventDefault();
+          const controls = controlsRef.current;
+          if (!controls) return;
+          const azimuth = controls.getAzimuthalAngle();
+          const dirKey = key as "w" | "a" | "s" | "d" | "arrowup" | "arrowdown";
+          const direction = wasdToBuildDirection(dirKey, azimuth);
+          store.buildMove(direction);
+          return;
+        }
+        if (key === "q") {
+          e.preventDefault();
+          store.undoBuildStep();
+          return;
+        }
+        if (key === "r") {
+          e.preventDefault();
+          store.cycleCubeType();
+          return;
+        }
+        if (key === "h") {
+          e.preventDefault();
+          store.toggleHadamard();
+          return;
+        }
+        if (key === "escape") {
+          e.preventDefault();
+          store.setMode("place");
+          return;
+        }
+      }
 
       // Non-modifier shortcuts
       if (!ctrl) {
         if (key === "delete" || key === "backspace") {
-          const store = useBlockStore.getState();
           if (store.selectedKeys.size > 0) {
             e.preventDefault();
             store.deleteSelected();
@@ -226,9 +314,9 @@ export default function App() {
           return;
         }
         if (key === "escape") {
-          if (useBlockStore.getState().selectedKeys.size > 0) {
+          if (store.selectedKeys.size > 0) {
             e.preventDefault();
-            useBlockStore.getState().clearSelection();
+            store.clearSelection();
           }
           return;
         }
@@ -236,18 +324,18 @@ export default function App() {
       }
 
       // Ctrl/Cmd shortcuts
-      if (key === "a" && useBlockStore.getState().mode === "select") {
+      if (key === "a" && store.mode === "select") {
         e.preventDefault();
-        useBlockStore.getState().selectAll();
+        store.selectAll();
       } else if (key === "z" && e.shiftKey) {
         e.preventDefault();
-        useBlockStore.getState().redo();
+        store.redo();
       } else if (key === "z") {
         e.preventDefault();
-        useBlockStore.getState().undo();
+        store.undo();
       } else if (key === "y") {
         e.preventDefault();
-        useBlockStore.getState().redo();
+        store.redo();
       }
     };
     window.addEventListener("keydown", handler);
@@ -287,6 +375,8 @@ export default function App() {
         <BlockInstances />
         <InvalidBlockHighlights />
         <SelectionHighlights />
+        <BuildCursor />
+        <CameraBuildSnap controlsRef={controlsRef} />
         <GridPlane />
         <GhostBlock />
         <AxisLabels />

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -230,6 +230,14 @@ function TypedInstances({
     const b = blocksRef.current;
     if (e.instanceId == null || e.instanceId >= b.length) return;
     const store = useBlockStore.getState();
+    if (store.mode === "build") {
+      // In build mode, clicking a cube moves the cursor there
+      const clicked = b[e.instanceId];
+      if (!isPipeType(clicked.type)) {
+        store.moveBuildCursor(clicked.pos);
+      }
+      return;
+    }
     if (store.mode === "select") {
       store.selectBlock(b[e.instanceId].pos, e.nativeEvent.shiftKey);
       return;
@@ -273,6 +281,7 @@ function TypedInstances({
 export function BlockInstances() {
   const blocks = useBlockStore((s) => s.blocks);
   const hiddenFaces = useBlockStore((s) => s.hiddenFaces);
+  const undeterminedCubes = useBlockStore((s) => s.undeterminedCubes);
 
   const grouped = useMemo(() => {
     type Group = {
@@ -281,8 +290,10 @@ export function BlockInstances() {
       blocks: Block[];
     };
     // Hidden faces are pre-computed in the store — just group by (type, mask)
+    // Skip undetermined cubes (rendered by BuildCursor instead)
     const map = new Map<string, Group>();
     for (const block of blocks.values()) {
+      if (undeterminedCubes.has(posKey(block.pos))) continue;
       const hf = hiddenFaces.get(posKey(block.pos)) ?? 0;
       const key = `${block.type}:${hf}`;
       const existing = map.get(key);
@@ -297,7 +308,7 @@ export function BlockInstances() {
       }
     }
     return map;
-  }, [blocks, hiddenFaces]);
+  }, [blocks, hiddenFaces, undeterminedCubes]);
 
   return (
     <>

--- a/piper_draw/gui/src/components/BuildCursor.tsx
+++ b/piper_draw/gui/src/components/BuildCursor.tsx
@@ -1,0 +1,105 @@
+import { useRef, useMemo } from "react";
+import * as THREE from "three";
+import { useFrame } from "@react-three/fiber";
+import { useBlockStore } from "../stores/blockStore";
+import { tqecToThree, blockThreeSize, posKey } from "../types";
+import type { Block } from "../types";
+
+const cursorMaterial = new THREE.MeshBasicMaterial({
+  color: 0xcccccc,
+  transparent: true,
+  opacity: 0.35,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+});
+
+const cursorLineMaterial = new THREE.LineBasicMaterial({
+  color: 0x333333,
+  linewidth: 2,
+});
+
+const undeterminedMaterial = new THREE.MeshBasicMaterial({
+  color: 0xbbbbbb,
+  transparent: true,
+  opacity: 0.3,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+});
+
+const undeterminedLineMaterial = new THREE.LineBasicMaterial({
+  color: 0x555555,
+  linewidth: 1,
+});
+
+// Default cube geometry for cursor/undetermined cubes (1x1x1 in Three.js)
+const defaultBox = new THREE.BoxGeometry(1, 1, 1);
+const defaultEdges = new THREE.EdgesGeometry(defaultBox);
+
+const noRaycast = () => {};
+
+/** Pulsing cursor at the build position */
+function CursorBox({ position, isCursor }: { position: [number, number, number]; isCursor: boolean }) {
+  const groupRef = useRef<THREE.Group>(null!);
+
+  useFrame(({ clock }) => {
+    if (!isCursor || !groupRef.current) return;
+    // Subtle pulsing scale for cursor (1.0 to 1.06)
+    const pulse = 1.0 + 0.03 * Math.sin(clock.getElapsedTime() * 4);
+    groupRef.current.scale.setScalar(pulse);
+  });
+
+  return (
+    <group ref={groupRef} position={position}>
+      <mesh
+        geometry={defaultBox}
+        material={isCursor ? cursorMaterial : undeterminedMaterial}
+        raycast={noRaycast}
+      />
+      <lineSegments
+        geometry={defaultEdges}
+        material={isCursor ? cursorLineMaterial : undeterminedLineMaterial}
+        raycast={noRaycast}
+      />
+    </group>
+  );
+}
+
+export function BuildCursor() {
+  const mode = useBlockStore((s) => s.mode);
+  const buildCursor = useBlockStore((s) => s.buildCursor);
+  const undeterminedCubes = useBlockStore((s) => s.undeterminedCubes);
+  const blocks = useBlockStore((s) => s.blocks);
+
+  const positions = useMemo(() => {
+    if (!buildCursor) return { cursor: null, undetermined: [] };
+
+    const cursorKey = posKey(buildCursor);
+    // Cursor position in Three.js coords (use default cube size)
+    const cursorThree = tqecToThree(buildCursor, "XZZ") as [number, number, number];
+
+    // Collect undetermined cube positions (excluding cursor if it's also undetermined)
+    const undetermined: Array<{ key: string; pos: [number, number, number] }> = [];
+    for (const [key] of undeterminedCubes) {
+      if (key === cursorKey) continue;
+      const block = blocks.get(key);
+      if (!block) continue;
+      undetermined.push({
+        key,
+        pos: tqecToThree(block.pos, block.type) as [number, number, number],
+      });
+    }
+
+    return { cursor: cursorThree, undetermined };
+  }, [buildCursor, undeterminedCubes, blocks]);
+
+  if (mode !== "build" || !positions.cursor) return null;
+
+  return (
+    <>
+      <CursorBox position={positions.cursor} isCursor={true} />
+      {positions.undetermined.map(({ key, pos }) => (
+        <CursorBox key={key} position={pos} isCursor={false} />
+      ))}
+    </>
+  );
+}

--- a/piper_draw/gui/src/components/BuildCursor.tsx
+++ b/piper_draw/gui/src/components/BuildCursor.tsx
@@ -2,8 +2,7 @@ import { useRef, useMemo } from "react";
 import * as THREE from "three";
 import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { tqecToThree, blockThreeSize, posKey } from "../types";
-import type { Block } from "../types";
+import { tqecToThree, posKey } from "../types";
 
 const cursorMaterial = new THREE.MeshBasicMaterial({
   color: 0xcccccc,

--- a/piper_draw/gui/src/components/GhostBlock.tsx
+++ b/piper_draw/gui/src/components/GhostBlock.tsx
@@ -93,6 +93,6 @@ function GhostBlockInner() {
 export function GhostBlock() {
   const hasHover = useBlockStore((s) => s.hoveredGridPos !== null);
   const mode = useBlockStore((s) => s.mode);
-  if (!hasHover || mode === "select") return null;
+  if (!hasHover || mode === "select" || mode === "build") return null;
   return <GhostBlockInner />;
 }

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -74,7 +74,7 @@ export function GridPlane() {
     setHoveredGridPos(null);
   };
 
-  if (mode === "delete") return null;
+  if (mode === "delete" || mode === "build") return null;
   if (mode === "select") {
     return (
       <mesh

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -128,6 +128,9 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
         <button onClick={() => setMode("delete")} style={btnStyle(mode === "delete")}>
           Delete
         </button>
+        <button onClick={() => setMode("build")} style={btnStyle(mode === "build")}>
+          Build
+        </button>
         <button onClick={onResetCamera} style={btnStyle(false)}>
           Origin
         </button>
@@ -217,7 +220,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
       <div style={{ width: 1, background: "#ddd" }} />
 
       {/* Blocks group (ZXCubes + Y) */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px", opacity: mode === "build" ? 0.4 : 1, pointerEvents: mode === "build" ? "none" : "auto" }}>
         <span style={groupLabelStyle}>Blocks</span>
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
           {CUBE_TYPES.map((ct) => (
@@ -250,7 +253,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
       <div style={{ width: 1, background: "#ddd" }} />
 
       {/* Pipes group */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px", opacity: mode === "build" ? 0.4 : 1, pointerEvents: mode === "build" ? "none" : "auto" }}>
         <span style={groupLabelStyle}>Pipes</span>
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
           {PIPE_VARIANTS.map((v) => (

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -24,7 +24,6 @@ import {
   cameraAzimuthForDirection,
   CUBE_TYPES,
   PIPE_TYPES,
-  tqecToThree,
 } from "../types";
 
 export type Mode = "place" | "delete" | "select" | "build";
@@ -579,7 +578,6 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         }
 
         const newBuildHistory = [...state.buildHistory, step];
-        const destPos = step.cube ? step.cube.block.pos : computeDestCubePos(step.prevCursorPos, { tqecAxis: 0, sign: 1 }); // fallback
 
         return {
           blocks,

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1,5 +1,8 @@
 import { create } from "zustand";
-import type { Position3D, Block, BlockType, CubeType, PipeVariant, SpatialIndex, FaceMask } from "../types";
+import type {
+  Position3D, Block, BlockType, CubeType, PipeVariant, PipeType, SpatialIndex, FaceMask,
+  BuildDirection, UndeterminedCubeInfo,
+} from "../types";
 import {
   posKey,
   hasBlockOverlap,
@@ -14,9 +17,17 @@ import {
   removeFromSpatialIndex,
   recomputeAffectedHiddenFaces,
   getHiddenFaceMaskForPos,
+  computeDestCubePos,
+  computePipePos,
+  inferPipeType,
+  determineCubeOptions,
+  cameraAzimuthForDirection,
+  CUBE_TYPES,
+  PIPE_TYPES,
+  tqecToThree,
 } from "../types";
 
-export type Mode = "place" | "delete" | "select";
+export type Mode = "place" | "delete" | "select" | "build";
 
 const MAX_HISTORY = 100;
 
@@ -30,13 +41,40 @@ const PIPE_VARIANT_CANONICAL: Record<PipeVariant, BlockType> = {
 // Add/remove commands are O(1) memory; clear saves the full map (rare).
 // ---------------------------------------------------------------------------
 
+/** Captures one keyboard-build step for atomic undo. */
+export type BuildStep = {
+  prevCursorPos: Position3D;
+  /** Pipe placed (null if pipe already existed). */
+  pipe: { key: string; block: Block } | null;
+  /** Cube placed at destination (null if cube already existed). */
+  cube: { key: string; block: Block } | null;
+  /** Origin cube placed on empty canvas (first step only). */
+  originCube?: { key: string; block: Block };
+  /** If the source cube was auto-determined during this step. */
+  sourceDetermination?: {
+    key: string;
+    prevType: CubeType;
+    prevUndeterminedInfo: UndeterminedCubeInfo;
+  };
+  /** If the destination cube is undetermined after this step. */
+  destUndetermined?: UndeterminedCubeInfo;
+  /** If an existing destination cube was re-typed to accommodate the new pipe. */
+  destTypeChange?: { key: string; prevType: CubeType; newType: CubeType };
+};
+
 type UndoCommand =
   | { kind: "add"; key: string; block: Block }
   | { kind: "remove"; key: string; block: Block }
   | { kind: "bulk-remove"; entries: Array<{ key: string; block: Block }> }
   | { kind: "clear"; savedBlocks: Map<string, Block>; savedHiddenFaces: Map<string, FaceMask> }
   | { kind: "load"; savedBlocks: Map<string, Block>; savedHiddenFaces: Map<string, FaceMask>;
-      newBlocks: Map<string, Block>; newIndex: SpatialIndex; newHiddenFaces: Map<string, FaceMask> };
+      newBlocks: Map<string, Block>; newIndex: SpatialIndex; newHiddenFaces: Map<string, FaceMask> }
+  | { kind: "build-step"; step: BuildStep }
+  | { kind: "hadamard-toggle"; pipeKey: string; oldType: PipeType; newType: PipeType;
+      retyped?: Array<{ cubeKey: string; oldType: CubeType; newType: CubeType;
+        oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo }> }
+  | { kind: "cube-cycle"; cubeKey: string; oldType: CubeType; newType: CubeType;
+      oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }> };
 
 interface BlockStore {
   blocks: Map<string, Block>;
@@ -52,6 +90,13 @@ interface BlockStore {
   hoveredInvalid: boolean;
   hoveredInvalidReason: string | null;
   selectedKeys: Set<string>;
+
+  // Build mode state
+  buildCursor: Position3D | null;
+  buildHistory: BuildStep[];
+  undeterminedCubes: Map<string, UndeterminedCubeInfo>;
+  /** Camera snap target set by build actions, consumed by CameraBuildSnap component. */
+  cameraSnapTarget: { azimuth: number | null; targetPos: Position3D } | null;
 
   setMode: (mode: Mode) => void;
   setCubeType: (cubeType: BlockType) => void;
@@ -69,6 +114,14 @@ interface BlockStore {
   clearSelection: () => void;
   deleteSelected: () => void;
   selectAll: () => void;
+
+  // Build mode actions
+  buildMove: (direction: BuildDirection) => boolean;
+  undoBuildStep: () => void;
+  cycleCubeType: () => void;
+  toggleHadamard: () => void;
+  moveBuildCursor: (pos: Position3D) => void;
+  clearCameraSnap: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -125,14 +178,73 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   hoveredInvalidReason: null,
   selectedKeys: new Set(),
 
-  setMode: (mode) => set({
-    mode,
-    hoveredGridPos: null,
-    hoveredBlockType: null,
-    hoveredInvalid: false,
-    hoveredInvalidReason: null,
-    ...(mode === "place" ? { selectedKeys: new Set<string>() } : {}),
-  }),
+  // Build mode state
+  buildCursor: null,
+  buildHistory: [],
+  undeterminedCubes: new Map(),
+  cameraSnapTarget: null,
+
+  setMode: (mode) => {
+    const prev = get();
+
+    // Leaving build mode: commit undetermined cubes to their current type
+    if (prev.mode === "build" && mode !== "build") {
+      set({
+        mode,
+        buildCursor: null,
+        buildHistory: [],
+        undeterminedCubes: new Map(),
+        cameraSnapTarget: null,
+        hoveredGridPos: null,
+        hoveredBlockType: null,
+        hoveredInvalid: false,
+        hoveredInvalidReason: null,
+        selectedKeys: new Set<string>(),
+      });
+      return;
+    }
+
+    // Entering build mode: place cursor on last-placed cube or origin
+    if (mode === "build") {
+      let cursorPos: Position3D = { x: 0, y: 0, z: 0 };
+
+      // Find the most recently placed cube by scanning history backwards
+      for (let i = prev.history.length - 1; i >= 0; i--) {
+        const cmd = prev.history[i];
+        if (cmd.kind === "add" && !isPipeType(cmd.block.type) && cmd.block.type !== "Y") {
+          cursorPos = cmd.block.pos;
+          break;
+        }
+        if (cmd.kind === "build-step") {
+          if (cmd.step.cube) { cursorPos = cmd.step.cube.block.pos; break; }
+          if (cmd.step.originCube) { cursorPos = cmd.step.originCube.block.pos; break; }
+        }
+      }
+
+      set({
+        mode,
+        buildCursor: cursorPos,
+        buildHistory: [],
+        undeterminedCubes: new Map(),
+        cameraSnapTarget: null,
+        hoveredGridPos: null,
+        hoveredBlockType: null,
+        hoveredInvalid: false,
+        hoveredInvalidReason: null,
+        selectedKeys: new Set<string>(),
+      });
+      return;
+    }
+
+    set({
+      mode,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredInvalidReason: null,
+      ...(mode === "place" ? { selectedKeys: new Set<string>() } : {}),
+    });
+  },
   setCubeType: (cubeType) => set({ cubeType, pipeVariant: null }),
   setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant] }),
   setHoveredGridPos: (pos, blockType, invalid, reason) => set((state) => {
@@ -256,6 +368,110 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         };
       }
 
+      if (cmd.kind === "build-step") {
+        const step = cmd.step;
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        const newUndetermined = new Map(state.undeterminedCubes);
+
+        // Remove dest cube
+        if (step.cube) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, step.cube.key, step.cube.block));
+          newUndetermined.delete(step.cube.key);
+        }
+        // Revert dest type change
+        if (step.destTypeChange) {
+          const dtc = step.destTypeChange;
+          const curDest = blocks.get(dtc.key);
+          if (curDest) {
+            ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, dtc.key, curDest));
+            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, dtc.key, { pos: curDest.pos, type: dtc.prevType }));
+          }
+        }
+        // Remove pipe
+        if (step.pipe) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, step.pipe.key, step.pipe.block));
+        }
+        // Revert source determination
+        if (step.sourceDetermination) {
+          const sd = step.sourceDetermination;
+          const curSrc = blocks.get(sd.key);
+          if (curSrc) ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, sd.key, curSrc));
+          const reverted: Block = { pos: step.prevCursorPos, type: sd.prevType };
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, sd.key, reverted));
+          newUndetermined.set(sd.key, { ...sd.prevUndeterminedInfo, options: [...sd.prevUndeterminedInfo.options] });
+        }
+        // Remove origin cube
+        if (step.originCube) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, step.originCube.key, step.originCube.block));
+          newUndetermined.delete(step.originCube.key);
+        }
+
+        const newBuildHistory = [...state.buildHistory];
+        if (newBuildHistory.length > 0) newBuildHistory.pop();
+
+        return {
+          blocks,
+          hiddenFaces,
+          history: newHistory,
+          future: [cmd, ...state.future].slice(0, MAX_HISTORY),
+          hoveredGridPos: null,
+          buildCursor: state.mode === "build" ? step.prevCursorPos : state.buildCursor,
+          buildHistory: newBuildHistory,
+          undeterminedCubes: newUndetermined,
+        };
+      }
+
+      if (cmd.kind === "hadamard-toggle") {
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        const newUndetermined = new Map(state.undeterminedCubes);
+
+        const pipeBlock = blocks.get(cmd.pipeKey);
+        if (pipeBlock) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cmd.pipeKey, pipeBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.pipeKey, { pos: pipeBlock.pos, type: cmd.oldType }));
+        }
+        if (cmd.retyped) {
+          for (const rd of cmd.retyped) {
+            const cubeBlock = blocks.get(rd.cubeKey);
+            if (cubeBlock) {
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, rd.cubeKey, cubeBlock));
+              ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, rd.cubeKey, { pos: cubeBlock.pos, type: rd.oldType }));
+            }
+            if (rd.oldUndetermined) newUndetermined.set(rd.cubeKey, rd.oldUndetermined);
+            else newUndetermined.delete(rd.cubeKey);
+          }
+        }
+        return { blocks, hiddenFaces, history: newHistory, future: [cmd, ...state.future].slice(0, MAX_HISTORY), undeterminedCubes: newUndetermined, hoveredGridPos: null };
+      }
+
+      if (cmd.kind === "cube-cycle") {
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        const newUndetermined = new Map(state.undeterminedCubes);
+
+        const cubeBlock = blocks.get(cmd.cubeKey);
+        if (cubeBlock) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, cubeBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, { pos: cubeBlock.pos, type: cmd.oldType }));
+        }
+        // Revert pipe updates
+        if (cmd.oldPipes) {
+          for (const pu of cmd.oldPipes) {
+            const pb = blocks.get(pu.key);
+            if (pb) {
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pb));
+              ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pb.pos, type: pu.oldType }));
+            }
+          }
+        }
+        // Restore undetermined index
+        const info = newUndetermined.get(cmd.cubeKey);
+        if (info) {
+          const idx = info.options.indexOf(cmd.oldType);
+          if (idx >= 0) newUndetermined.set(cmd.cubeKey, { ...info, currentIndex: idx });
+        }
+        return { blocks, hiddenFaces, history: newHistory, future: [cmd, ...state.future].slice(0, MAX_HISTORY), undeterminedCubes: newUndetermined, hoveredGridPos: null };
+      }
+
       // cmd.kind === "clear" — restore saved state, rebuild spatial index
       const newIndex = buildSpatialIndex(cmd.savedBlocks);
       return {
@@ -321,6 +537,109 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           future: newFuture,
           hoveredGridPos: null,
         };
+      }
+
+      if (cmd.kind === "build-step") {
+        const step = cmd.step;
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        const newUndetermined = new Map(state.undeterminedCubes);
+
+        // Re-place origin cube
+        if (step.originCube) {
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, step.originCube.key, step.originCube.block));
+        }
+        // Re-determine source
+        if (step.sourceDetermination) {
+          const sd = step.sourceDetermination;
+          const curSrc = blocks.get(sd.key);
+          if (curSrc) ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, sd.key, curSrc));
+          // Re-determine using constraints from adjacent pipes (pipe not yet re-placed)
+          const newSrcOptions = determineCubeOptions(step.prevCursorPos, blocks);
+          const srcType = newSrcOptions.determined ? newSrcOptions.type : (newSrcOptions.options[0] ?? sd.prevType);
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, sd.key, { pos: step.prevCursorPos, type: srcType }));
+          newUndetermined.delete(sd.key);
+        }
+        // Re-place pipe
+        if (step.pipe) {
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, step.pipe.key, step.pipe.block));
+        }
+        // Re-apply dest type change
+        if (step.destTypeChange) {
+          const dtc = step.destTypeChange;
+          const curDest = blocks.get(dtc.key);
+          if (curDest) {
+            ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, dtc.key, curDest));
+            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, dtc.key, { pos: curDest.pos, type: dtc.newType }));
+          }
+        }
+        // Re-place dest cube
+        if (step.cube) {
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, step.cube.key, step.cube.block));
+          if (step.destUndetermined) newUndetermined.set(step.cube.key, step.destUndetermined);
+        }
+
+        const newBuildHistory = [...state.buildHistory, step];
+        const destPos = step.cube ? step.cube.block.pos : computeDestCubePos(step.prevCursorPos, { tqecAxis: 0, sign: 1 }); // fallback
+
+        return {
+          blocks,
+          hiddenFaces,
+          history: [...state.history, cmd],
+          future: newFuture,
+          hoveredGridPos: null,
+          buildCursor: step.cube ? step.cube.block.pos : state.buildCursor,
+          buildHistory: newBuildHistory,
+          undeterminedCubes: newUndetermined,
+        };
+      }
+
+      if (cmd.kind === "hadamard-toggle") {
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        const newUndetermined = new Map(state.undeterminedCubes);
+
+        const pipeBlock = blocks.get(cmd.pipeKey);
+        if (pipeBlock) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cmd.pipeKey, pipeBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.pipeKey, { pos: pipeBlock.pos, type: cmd.newType }));
+        }
+        if (cmd.retyped) {
+          for (const rd of cmd.retyped) {
+            const cubeBlock = blocks.get(rd.cubeKey);
+            if (cubeBlock) {
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, rd.cubeKey, cubeBlock));
+              ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, rd.cubeKey, { pos: cubeBlock.pos, type: rd.newType }));
+            }
+            if (rd.newUndetermined) newUndetermined.set(rd.cubeKey, rd.newUndetermined);
+            else newUndetermined.delete(rd.cubeKey);
+          }
+        }
+        return { blocks, hiddenFaces, history: [...state.history, cmd], future: newFuture, undeterminedCubes: newUndetermined, hoveredGridPos: null };
+      }
+
+      if (cmd.kind === "cube-cycle") {
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        const newUndetermined = new Map(state.undeterminedCubes);
+
+        const cubeBlock = blocks.get(cmd.cubeKey);
+        if (cubeBlock) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, cubeBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, { pos: cubeBlock.pos, type: cmd.newType }));
+        }
+        if (cmd.oldPipes) {
+          for (const pu of cmd.oldPipes) {
+            const pb = blocks.get(pu.key);
+            if (pb) {
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pb));
+              ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pb.pos, type: pu.newType }));
+            }
+          }
+        }
+        const info = newUndetermined.get(cmd.cubeKey);
+        if (info) {
+          const idx = info.options.indexOf(cmd.newType);
+          if (idx >= 0) newUndetermined.set(cmd.cubeKey, { ...info, currentIndex: idx });
+        }
+        return { blocks, hiddenFaces, history: [...state.history, cmd], future: newFuture, undeterminedCubes: newUndetermined, hoveredGridPos: null };
       }
 
       // cmd.kind === "clear" — save current state, then clear
@@ -435,4 +754,494 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       if (state.blocks.size === 0) return state;
       return { selectedKeys: new Set(state.blocks.keys()) };
     }),
+
+  // ---------------------------------------------------------------------------
+  // Build mode actions
+  // ---------------------------------------------------------------------------
+
+  buildMove: (direction) => {
+    const state = get();
+    if (state.mode !== "build" || !state.buildCursor) return false;
+
+    const cursor = state.buildCursor;
+    const pipePos = computePipePos(cursor, direction);
+    const destPos = computeDestCubePos(cursor, direction);
+    const pipeKey = posKey(pipePos);
+    const destKey = posKey(destPos);
+    const srcKey = posKey(cursor);
+
+    // If pipe already exists, just move cursor to destination if it has a cube
+    const existingPipe = state.blocks.get(pipeKey);
+    if (existingPipe) {
+      const existingDest = state.blocks.get(destKey);
+      if (existingDest && !isPipeType(existingDest.type)) {
+        const azimuth = cameraAzimuthForDirection(direction);
+        set({
+          buildCursor: destPos,
+          cameraSnapTarget: { azimuth, targetPos: destPos },
+        });
+        return true;
+      }
+      return false;
+    }
+
+    const srcBlock = state.blocks.get(srcKey);
+    const isEmptyOrigin = !srcBlock;
+    const isUndetermined = !isEmptyOrigin && state.undeterminedCubes.has(srcKey);
+
+    // Determine source cube type
+    let srcType: CubeType;
+    let sourceDetermination: BuildStep["sourceDetermination"];
+
+    if (isEmptyOrigin) {
+      // First step on empty canvas — pick a valid cube type for this build axis
+      const validOrigin = CUBE_TYPES.filter(ct => inferPipeType(ct, direction.tqecAxis) !== null);
+      if (validOrigin.length === 0) return false;
+      srcType = validOrigin[0];
+    } else if (srcBlock!.type === "Y" || isPipeType(srcBlock!.type)) {
+      return false;
+    } else if (isUndetermined) {
+      // Source is undetermined — always commit when building away.
+      // Filter to options that can pipe on this axis.
+      const info = state.undeterminedCubes.get(srcKey)!;
+      const validForDir = info.options.filter(opt => inferPipeType(opt, direction.tqecAxis) !== null);
+      if (validForDir.length === 0) return false;
+
+      // Check if all valid options produce the same pipe type
+      const pipeSet = new Set(validForDir.map(opt => inferPipeType(opt, direction.tqecAxis)));
+      if (pipeSet.size > 1) return false; // Truly ambiguous — different pipe types, must cycle (R)
+
+      // Prefer current type if it's valid for this direction
+      const currentType = srcBlock!.type as CubeType;
+      srcType = validForDir.includes(currentType) ? currentType : validForDir[0];
+      // Always determine source — commit to chosen type
+      sourceDetermination = {
+        key: srcKey,
+        prevType: currentType,
+        prevUndeterminedInfo: { ...info, options: [...info.options] },
+      };
+    } else {
+      srcType = srcBlock!.type as CubeType;
+    }
+
+    // Infer pipe type from source
+    const pipeType = inferPipeType(srcType, direction.tqecAxis);
+    if (!pipeType) return false;
+
+    // Validate pipe position and overlap
+    if (!isValidPos(pipePos, pipeType)) return false;
+    if (hasBlockOverlap(pipePos, pipeType, state.blocks, state.spatialIndex)) return false;
+
+    // Y cube pipe axis conflict: Y cubes only work with Z-open pipes
+    if (hasYCubePipeAxisConflict(pipeType, pipePos, state.blocks)) return false;
+
+    // Check if destination already has a cube
+    const existingDest = state.blocks.get(destKey);
+    let destTypeChange: BuildStep["destTypeChange"];
+    if (existingDest) {
+      if (existingDest.type === "Y" || isPipeType(existingDest.type)) return false;
+      // Destination exists — check if current type is compatible, auto-retype if needed
+      const tmpBlocks = new Map(state.blocks);
+      if (sourceDetermination || isEmptyOrigin) {
+        tmpBlocks.set(srcKey, { pos: cursor, type: srcType });
+      }
+      tmpBlocks.set(pipeKey, { pos: pipePos, type: pipeType });
+      const destOptions = determineCubeOptions(destPos, tmpBlocks);
+      const currentDestType = existingDest.type as CubeType;
+      if (destOptions.determined) {
+        if (destOptions.type !== currentDestType) {
+          destTypeChange = { key: destKey, prevType: currentDestType, newType: destOptions.type };
+        }
+      } else if (destOptions.options.includes(currentDestType)) {
+        // Current type is still valid — keep it
+      } else if (destOptions.options.length > 0) {
+        destTypeChange = { key: destKey, prevType: currentDestType, newType: destOptions.options[0] };
+      } else {
+        return false; // No valid type exists for dest with this pipe
+      }
+    } else {
+      // Validate destination position and check for overlap with non-cube blocks
+      if (!isValidPos(destPos, "XZZ")) return false;
+      if (hasBlockOverlap(destPos, "XZZ", state.blocks, state.spatialIndex)) return false;
+    }
+
+    // All validation passed — apply mutations
+    set((s) => {
+      let { blocks, hiddenFaces } = { blocks: s.blocks, hiddenFaces: s.hiddenFaces };
+      const newUndetermined = new Map(s.undeterminedCubes);
+      let originCubeEntry: BuildStep["originCube"];
+
+      // Place origin cube on empty canvas (always determined — no ghost)
+      if (isEmptyOrigin) {
+        const originBlock: Block = { pos: cursor, type: srcType };
+        ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, srcKey, originBlock));
+        originCubeEntry = { key: srcKey, block: originBlock };
+      }
+
+      // Apply source determination (commit undetermined source to chosen type)
+      if (sourceDetermination) {
+        const oldSrc = blocks.get(srcKey)!;
+        ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, srcKey, oldSrc));
+        const newSrc: Block = { pos: cursor, type: srcType };
+        ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, srcKey, newSrc));
+        newUndetermined.delete(srcKey);
+      }
+
+      // Place pipe
+      const pipeBlock: Block = { pos: pipePos, type: pipeType };
+      ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pipeKey, pipeBlock));
+
+      // Apply dest type change if existing cube needs re-typing
+      if (destTypeChange) {
+        const oldDest = blocks.get(destTypeChange.key)!;
+        ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, destTypeChange.key, oldDest));
+        const newDest: Block = { pos: oldDest.pos, type: destTypeChange.newType };
+        ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, destTypeChange.key, newDest));
+      }
+
+      // Handle destination
+      let cubeAdded: BuildStep["cube"] = null;
+      let destUndetermined: UndeterminedCubeInfo | undefined;
+
+      if (!existingDest) {
+        // Determine destination cube type
+        const destOptions = determineCubeOptions(destPos, blocks);
+        let destType: CubeType;
+        if (destOptions.determined) {
+          destType = destOptions.type;
+        } else if (destOptions.options.length > 0) {
+          destType = destOptions.options[0];
+          destUndetermined = { options: [...destOptions.options], currentIndex: 0 };
+          newUndetermined.set(destKey, destUndetermined);
+        } else {
+          // Shouldn't happen — pipe was valid
+          destType = srcType;
+        }
+        const destBlock: Block = { pos: destPos, type: destType };
+        ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, destKey, destBlock));
+        cubeAdded = { key: destKey, block: destBlock };
+      }
+
+      const step: BuildStep = {
+        prevCursorPos: cursor,
+        pipe: { key: pipeKey, block: pipeBlock },
+        cube: cubeAdded,
+        originCube: originCubeEntry,
+        sourceDetermination,
+        destUndetermined,
+        destTypeChange,
+      };
+
+      const azimuth = cameraAzimuthForDirection(direction);
+
+      return {
+        blocks,
+        hiddenFaces,
+        buildCursor: destPos,
+        buildHistory: [...s.buildHistory, step],
+        undeterminedCubes: newUndetermined,
+        cameraSnapTarget: { azimuth, targetPos: destPos },
+        history: [...s.history, { kind: "build-step" as const, step }].slice(-MAX_HISTORY),
+        future: [],
+      };
+    });
+    return true;
+  },
+
+  undoBuildStep: () => {
+    const state = get();
+    if (state.mode !== "build" || state.buildHistory.length === 0) return;
+
+    set((s) => {
+      if (s.buildHistory.length === 0) return s;
+      const newBuildHistory = [...s.buildHistory];
+      const step = newBuildHistory.pop()!;
+
+      let { blocks, hiddenFaces } = { blocks: s.blocks, hiddenFaces: s.hiddenFaces };
+      const newUndetermined = new Map(s.undeterminedCubes);
+
+      // Remove destination cube if we placed it
+      if (step.cube) {
+        ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, step.cube.key, step.cube.block));
+        newUndetermined.delete(step.cube.key);
+      }
+
+      // Revert dest type change (restore original type)
+      if (step.destTypeChange) {
+        const dtc = step.destTypeChange;
+        const curDest = blocks.get(dtc.key);
+        if (curDest) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, dtc.key, curDest));
+          ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, dtc.key, { pos: curDest.pos, type: dtc.prevType }));
+        }
+      }
+
+      // Remove pipe
+      if (step.pipe) {
+        ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, step.pipe.key, step.pipe.block));
+      }
+
+      // Revert source determination
+      if (step.sourceDetermination) {
+        const sd = step.sourceDetermination;
+        const curSrc = blocks.get(sd.key);
+        if (curSrc) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, sd.key, curSrc));
+        }
+        const reverted: Block = { pos: step.prevCursorPos, type: sd.prevType };
+        ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, sd.key, reverted));
+        newUndetermined.set(sd.key, { ...sd.prevUndeterminedInfo, options: [...sd.prevUndeterminedInfo.options] });
+      }
+
+      // Remove origin cube if this was first step
+      if (step.originCube) {
+        ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, step.originCube.key, step.originCube.block));
+        newUndetermined.delete(step.originCube.key);
+      }
+
+      // Also pop from general undo history if the last command is a matching build-step
+      const newHistory = [...s.history];
+      if (newHistory.length > 0 && newHistory[newHistory.length - 1].kind === "build-step") {
+        const cmd = newHistory.pop()!;
+        return {
+          blocks,
+          hiddenFaces,
+          buildCursor: step.prevCursorPos,
+          buildHistory: newBuildHistory,
+          undeterminedCubes: newUndetermined,
+          cameraSnapTarget: { azimuth: null, targetPos: step.prevCursorPos },
+          history: newHistory,
+          future: [cmd, ...s.future].slice(0, MAX_HISTORY),
+          hoveredGridPos: null,
+        };
+      }
+
+      return {
+        blocks,
+        hiddenFaces,
+        buildCursor: step.prevCursorPos,
+        buildHistory: newBuildHistory,
+        undeterminedCubes: newUndetermined,
+        cameraSnapTarget: { azimuth: null, targetPos: step.prevCursorPos },
+        hoveredGridPos: null,
+      };
+    });
+  },
+
+  cycleCubeType: () =>
+    set((state) => {
+      if (state.mode !== "build" || !state.buildCursor) return state;
+      const cursorKey = posKey(state.buildCursor);
+      const info = state.undeterminedCubes.get(cursorKey);
+      if (!info || info.options.length <= 1) return state;
+
+      const block = state.blocks.get(cursorKey);
+      if (!block) return state;
+
+      const oldType = block.type as CubeType;
+      const newIndex = (info.currentIndex + 1) % info.options.length;
+      const newType = info.options[newIndex];
+
+      // Replace cube block with new type
+      let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+      ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, block));
+      const newBlock: Block = { pos: state.buildCursor, type: newType };
+      ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
+
+      // Update adjacent pipes to match new cube type, validating far-end compatibility
+      const pipeUpdates: Array<{ key: string; oldType: PipeType; newType: PipeType }> = [];
+      const coords: [number, number, number] = [state.buildCursor.x, state.buildCursor.y, state.buildCursor.z];
+
+      // First pass: check all pipe updates are valid before mutating
+      for (let axis = 0; axis < 3; axis++) {
+        for (const pipeOffset of [1, -2]) {
+          const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+          nCoords[axis] += pipeOffset;
+          const nKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
+          const neighbor = blocks.get(nKey);
+          if (!neighbor || !isPipeType(neighbor.type)) continue;
+
+          const base = neighbor.type.replace("H", "");
+          const hadamard = neighbor.type.length > 3;
+          const openAxis = base.indexOf("O");
+          if (openAxis !== axis) continue;
+
+          const newPipe = inferPipeType(newType, axis as 0 | 1 | 2);
+          if (!newPipe) {
+            // Can't create valid pipe on this axis with new type — reject cycle
+            // Revert the cube change
+            ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
+            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, block));
+            return state;
+          }
+          const newPipeType = hadamard ? (newPipe + "H") as PipeType : newPipe;
+          if (newPipeType === neighbor.type) continue;
+
+          // Validate new pipe against the far-end cube
+          const tmpBlocks = new Map(blocks);
+          tmpBlocks.set(nKey, { pos: neighbor.pos, type: newPipeType });
+          if (hasPipeColorConflict(newPipeType, neighbor.pos, tmpBlocks)) {
+            // Conflict with far-end cube — reject cycle
+            ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
+            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, block));
+            return state;
+          }
+
+          pipeUpdates.push({ key: nKey, oldType: neighbor.type as PipeType, newType: newPipeType });
+        }
+      }
+
+      // All valid — apply pipe mutations
+      for (const pu of pipeUpdates) {
+        const pipeBlock = blocks.get(pu.key)!;
+        ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pipeBlock));
+        ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pipeBlock.pos, type: pu.newType }));
+      }
+
+      const newUndetermined = new Map(state.undeterminedCubes);
+      newUndetermined.set(cursorKey, { ...info, currentIndex: newIndex });
+
+      const cmd: UndoCommand = { kind: "cube-cycle", cubeKey: cursorKey, oldType, newType, oldPipes: pipeUpdates };
+      return {
+        blocks,
+        hiddenFaces,
+        undeterminedCubes: newUndetermined,
+        history: [...state.history, cmd].slice(-MAX_HISTORY),
+        future: [],
+      };
+    }),
+
+  toggleHadamard: () => {
+    const state = get();
+    if (state.mode !== "build" || state.buildHistory.length === 0) return;
+
+    // Find last pipe in build history
+    const lastStep = state.buildHistory[state.buildHistory.length - 1];
+    if (!lastStep.pipe) return;
+
+    const pipeKey = lastStep.pipe.key;
+    const pipeBlock = state.blocks.get(pipeKey);
+    if (!pipeBlock || !isPipeType(pipeBlock.type)) return;
+
+    const oldPipeType = pipeBlock.type as PipeType;
+    const isHadamard = oldPipeType.length > 3;
+    const newPipeType = (isHadamard ? oldPipeType.slice(0, 3) : oldPipeType + "H") as PipeType;
+
+    if (!(PIPE_TYPES as readonly string[]).includes(newPipeType)) return;
+
+    // --- Dry-run pass: validate all neighbors using a temp blocks map ---
+    // No spatial index mutations happen here.
+    const tmpBlocks = new Map(state.blocks);
+    tmpBlocks.set(pipeKey, { pos: pipeBlock.pos, type: newPipeType });
+
+    const base = newPipeType.replace("H", "");
+    const openAxis = base.indexOf("O");
+    const pipeCoords: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];
+
+    type RetypeEntry = { key: string; pos: Position3D; oldType: CubeType; newType: CubeType;
+      oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo };
+    const planned: RetypeEntry[] = [];
+
+    for (const offset of [-1, 2]) {
+      const nCoords: [number, number, number] = [pipeCoords[0], pipeCoords[1], pipeCoords[2]];
+      nCoords[openAxis] += offset;
+      const nKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
+      const neighbor = tmpBlocks.get(nKey);
+      if (!neighbor || isPipeType(neighbor.type) || neighbor.type === "Y") continue;
+
+      const cubeInfo = state.undeterminedCubes.get(nKey);
+      const newOptions = determineCubeOptions(neighbor.pos, tmpBlocks);
+      const currentType = neighbor.type as CubeType;
+
+      if (newOptions.determined) {
+        if (newOptions.type !== currentType) {
+          planned.push({ key: nKey, pos: neighbor.pos, oldType: currentType, newType: newOptions.type,
+            oldUndetermined: cubeInfo, newUndetermined: undefined });
+        }
+      } else if (newOptions.options.length > 0) {
+        if (!newOptions.options.includes(currentType)) {
+          const newInfo = cubeInfo ? { options: [...newOptions.options], currentIndex: 0 } : undefined;
+          planned.push({ key: nKey, pos: neighbor.pos, oldType: currentType, newType: newOptions.options[0],
+            oldUndetermined: cubeInfo, newUndetermined: newInfo });
+        }
+        // else: current type still valid, no retype needed
+      } else {
+        // No valid type — reject Hadamard toggle. No mutations happened.
+        return;
+      }
+    }
+
+    // --- All validated, now apply actual mutations ---
+    set((s) => {
+      let { blocks, hiddenFaces } = { blocks: s.blocks, hiddenFaces: s.hiddenFaces };
+      const newUndetermined = new Map(s.undeterminedCubes);
+
+      // Toggle pipe
+      ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, pipeKey, pipeBlock));
+      const newPipeBlock: Block = { pos: pipeBlock.pos, type: newPipeType };
+      ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pipeKey, newPipeBlock));
+
+      // Apply planned retypes
+      const retyped: Array<{ cubeKey: string; oldType: CubeType; newType: CubeType;
+        oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo }> = [];
+      for (const p of planned) {
+        const cur = blocks.get(p.key);
+        if (cur) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, p.key, cur));
+          ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, p.key, { pos: p.pos, type: p.newType }));
+        }
+        if (p.newUndetermined) newUndetermined.set(p.key, p.newUndetermined);
+        else if (p.oldUndetermined) newUndetermined.delete(p.key);
+        retyped.push({ cubeKey: p.key, oldType: p.oldType, newType: p.newType,
+          oldUndetermined: p.oldUndetermined, newUndetermined: p.newUndetermined });
+      }
+
+      // Update undetermined info for neighbors that didn't need retyping but are undetermined
+      for (const offset of [-1, 2]) {
+        const nCoords: [number, number, number] = [pipeCoords[0], pipeCoords[1], pipeCoords[2]];
+        nCoords[openAxis] += offset;
+        const nKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
+        if (planned.some(p => p.key === nKey)) continue; // already handled
+        const cubeInfo = newUndetermined.get(nKey);
+        if (!cubeInfo) continue;
+        const neighbor = blocks.get(nKey);
+        if (!neighbor) continue;
+        const newOptions = determineCubeOptions(neighbor.pos, blocks);
+        if (newOptions.determined) {
+          newUndetermined.delete(nKey);
+        } else if (newOptions.options.length > 0) {
+          const idx = Math.max(0, newOptions.options.indexOf(neighbor.type as CubeType));
+          newUndetermined.set(nKey, { options: [...newOptions.options], currentIndex: idx });
+        }
+      }
+
+      // Update the build history's last step to reflect new pipe type
+      const newBuildHistory = [...s.buildHistory];
+      const lastH = { ...newBuildHistory[newBuildHistory.length - 1] };
+      lastH.pipe = { key: pipeKey, block: newPipeBlock };
+      newBuildHistory[newBuildHistory.length - 1] = lastH;
+
+      const cmd: UndoCommand = { kind: "hadamard-toggle", pipeKey, oldType: oldPipeType, newType: newPipeType,
+        retyped: retyped.length > 0 ? retyped : undefined };
+      return {
+        blocks,
+        hiddenFaces,
+        buildHistory: newBuildHistory,
+        undeterminedCubes: newUndetermined,
+        history: [...s.history, cmd].slice(-MAX_HISTORY),
+        future: [],
+      };
+    });
+  },
+
+  moveBuildCursor: (pos) =>
+    set((state) => {
+      if (state.mode !== "build") return state;
+      const key = posKey(pos);
+      const block = state.blocks.get(key);
+      if (!block || isPipeType(block.type)) return state;
+      return { buildCursor: pos };
+    }),
+
+  clearCameraSnap: () => set({ cameraSnapTarget: null }),
 }));

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -895,6 +895,170 @@ export function hasYCubePipeAxisConflict(
  *   (0, ±1, 0) → TQEC Z ± srcSizeZ / dstSizeZ
  *   (0, 0, ±1) → TQEC Y ∓ srcSizeY / dstSizeY
  */
+// ---------------------------------------------------------------------------
+// Build mode types & logic
+// ---------------------------------------------------------------------------
+
+export type BuildDirection = { tqecAxis: 0 | 1 | 2; sign: 1 | -1 };
+
+export type UndeterminedCubeInfo = {
+  options: CubeType[];
+  currentIndex: number;
+};
+
+/**
+ * Compute destination cube position from cursor position and build direction.
+ * Cubes are spaced 3 apart on the grid.
+ */
+export function computeDestCubePos(cursorPos: Position3D, dir: BuildDirection): Position3D {
+  const dst = { ...cursorPos };
+  const key: keyof Position3D = dir.tqecAxis === 0 ? "x" : dir.tqecAxis === 1 ? "y" : "z";
+  dst[key] += dir.sign * 3;
+  return dst;
+}
+
+/**
+ * Compute pipe position between cursor and destination for a build direction.
+ * Pipe occupies the slot at cursor[axis]+1 (positive dir) or cursor[axis]-2 (negative dir).
+ */
+export function computePipePos(cursorPos: Position3D, dir: BuildDirection): Position3D {
+  const pipe = { ...cursorPos };
+  const key: keyof Position3D = dir.tqecAxis === 0 ? "x" : dir.tqecAxis === 1 ? "y" : "z";
+  pipe[key] += dir.sign > 0 ? 1 : -2;
+  return pipe;
+}
+
+/**
+ * Infer the non-Hadamard PipeType to place from a source cube along the given axis.
+ * The pipe's closed-axis characters come from the source cube's type characters.
+ * Returns null if the closed-axis characters are both the same (e.g. "OZZ"),
+ * which is not a valid pipe variant.
+ */
+export function inferPipeType(srcType: CubeType, tqecAxis: 0 | 1 | 2): PipeType | null {
+  const chars = [srcType[0], srcType[1], srcType[2]];
+  chars[tqecAxis] = "O";
+  const result = chars.join("");
+  return (PIPE_TYPES as readonly string[]).includes(result) ? result as PipeType : null;
+}
+
+/**
+ * Determine valid CubeType options for a cube at cubePos given adjacent pipes in blocks.
+ * Each adjacent pipe constrains 2 of the cube's 3 axis characters.
+ * For Hadamard pipes, the swapped end has its two closed-axis chars exchanged.
+ */
+export function determineCubeOptions(
+  cubePos: Position3D,
+  blocks: Map<string, Block>,
+): { determined: true; type: CubeType } | { determined: false; options: CubeType[] } {
+  const constraints: (string | null)[] = [null, null, null];
+  const coords: [number, number, number] = [cubePos.x, cubePos.y, cubePos.z];
+
+  for (let axis = 0; axis < 3; axis++) {
+    for (const pipeOffset of [1, -2]) {
+      const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+      nCoords[axis] += pipeOffset;
+      const neighbor = blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
+
+      if (!neighbor || !isPipeType(neighbor.type)) continue;
+
+      const base = neighbor.type.replace("H", "");
+      const hadamard = neighbor.type.length > 3;
+      const openAxis = base.indexOf("O");
+      if (openAxis !== axis) continue;
+
+      // Cube at pipeOffset +1 from cube = pipe's -1 end; pipeOffset -2 = pipe's +2 end.
+      // Y-open: swapped at -1 end. X/Z-open: swapped at +2 end.
+      const cubeAtPipeEnd = pipeOffset === 1 ? -1 : 2;
+      const swapped = openAxis === 1 ? cubeAtPipeEnd === -1 : cubeAtPipeEnd === 2;
+
+      for (let ca = 0; ca < 3; ca++) {
+        if (ca === openAxis) continue;
+        const required = pipeEndBasis(base, hadamard, openAxis, ca, swapped);
+        if (constraints[ca] === null) {
+          constraints[ca] = required;
+        } else if (constraints[ca] !== required) {
+          return { determined: false, options: [] };
+        }
+      }
+    }
+  }
+
+  const valid = CUBE_TYPES.filter(ct => {
+    for (let i = 0; i < 3; i++) {
+      if (constraints[i] !== null && ct[i] !== constraints[i]) return false;
+    }
+    return true;
+  });
+
+  if (valid.length === 1) return { determined: true, type: valid[0] };
+  return { determined: false, options: [...valid] };
+}
+
+/**
+ * Map a WASD/Arrow key + camera azimuthal angle to a TQEC BuildDirection.
+ * Camera azimuth is snapped to the nearest 90° to align with grid axes.
+ *
+ * OrbitControls azimuthal angle reference:
+ *   0    = camera on +Z (Three.js), looking toward -Z = TQEC +Y
+ *   π/2  = camera on +X, looking toward -X = TQEC -X
+ *   π    = camera on -Z, looking toward +Z = TQEC -Y
+ *  -π/2  = camera on -X, looking toward +X = TQEC +X
+ */
+export function wasdToBuildDirection(
+  key: "w" | "a" | "s" | "d" | "arrowup" | "arrowdown",
+  cameraAzimuth: number,
+): BuildDirection {
+  if (key === "arrowup") return { tqecAxis: 2, sign: 1 };
+  if (key === "arrowdown") return { tqecAxis: 2, sign: -1 };
+
+  // Snap to nearest 90° quadrant: 0, 1, 2, 3
+  const q = ((Math.round(cameraAzimuth / (Math.PI / 2)) % 4) + 4) % 4;
+
+  // [forward, right] pairs in TQEC coordinates per quadrant
+  const cardinals: Array<[BuildDirection, BuildDirection]> = [
+    [{ tqecAxis: 1, sign: 1 },  { tqecAxis: 0, sign: 1 }],   // q=0: fwd +Y, right +X
+    [{ tqecAxis: 0, sign: -1 }, { tqecAxis: 1, sign: 1 }],   // q=1: fwd -X, right +Y
+    [{ tqecAxis: 1, sign: -1 }, { tqecAxis: 0, sign: -1 }],  // q=2: fwd -Y, right -X
+    [{ tqecAxis: 0, sign: 1 },  { tqecAxis: 1, sign: -1 }],  // q=3: fwd +X, right -Y
+  ];
+
+  const [forward, right] = cardinals[q];
+
+  switch (key) {
+    case "w": return forward;
+    case "s": return { tqecAxis: forward.tqecAxis, sign: (forward.sign * -1) as 1 | -1 };
+    case "d": return right;
+    case "a": return { tqecAxis: right.tqecAxis, sign: (right.sign * -1) as 1 | -1 };
+  }
+}
+
+/**
+ * Compute the camera azimuthal angle to "look from behind" a build direction.
+ * Returns null for Z-axis movement (no azimuth change for temporal axis).
+ */
+export function cameraAzimuthForDirection(dir: BuildDirection): number | null {
+  if (dir.tqecAxis === 2) return null;
+  // Camera should be behind the build direction:
+  //   build +Y → camera at +Z → azimuth 0
+  //   build -Y → camera at -Z → azimuth π
+  //   build +X → camera at -X → azimuth -π/2
+  //   build -X → camera at +X → azimuth π/2
+  if (dir.tqecAxis === 1) return dir.sign === 1 ? 0 : Math.PI;
+  return dir.sign === 1 ? -Math.PI / 2 : Math.PI / 2;
+}
+
+// ---------------------------------------------------------------------------
+// Adjacency
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the TQEC position for a new block placed adjacent to an existing block's face.
+ *
+ * Three.js face normal → TQEC axis:
+ *   (±1, 0, 0) → TQEC X ± srcSizeX / dstSizeX
+ *   (0, ±1, 0) → TQEC Z ± srcSizeZ / dstSizeZ
+ *   (0, 0, ±1) → TQEC Y ∓ srcSizeY / dstSizeY
+ */
 export function getAdjacentPos(
   srcPos: Position3D,
   srcType: BlockType,


### PR DESCRIPTION
## Summary
- Implements keyboard build mode (#13): WASD for camera-relative XY movement, ArrowUp/Down for Z (temporal), with auto-determined cube types
- Camera follows behind build direction with clamped viewing angle; slight rotation on Z moves to reveal vertical builds
- Supports Hadamard toggle (H), build undo (Q), cube type cycling (R), and click-to-move cursor
- Auto-retypes existing determined cubes when building into them if a compatible type exists
- Two-pass Hadamard validation prevents spatial index corruption on rejected toggles

## Test plan
- [ ] Enter build mode, press WASD to build in each direction — cubes and pipes placed correctly
- [ ] Press W repeatedly — chain extends without ghost block accumulation
- [ ] Press H after first step — Hadamard toggles and neighbor cubes retype
- [ ] Press Q to undo — each step reverts cleanly
- [ ] Press R on undetermined cursor — cycles through valid cube types
- [ ] ArrowUp/Down builds vertically with camera rotation
- [ ] Build into existing cubes — auto-retypes if needed, blocks if impossible
- [ ] Switch between build/place/delete/select modes — state transitions clean
- [ ] All 120 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)