### PR TITLE
Fix keyboard build mode and place mode improvements

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -186,9 +186,11 @@ function SelectModeHints() {
  */
 function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> }) {
   const cameraSnapTarget = useBlockStore((s) => s.cameraSnapTarget);
+  const lastBuildAxis = useBlockStore((s) => s.lastBuildAxis);
   const clearCameraSnap = useBlockStore((s) => s.clearCameraSnap);
   const { camera } = useThree();
   const prevTarget = useRef<{ azimuth: number | null; targetPos: { x: number; y: number; z: number } } | null>(null);
+  const prevBuildAxis = useRef<number | null>(null);
 
   useFrame(() => {
     if (!cameraSnapTarget || !controlsRef.current) return;
@@ -198,31 +200,35 @@ function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> })
     const controls = controlsRef.current;
     const [tx, ty, tz] = tqecToThree(cameraSnapTarget.targetPos, "XZZ");
 
-    if (cameraSnapTarget.azimuth !== null) {
-      // Compute distance BEFORE moving target so it stays constant
-      const currentDistance = camera.position.distanceTo(controls.target);
-      const dist = Math.max(currentDistance, 15);
-      // Update orbit target to follow cursor
-      controls.target.set(tx, ty, tz);
-      // Clamp polar angle to at most ~55° from horizontal (1.2 rad from vertical)
-      // so the camera looks slightly down rather than from above
-      const polar = Math.min(controls.getPolarAngle(), 1.2);
-      const az = cameraSnapTarget.azimuth;
+    // Check if axis changed compared to previous build move
+    const axisChanged = prevBuildAxis.current !== lastBuildAxis;
+    prevBuildAxis.current = lastBuildAxis;
 
-      camera.position.set(
-        tx + dist * Math.sin(polar) * Math.sin(az),
-        ty + dist * Math.cos(polar),
-        tz + dist * Math.sin(polar) * Math.cos(az),
-      );
+    if (cameraSnapTarget.azimuth !== null) {
+      if (axisChanged) {
+        // First move into this axis — reposition camera behind build direction with slight offset
+        const currentDistance = camera.position.distanceTo(controls.target);
+        const dist = Math.max(currentDistance, 15);
+        controls.target.set(tx, ty, tz);
+        const polar = Math.min(controls.getPolarAngle(), 1.2);
+        const az = cameraSnapTarget.azimuth + 0.12;
+
+        camera.position.set(
+          tx + dist * Math.sin(polar) * Math.sin(az),
+          ty + dist * Math.cos(polar),
+          tz + dist * Math.sin(polar) * Math.cos(az),
+        );
+      } else {
+        // Same axis — translate camera to follow cursor, keep current viewing angle
+        const offset = new THREE.Vector3().subVectors(camera.position, controls.target);
+        controls.target.set(tx, ty, tz);
+        camera.position.set(tx + offset.x, ty + offset.y, tz + offset.z);
+      }
     } else {
-      // Z movement — translate camera + slight rotation to reveal vertical build
+      // Z movement — translate camera, preserve current viewing angle
       const offset = new THREE.Vector3().subVectors(camera.position, controls.target);
-      const nudge = 0.08; // ~5° rotation around Y axis
-      const cos = Math.cos(nudge), sin = Math.sin(nudge);
-      const rx = offset.x * cos - offset.z * sin;
-      const rz = offset.x * sin + offset.z * cos;
       controls.target.set(tx, ty, tz);
-      camera.position.set(tx + rx, ty + offset.y, tz + rz);
+      camera.position.set(tx + offset.x, ty + offset.y, tz + offset.z);
     }
 
     controls.update();
@@ -365,7 +371,7 @@ export default function App() {
       <SelectModeHints />
       <PlacementWarning />
       <Canvas
-        camera={{ position: [10, 10, -10], fov: 35 }}
+        camera={{ position: [14, 14, -14], fov: 35 }}
         gl={{ logarithmicDepthBuffer: true, toneMapping: THREE.ACESFilmicToneMapping }}
         onContextMenu={(e) => e.preventDefault()}
       >

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -210,7 +210,11 @@ function TypedInstances({
 
       const adj = getAdjacentPos(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, dstType);
 
-      if (!isValidPos(adj, dstType) || hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex)) {
+      if (!isValidPos(adj, dstType)) {
+        store.setHoveredGridPos(null);
+        return;
+      }
+      if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex)) {
         store.setHoveredGridPos(adj, dstType, true);
       } else if (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
         store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube");

--- a/piper_draw/gui/src/components/BuildCursor.tsx
+++ b/piper_draw/gui/src/components/BuildCursor.tsx
@@ -42,8 +42,8 @@ function CursorBox({ position, isCursor }: { position: [number, number, number];
 
   useFrame(({ clock }) => {
     if (!isCursor || !groupRef.current) return;
-    // Subtle pulsing scale for cursor (1.0 to 1.06)
-    const pulse = 1.0 + 0.03 * Math.sin(clock.getElapsedTime() * 4);
+    // Pulsing scale for cursor (1.03 to 1.09) — never smaller than the block
+    const pulse = 1.06 + 0.03 * Math.sin(clock.getElapsedTime() * 4);
     groupRef.current.scale.setScalar(pulse);
   });
 

--- a/piper_draw/gui/src/components/PreviewRenderer.tsx
+++ b/piper_draw/gui/src/components/PreviewRenderer.tsx
@@ -62,10 +62,11 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
 
     // Pre-build meshes
     for (const { key, blockType } of PREVIEW_TYPES) {
-      const geo = createBlockGeometry(blockType, 0);
+      const previewBandHH = blockType.toString().endsWith("H") ? 0.16 : undefined;
+      const geo = createBlockGeometry(blockType, 0, previewBandHH);
       const mesh = new THREE.Mesh(geo, vertexColorMaterial);
 
-      const edgeGeo = createBlockEdges(blockType, 0);
+      const edgeGeo = createBlockEdges(blockType, 0, previewBandHH);
       const edges = new THREE.LineSegments(edgeGeo, edgeMaterial);
 
       const [sx, sy, sz] = blockThreeSize(blockType);

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useBlockStore } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
-import { CUBE_TYPES, PIPE_VARIANTS } from "../types";
-import type { BlockType } from "../types";
+import { CUBE_TYPES, PIPE_VARIANTS, isPipeType, pipeAxisFromPos } from "../types";
+import type { BlockType, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
 import * as THREE from "three";
@@ -75,6 +75,9 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
     return count;
   });
   const deleteSelected = useBlockStore((s) => s.deleteSelected);
+
+  const buildCursor = useBlockStore((s) => s.buildCursor);
+  const hoveredGridPos = useBlockStore((s) => s.hoveredGridPos);
 
   const previewImages = usePreviewImages(controlsRef);
 
@@ -270,6 +273,32 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
             </button>
           ))}
         </div>
+      </div>
+
+      {/* Position display */}
+      <div style={{ width: 1, background: "#ddd" }} />
+      <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", fontFamily: "monospace", fontSize: "12px", color: "#555", lineHeight: "1.6", minWidth: 90 }}>
+        <span style={groupLabelStyle}>Position</span>
+        {(() => {
+          const pos: Position3D | null = mode === "build" ? buildCursor : hoveredGridPos;
+          const bt: BlockType | null = mode === "build" ? null : useBlockStore.getState().hoveredBlockType;
+          if (!pos) return <><span>X: —</span><span>Y: —</span><span>Z: —</span></>;
+          const isPipe = bt ? isPipeType(bt) : pipeAxisFromPos(pos) !== null;
+          if (isPipe) {
+            const axis = pipeAxisFromPos(pos);
+            const coords = [pos.x, pos.y, pos.z];
+            const labels = ["X", "Y", "Z"];
+            return labels.map((l, i) => {
+              if (i === axis) {
+                const c1 = (coords[i] - 1) / 3;
+                const c2 = (coords[i] + 2) / 3;
+                return <span key={i}>{l}: {c1} → {c2}</span>;
+              }
+              return <span key={i}>{l}: {coords[i] / 3}</span>;
+            });
+          }
+          return <><span>X: {pos.x / 3}</span><span>Y: {pos.y / 3}</span><span>Z: {pos.z / 3}</span></>;
+        })()}
       </div>
     </div>
   );

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -20,6 +20,7 @@ import {
   computeDestCubePos,
   computePipePos,
   inferPipeType,
+  swapPipeVariant,
   determineCubeOptions,
   cameraAzimuthForDirection,
   CUBE_TYPES,
@@ -1123,7 +1124,26 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
     const oldPipeType = pipeBlock.type as PipeType;
     const isHadamard = oldPipeType.length > 3;
-    const newPipeType = (isHadamard ? oldPipeType.slice(0, 3) : oldPipeType + "H") as PipeType;
+
+    // When building in a negative direction, the source cube is at the pipe's
+    // +2 end (swapped end for Hadamard). We need to swap the pipe variant so
+    // that the swapped end's constraints match the source cube.
+    const oldBase = oldPipeType.replace("H", "");
+    const oldOpenAxis = oldBase.indexOf("O");
+    const srcAtSwappedEnd =
+      [lastStep.prevCursorPos.x, lastStep.prevCursorPos.y, lastStep.prevCursorPos.z][oldOpenAxis] ===
+      [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z][oldOpenAxis] + 2;
+
+    let newPipeType: PipeType;
+    if (isHadamard) {
+      // Removing Hadamard — if variant was swapped when toggling on, swap back
+      const reverted = srcAtSwappedEnd ? swapPipeVariant(oldBase) : oldBase;
+      newPipeType = reverted as PipeType;
+    } else {
+      // Adding Hadamard — swap variant if source is at the +2 (swapped) end
+      const swapped = srcAtSwappedEnd ? swapPipeVariant(oldBase) : oldBase;
+      newPipeType = (swapped + "H") as PipeType;
+    }
 
     if (!(PIPE_TYPES as readonly string[]).includes(newPipeType)) return;
 

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -50,12 +50,16 @@ export type BuildStep = {
   cube: { key: string; block: Block } | null;
   /** Origin cube placed on empty canvas (first step only). */
   originCube?: { key: string; block: Block };
-  /** If the source cube was auto-determined during this step. */
+  /** If the source cube was auto-determined during this step (was undetermined). */
   sourceDetermination?: {
     key: string;
     prevType: CubeType;
     prevUndeterminedInfo: UndeterminedCubeInfo;
   };
+  /** If a determined source cube was retyped to accommodate a new pipe direction. */
+  sourceRetype?: { key: string; prevType: CubeType };
+  /** If the origin cube is undetermined after this step (first step only). */
+  originUndetermined?: UndeterminedCubeInfo;
   /** If the destination cube is undetermined after this step. */
   destUndetermined?: UndeterminedCubeInfo;
   /** If an existing destination cube was re-typed to accommodate the new pipe. */
@@ -66,8 +70,8 @@ type UndoCommand =
   | { kind: "add"; key: string; block: Block }
   | { kind: "remove"; key: string; block: Block }
   | { kind: "bulk-remove"; entries: Array<{ key: string; block: Block }> }
-  | { kind: "clear"; savedBlocks: Map<string, Block>; savedHiddenFaces: Map<string, FaceMask> }
-  | { kind: "load"; savedBlocks: Map<string, Block>; savedHiddenFaces: Map<string, FaceMask>;
+  | { kind: "clear"; savedBlocks: Map<string, Block>; savedHiddenFaces: Map<string, FaceMask>; savedUndetermined: Map<string, UndeterminedCubeInfo> }
+  | { kind: "load"; savedBlocks: Map<string, Block>; savedHiddenFaces: Map<string, FaceMask>; savedUndetermined: Map<string, UndeterminedCubeInfo>;
       newBlocks: Map<string, Block>; newIndex: SpatialIndex; newHiddenFaces: Map<string, FaceMask> }
   | { kind: "build-step"; step: BuildStep }
   | { kind: "hadamard-toggle"; pipeKey: string; oldType: PipeType; newType: PipeType;
@@ -97,6 +101,8 @@ interface BlockStore {
   undeterminedCubes: Map<string, UndeterminedCubeInfo>;
   /** Camera snap target set by build actions, consumed by CameraBuildSnap component. */
   cameraSnapTarget: { azimuth: number | null; targetPos: Position3D } | null;
+  /** Tracks the tqecAxis of the last build move (0/1/2) so camera only rotates on axis changes. */
+  lastBuildAxis: number | null;
 
   setMode: (mode: Mode) => void;
   setCubeType: (cubeType: BlockType) => void;
@@ -183,18 +189,19 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   buildHistory: [],
   undeterminedCubes: new Map(),
   cameraSnapTarget: null,
+  lastBuildAxis: null,
 
   setMode: (mode) => {
     const prev = get();
 
-    // Leaving build mode: commit undetermined cubes to their current type
+    // Leaving build mode: keep undetermined cubes as-is (only committed when building away)
     if (prev.mode === "build" && mode !== "build") {
       set({
         mode,
         buildCursor: null,
         buildHistory: [],
-        undeterminedCubes: new Map(),
         cameraSnapTarget: null,
+        lastBuildAxis: null,
         hoveredGridPos: null,
         hoveredBlockType: null,
         hoveredInvalid: false,
@@ -225,7 +232,6 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         mode,
         buildCursor: cursorPos,
         buildHistory: [],
-        undeterminedCubes: new Map(),
         cameraSnapTarget: null,
         hoveredGridPos: null,
         hoveredBlockType: null,
@@ -245,8 +251,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       ...(mode === "place" ? { selectedKeys: new Set<string>() } : {}),
     });
   },
-  setCubeType: (cubeType) => set({ cubeType, pipeVariant: null }),
-  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant] }),
+  setCubeType: (cubeType) => set({ cubeType, pipeVariant: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null }),
+  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null }),
   setHoveredGridPos: (pos, blockType, invalid, reason) => set((state) => {
     const bt = blockType ?? null;
     const inv = invalid ?? false;
@@ -303,6 +309,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
       const { blocks, hiddenFaces } = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, block);
       const cmd: UndoCommand = { kind: "remove", key, block };
+      const newUndetermined = new Map(state.undeterminedCubes);
+      newUndetermined.delete(key);
 
       return {
         blocks,
@@ -310,6 +318,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
         hoveredGridPos: null,
+        undeterminedCubes: newUndetermined,
       };
     }),
 
@@ -365,6 +374,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           history: newHistory,
           future: [cmd, ...state.future].slice(0, MAX_HISTORY),
           hoveredGridPos: null,
+          undeterminedCubes: cmd.savedUndetermined,
         };
       }
 
