### PR TITLE
Add ghost cubes at open pipe endpoints

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -20,6 +20,7 @@ import { ValidationToast } from "./components/ValidationToast";
 import { InvalidBlockHighlights } from "./components/InvalidBlockHighlights";
 import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
+import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
 import { useBlockStore } from "./stores/blockStore";
 import { wasdToBuildDirection, tqecToThree } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
@@ -387,6 +388,7 @@ export default function App() {
         <InvalidBlockHighlights />
         <SelectionHighlights />
         <BuildCursor />
+        <OpenPipeGhosts />
         <CameraBuildSnap controlsRef={controlsRef} />
         <GridPlane />
         <GhostBlock />

--- a/piper_draw/gui/src/components/OpenPipeGhosts.tsx
+++ b/piper_draw/gui/src/components/OpenPipeGhosts.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import * as THREE from "three";
+import { useBlockStore } from "../stores/blockStore";
+import { tqecToThree, posKey, isPipeType } from "../types";
+import type { Position3D, Block } from "../types";
+
+const ghostMaterial = new THREE.MeshBasicMaterial({
+  color: 0xffffff,
+  transparent: true,
+  opacity: 0.35,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+});
+
+const ghostLineMaterial = new THREE.LineBasicMaterial({
+  color: 0x999999,
+  linewidth: 1,
+});
+
+const defaultBox = new THREE.BoxGeometry(1, 1, 1);
+const defaultEdges = new THREE.EdgesGeometry(defaultBox);
+
+const noRaycast = () => {};
+
+/**
+ * Find positions at open pipe endpoints where no cube exists.
+ * Returns an array of TQEC positions where ghost cubes should appear.
+ */
+function getOpenPipeEndpoints(blocks: Map<string, Block>): Position3D[] {
+  const endpoints: Position3D[] = [];
+  const seen = new Set<string>();
+
+  for (const block of blocks.values()) {
+    if (!isPipeType(block.type)) continue;
+
+    const base = block.type.replace("H", "");
+    const openAxis = base.indexOf("O"); // 0, 1, or 2
+    const coords: [number, number, number] = [block.pos.x, block.pos.y, block.pos.z];
+
+    for (const offset of [-1, 2]) {
+      const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+      nCoords[openAxis] += offset;
+      const pos: Position3D = { x: nCoords[0], y: nCoords[1], z: nCoords[2] };
+      const key = posKey(pos);
+
+      // Only add if there's no real block there and we haven't already added it
+      if (!blocks.has(key) && !seen.has(key)) {
+        seen.add(key);
+        endpoints.push(pos);
+      }
+    }
+  }
+
+  return endpoints;
+}
+
+/**
+ * Renders white semi-transparent ghost cubes at open pipe endpoints.
+ * These are visualization-only — not interactive, not exported.
+ */
+export function OpenPipeGhosts() {
+  const blocks = useBlockStore((s) => s.blocks);
+
+  const positions = useMemo(() => {
+    const endpoints = getOpenPipeEndpoints(blocks);
+    return endpoints.map((pos) => ({
+      key: posKey(pos),
+      threePos: tqecToThree(pos, "XZZ") as [number, number, number],
+    }));
+  }, [blocks]);
+
+  if (positions.length === 0) return null;
+
+  return (
+    <>
+      {positions.map(({ key, threePos }) => (
+        <group key={key} position={threePos}>
+          <mesh
+            geometry={defaultBox}
+            material={ghostMaterial}
+            raycast={noRaycast}
+          />
+          <lineSegments
+            geometry={defaultEdges}
+            material={ghostLineMaterial}
+            raycast={noRaycast}
+          />
+        </group>
+      ))}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds white semi-transparent ghost cubes at unconnected pipe endpoints to make open pipes visually obvious
- Ghost cubes are non-interactive (`raycast` disabled) so place-mode hover works through them
- Excluded from DAE export since they are not real blocks — just derived reactively from block state
- Automatically appear after DAE import with no extra logic needed

## Test plan
- [ ] Place a pipe with one or both ends open — ghost cubes should appear at the open ends
- [ ] Place a cube at a ghost cube position — ghost disappears, place-mode hover/preview works normally
- [ ] Enter build mode — ghost cubes still visible alongside build cursor
- [ ] Export to DAE — ghost cubes should not appear in the exported file
- [ ] Import a DAE file with open pipes — ghost cubes should appear after import

🤖 Generated with [Claude Code](https://claude.com/claude-code)