@@ -399,6 +409,14 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const reverted: Block = { pos: step.prevCursorPos, type: sd.prevType };
           ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, sd.key, reverted));
           newUndetermined.set(sd.key, { ...sd.prevUndeterminedInfo, options: [...sd.prevUndeterminedInfo.options] });
+        }
+        // Revert source retype
+        if (step.sourceRetype) {
+          const sr = step.sourceRetype;
+          const curSrc = blocks.get(sr.key);
+          if (curSrc) ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, sr.key, curSrc));
+          const reverted: Block = { pos: step.prevCursorPos, type: sr.prevType };
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, sr.key, reverted));
         }
         // Remove origin cube
         if (step.originCube) {
@@ -481,6 +499,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         history: newHistory,
         future: [cmd, ...state.future].slice(0, MAX_HISTORY),
         hoveredGridPos: null,
+        undeterminedCubes: cmd.savedUndetermined,
       };
     }),
 
@@ -536,6 +555,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           history: [...state.history, cmd],
           future: newFuture,
           hoveredGridPos: null,
+          undeterminedCubes: new Map(),
         };
       }
 
@@ -553,11 +573,23 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const sd = step.sourceDetermination;
           const curSrc = blocks.get(sd.key);
           if (curSrc) ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, sd.key, curSrc));
-          // Re-determine using constraints from adjacent pipes (pipe not yet re-placed)
           const newSrcOptions = determineCubeOptions(step.prevCursorPos, blocks);
           const srcType = newSrcOptions.determined ? newSrcOptions.type : (newSrcOptions.options[0] ?? sd.prevType);
           ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, sd.key, { pos: step.prevCursorPos, type: srcType }));
           newUndetermined.delete(sd.key);
+        }
+        // Re-retype source
+        if (step.sourceRetype) {
+          const sr = step.sourceRetype;
+          const curSrc = blocks.get(sr.key);
+          if (curSrc) {
+            ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, sr.key, curSrc));
+            const newSrcOptions = determineCubeOptions(step.prevCursorPos, blocks);
+            const candidates = newSrcOptions.determined ? [newSrcOptions.type] : newSrcOptions.options;
+            const validForPipe = candidates.filter(ct => step.pipe && inferPipeType(ct, step.pipe.block.type.replace("H", "").indexOf("O") as 0 | 1 | 2) !== null);
+            const srcType = validForPipe.length > 0 ? validForPipe[0] : sr.prevType;
+            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, sr.key, { pos: step.prevCursorPos, type: srcType }));
+          }
         }
         // Re-place pipe
         if (step.pipe) {
@@ -646,6 +678,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         kind: "clear",
         savedBlocks: state.blocks,
         savedHiddenFaces: state.hiddenFaces,
+        savedUndetermined: state.undeterminedCubes,
       };
       return {
         blocks: new Map(),
@@ -654,6 +687,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         history: [...state.history, savedCmd],
         future: newFuture,
         hoveredGridPos: null,
+        undeterminedCubes: new Map(),
       };
     }),
 
@@ -670,6 +704,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         kind: "load",
         savedBlocks: state.blocks,
         savedHiddenFaces: state.hiddenFaces,
+        savedUndetermined: state.undeterminedCubes,
         newBlocks: incoming,
         newIndex,
         newHiddenFaces: newHidden,
@@ -681,6 +716,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
         hoveredGridPos: null,
+        undeterminedCubes: new Map(),
       };
     }),
 
@@ -691,6 +727,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         kind: "clear",
         savedBlocks: state.blocks,
         savedHiddenFaces: state.hiddenFaces,
+        savedUndetermined: state.undeterminedCubes,
       };
       return {
         blocks: new Map(),
@@ -700,6 +737,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         future: [],
         hoveredGridPos: null,
         selectedKeys: new Set<string>(),
+        undeterminedCubes: new Map(),
       };
     }),
 
@@ -738,6 +776,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       }
       if (entries.length === 0) return state;
       const cmd: UndoCommand = { kind: "bulk-remove", entries };
+      const newUndetermined = new Map(state.undeterminedCubes);
+      for (const { key } of entries) newUndetermined.delete(key);
       return {
         blocks,
         hiddenFaces,
@@ -745,6 +785,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         future: [],
         selectedKeys: new Set<string>(),
         hoveredGridPos: null,
+        undeterminedCubes: newUndetermined,
       };
     }),
 
@@ -778,6 +819,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         set({
           buildCursor: destPos,
           cameraSnapTarget: { azimuth, targetPos: destPos },
+          lastBuildAxis: direction.tqecAxis,
         });
         return true;
       }
@@ -791,6 +833,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     // Determine source cube type
     let srcType: CubeType;
     let sourceDetermination: BuildStep["sourceDetermination"];
+    let sourceRetype: BuildStep["sourceRetype"];
 
     if (isEmptyOrigin) {
       // First step on empty canvas — pick a valid cube type for this build axis
@@ -813,7 +856,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       // Prefer current type if it's valid for this direction
       const currentType = srcBlock!.type as CubeType;
       srcType = validForDir.includes(currentType) ? currentType : validForDir[0];
-      // Always determine source — commit to chosen type
+      // Always commit undetermined source
       sourceDetermination = {
         key: srcKey,
         prevType: currentType,
@@ -821,6 +864,18 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       };
     } else {
       srcType = srcBlock!.type as CubeType;
+
+      // If current type can't pipe in this direction, try retyping via open axis
+      if (!inferPipeType(srcType, direction.tqecAxis)) {
+        const options = determineCubeOptions(cursor, state.blocks);
+        const candidates = options.determined ? [options.type] : options.options;
+        const validForDir = candidates.filter(ct => inferPipeType(ct, direction.tqecAxis) !== null);
+        if (validForDir.length === 0) return false;
+        const pipeSet = new Set(validForDir.map(ct => inferPipeType(ct, direction.tqecAxis)));
+        if (pipeSet.size > 1) return false; // Ambiguous — user must cycle (R)
+        sourceRetype = { key: srcKey, prevType: srcType };
+        srcType = validForDir[0];
+      }
     }
 
     // Infer pipe type from source
@@ -886,9 +941,28 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         newUndetermined.delete(srcKey);
       }
 
+      // Apply source retype (determined cube retyped for new pipe direction)
+      if (sourceRetype) {
+        const oldSrc = blocks.get(srcKey)!;
+        ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, srcKey, oldSrc));
+        const newSrc: Block = { pos: cursor, type: srcType };
+        ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, srcKey, newSrc));
+      }
+
       // Place pipe
       const pipeBlock: Block = { pos: pipePos, type: pipeType };
       ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pipeKey, pipeBlock));
+
+      // Check if origin cube should be undetermined (placed before the pipe was known)
+      let originUndetermined: UndeterminedCubeInfo | undefined;
+      if (isEmptyOrigin) {
+        const originOptions = determineCubeOptions(cursor, blocks);
+        if (!originOptions.determined && originOptions.options.length > 1) {
+          const idx = Math.max(0, originOptions.options.indexOf(srcType));
+          originUndetermined = { options: [...originOptions.options], currentIndex: idx };
+          newUndetermined.set(srcKey, originUndetermined);
+        }
+      }
 
       // Apply dest type change if existing cube needs re-typing
       if (destTypeChange) {
@@ -927,6 +1001,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         cube: cubeAdded,
         originCube: originCubeEntry,
         sourceDetermination,
+        sourceRetype,
+        originUndetermined,
         destUndetermined,
         destTypeChange,
       };
@@ -940,6 +1016,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         buildHistory: [...s.buildHistory, step],
         undeterminedCubes: newUndetermined,
         cameraSnapTarget: { azimuth, targetPos: destPos },
+        lastBuildAxis: direction.tqecAxis,
         history: [...s.history, { kind: "build-step" as const, step }].slice(-MAX_HISTORY),
         future: [],
       };
@@ -992,6 +1069,17 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         newUndetermined.set(sd.key, { ...sd.prevUndeterminedInfo, options: [...sd.prevUndeterminedInfo.options] });
       }
 
+      // Revert source retype (determined cube back to previous type)
+      if (step.sourceRetype) {
+        const sr = step.sourceRetype;
+        const curSrc = blocks.get(sr.key);
+        if (curSrc) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, sr.key, curSrc));
+          const reverted: Block = { pos: step.prevCursorPos, type: sr.prevType };
+          ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, sr.key, reverted));
+        }
+      }
+
       // Remove origin cube if this was first step
       if (step.originCube) {
         ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, step.originCube.key, step.originCube.block));
@@ -1009,6 +1097,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           buildHistory: newBuildHistory,
           undeterminedCubes: newUndetermined,
           cameraSnapTarget: { azimuth: null, targetPos: step.prevCursorPos },
+          lastBuildAxis: null,
           history: newHistory,
           future: [cmd, ...s.future].slice(0, MAX_HISTORY),
           hoveredGridPos: null,
@@ -1022,6 +1111,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         buildHistory: newBuildHistory,
         undeterminedCubes: newUndetermined,
         cameraSnapTarget: { azimuth: null, targetPos: step.prevCursorPos },
+        lastBuildAxis: null,
         hoveredGridPos: null,
       };
     });
@@ -1258,7 +1348,12 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       const key = posKey(pos);
       const block = state.blocks.get(key);
       if (!block || isPipeType(block.type)) return state;
-      return { buildCursor: pos };
+      return {
+        buildCursor: pos,
+        buildHistory: [],
+        lastBuildAxis: null,
+        cameraSnapTarget: { azimuth: null, targetPos: pos },
+      };
     }),
 
   clearCameraSnap: () => set({ cameraSnapTarget: null }),

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -930,6 +930,18 @@ export function computePipePos(cursorPos: Position3D, dir: BuildDirection): Posi
 }
 
 /**
+ * Swap the two closed-axis characters of a pipe base type.
+ * E.g. "OXZ" → "OZX", "ZOX" → "XOZ", "XZO" → "ZXO".
+ */
+export function swapPipeVariant(pipeBase: string): string {
+  const openAxis = pipeBase.indexOf("O");
+  const chars = pipeBase.split("");
+  const closedAxes = [0, 1, 2].filter(a => a !== openAxis);
+  [chars[closedAxes[0]], chars[closedAxes[1]]] = [chars[closedAxes[1]], chars[closedAxes[0]]];
+  return chars.join("");
+}
+
+/**
  * Infer the non-Hadamard PipeType to place from a source cube along the given axis.
  * The pipe's closed-axis characters come from the source cube's type characters.
  * Returns null if the closed-axis characters are both the same (e.g. "OZZ"),
@@ -968,9 +980,9 @@ export function determineCubeOptions(
       if (openAxis !== axis) continue;
 
       // Cube at pipeOffset +1 from cube = pipe's -1 end; pipeOffset -2 = pipe's +2 end.
-      // Y-open: swapped at -1 end. X/Z-open: swapped at +2 end.
+      // Hadamard pipes swap their closed-axis colors at the +2 (tail) end.
       const cubeAtPipeEnd = pipeOffset === 1 ? -1 : 2;
-      const swapped = openAxis === 1 ? cubeAtPipeEnd === -1 : cubeAtPipeEnd === 2;
+      const swapped = cubeAtPipeEnd === 2;
 
       for (let ca = 0; ca < 3; ca++) {
         if (ca === openAxis) continue;

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -251,6 +251,7 @@ function createPipeGeometry(
   wallColors: [THREE.Color, THREE.Color],
   hadamard: boolean,
   hiddenFaces: FaceMask = 0,
+  hBandHalfHeight?: number,
 ): THREE.BufferGeometry {
   const closedAxes = [0, 1, 2].filter(a => a !== openAxis) as [number, number];
 
@@ -303,7 +304,7 @@ function createPipeGeometry(
 
   const halfExt: [number, number, number] = [0.5, 0.5, 0.5];
   for (const ca of closedAxes) halfExt[ca] -= WALL_EPS;
-  const bh = H_BAND_HALF_HEIGHT;
+  const bh = hBandHalfHeight ?? H_BAND_HALF_HEIGHT;
   // Above the band, the two closed-axis colors swap per TQEC convention
   const wallColorsAbove: [THREE.Color, THREE.Color] = [wallColors[1], wallColors[0]];
 
@@ -384,7 +385,7 @@ function createPipeGeometry(
  * Pipe types are parsed from the type name: each character gives the basis
  * for that TQEC axis ('X', 'Z', or 'O' for open). Hadamard variants end in 'H'.
  */
-export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask = 0): THREE.BufferGeometry {
+export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
   if (isPipeType(blockType)) {
     const base = blockType.replace("H", "");
     const hadamard = blockType.length > 3;
@@ -398,7 +399,7 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
     if (hadamard && tqecOpenAxis === 1) {
       wallColors = [wallColors[1], wallColors[0]];
     }
-    return createPipeGeometry(threeOpenAxis, wallColors, hadamard, hiddenFaces);
+    return createPipeGeometry(threeOpenAxis, wallColors, hadamard, hiddenFaces, hBandHalfHeight);
   }
 
   if (blockType === "Y") {
@@ -459,7 +460,7 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
 }
 
 /** Edge line segments for a block type, including Hadamard band edges for H pipes. */
-export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0): THREE.BufferGeometry {
+export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
   const [bx, by, bz] = blockThreeSize(blockType);
   const pipe = isPipeType(blockType);
   const e2 = pipe ? 2 * WALL_EPS : 0;
@@ -515,7 +516,8 @@ export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0
     const halfExts = [hx, hy, hz];
     const bandEdges: number[] = [];
 
-    for (const bp of [H_BAND_HALF_HEIGHT, -H_BAND_HALF_HEIGHT]) {
+    const bandHH = hBandHalfHeight ?? H_BAND_HALF_HEIGHT;
+    for (const bp of [bandHH, -bandHH]) {
       const faceBit = FACE_BIT_BY_INDEX[threeOpen * 2 + (bp > 0 ? 0 : 1)];
       if (hiddenFaces & faceBit) continue;
 


### PR DESCRIPTION
## Summary
- **Source cube retyping**: Determined cubes can now be automatically retyped via their open axis when building in a new direction, fixing the inability to turn from the middle of a pipe snake
- **Origin cube undetermined**: First cube placed on empty canvas is now correctly marked undetermined when multiple types are valid, allowing building in any direction
- **Camera improvements**: Only snaps azimuth on axis change (preserves slight rotation on subsequent moves), translates to follow cursor on click-to-move
- **Ghost snapping fix**: Ghost block no longer appears at invalid grid positions when hovering pipe side faces in place mode
- **Undetermined state persistence**: Undetermined cubes preserved across mode changes and properly tracked through undo/redo of clear/load operations

## Test plan
- [ ] Build a straight pipe snake in +X, click middle cube, verify you can build in +Y
- [ ] Verify cubes along a snake show as determined (colored, not white ghost)
- [ ] Build in +X then +Z (vertical), verify camera keeps slight rotation offset
- [ ] Switch between place/select/build modes, verify undetermined cubes stay as ghosts
- [ ] Hover pipe side faces in place mode, verify no ghost at invalid positions
- [ ] Undo/redo build steps with source retype, verify correct state restoration
- [ ] Click to move cursor in build mode, verify camera follows and building works

🤖 Generated with [Claude Code](https://claude.com/claude-code)