### PR TITLE
Fix ghost blocks visible in all modes

### DIFF
--- a/piper_draw/gui/src/components/BuildCursor.tsx
+++ b/piper_draw/gui/src/components/BuildCursor.tsx
@@ -2,7 +2,7 @@ import { useRef, useMemo } from "react";
 import * as THREE from "three";
 import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { tqecToThree, posKey } from "../types";
+import { tqecToThree } from "../types";
 
 const cursorMaterial = new THREE.MeshBasicMaterial({
   color: 0xcccccc,
@@ -17,32 +17,18 @@ const cursorLineMaterial = new THREE.LineBasicMaterial({
   linewidth: 2,
 });
 
-const undeterminedMaterial = new THREE.MeshBasicMaterial({
-  color: 0xbbbbbb,
-  transparent: true,
-  opacity: 0.3,
-  depthWrite: false,
-  side: THREE.DoubleSide,
-});
-
-const undeterminedLineMaterial = new THREE.LineBasicMaterial({
-  color: 0x555555,
-  linewidth: 1,
-});
-
-// Default cube geometry for cursor/undetermined cubes (1x1x1 in Three.js)
+// Default cube geometry for cursor (1x1x1 in Three.js)
 const defaultBox = new THREE.BoxGeometry(1, 1, 1);
 const defaultEdges = new THREE.EdgesGeometry(defaultBox);
 
 const noRaycast = () => {};
 
 /** Pulsing cursor at the build position */
-function CursorBox({ position, isCursor }: { position: [number, number, number]; isCursor: boolean }) {
+function CursorBox({ position }: { position: [number, number, number] }) {
   const groupRef = useRef<THREE.Group>(null!);
 
   useFrame(({ clock }) => {
-    if (!isCursor || !groupRef.current) return;
-    // Pulsing scale for cursor (1.03 to 1.09) — never smaller than the block
+    if (!groupRef.current) return;
     const pulse = 1.06 + 0.03 * Math.sin(clock.getElapsedTime() * 4);
     groupRef.current.scale.setScalar(pulse);
   });
@@ -51,12 +37,12 @@ function CursorBox({ position, isCursor }: { position: [number, number, number];
     <group ref={groupRef} position={position}>
       <mesh
         geometry={defaultBox}
-        material={isCursor ? cursorMaterial : undeterminedMaterial}
+        material={cursorMaterial}
         raycast={noRaycast}
       />
       <lineSegments
         geometry={defaultEdges}
-        material={isCursor ? cursorLineMaterial : undeterminedLineMaterial}
+        material={cursorLineMaterial}
         raycast={noRaycast}
       />
     </group>
@@ -66,39 +52,14 @@ function CursorBox({ position, isCursor }: { position: [number, number, number];
 export function BuildCursor() {
   const mode = useBlockStore((s) => s.mode);
   const buildCursor = useBlockStore((s) => s.buildCursor);
-  const undeterminedCubes = useBlockStore((s) => s.undeterminedCubes);
-  const blocks = useBlockStore((s) => s.blocks);
 
-  const positions = useMemo(() => {
-    if (!buildCursor) return { cursor: null, undetermined: [] };
+  const cursorThree = useMemo(() => {
+    if (!buildCursor) return null;
+    return tqecToThree(buildCursor, "XZZ") as [number, number, number];
+  }, [buildCursor]);
 
-    const cursorKey = posKey(buildCursor);
-    // Cursor position in Three.js coords (use default cube size)
-    const cursorThree = tqecToThree(buildCursor, "XZZ") as [number, number, number];
+  if (mode !== "build" || !cursorThree) return null;
 
-    // Collect undetermined cube positions (excluding cursor if it's also undetermined)
-    const undetermined: Array<{ key: string; pos: [number, number, number] }> = [];
-    for (const [key] of undeterminedCubes) {
-      if (key === cursorKey) continue;
-      const block = blocks.get(key);
-      if (!block) continue;
-      undetermined.push({
-        key,
-        pos: tqecToThree(block.pos, block.type) as [number, number, number],
-      });
-    }
-
-    return { cursor: cursorThree, undetermined };
-  }, [buildCursor, undeterminedCubes, blocks]);
-
-  if (mode !== "build" || !positions.cursor) return null;
-
-  return (
-    <>
-      <CursorBox position={positions.cursor} isCursor={true} />
-      {positions.undetermined.map(({ key, pos }) => (
-        <CursorBox key={key} position={pos} isCursor={false} />
-      ))}
-    </>
-  );
+  // Only renders the pulsing cursor; undetermined cubes are rendered by OpenPipeGhosts
+  return <CursorBox position={cursorThree} />;
 }

--- a/piper_draw/gui/src/components/OpenPipeGhosts.tsx
+++ b/piper_draw/gui/src/components/OpenPipeGhosts.tsx
@@ -5,7 +5,7 @@ import { tqecToThree, posKey, isPipeType } from "../types";
 import type { Position3D, Block } from "../types";
 
 const ghostMaterial = new THREE.MeshBasicMaterial({
-  color: 0xffffff,
+  color: 0xdddddd,
   transparent: true,
   opacity: 0.35,
   depthWrite: false,
@@ -13,7 +13,7 @@ const ghostMaterial = new THREE.MeshBasicMaterial({
 });
 
 const ghostLineMaterial = new THREE.LineBasicMaterial({
-  color: 0x999999,
+  color: 0x000000,
   linewidth: 1,
 });
 
@@ -55,19 +55,46 @@ function getOpenPipeEndpoints(blocks: Map<string, Block>): Position3D[] {
 }
 
 /**
- * Renders white semi-transparent ghost cubes at open pipe endpoints.
- * These are visualization-only — not interactive, not exported.
+ * Renders white semi-transparent ghost cubes at open pipe endpoints
+ * and at undetermined cube positions. These are visualization-only —
+ * not interactive, not exported.
  */
 export function OpenPipeGhosts() {
   const blocks = useBlockStore((s) => s.blocks);
+  const undeterminedCubes = useBlockStore((s) => s.undeterminedCubes);
+  const mode = useBlockStore((s) => s.mode);
+  const buildCursor = useBlockStore((s) => s.buildCursor);
 
   const positions = useMemo(() => {
-    const endpoints = getOpenPipeEndpoints(blocks);
-    return endpoints.map((pos) => ({
-      key: posKey(pos),
-      threePos: tqecToThree(pos, "XZZ") as [number, number, number],
-    }));
-  }, [blocks]);
+    const result: Array<{ key: string; threePos: [number, number, number] }> = [];
+    const seen = new Set<string>();
+
+    // Ghost cubes at open pipe endpoints (positions with no block)
+    for (const pos of getOpenPipeEndpoints(blocks)) {
+      const key = posKey(pos);
+      seen.add(key);
+      result.push({
+        key,
+        threePos: tqecToThree(pos, "XZZ") as [number, number, number],
+      });
+    }
+
+    // Ghost cubes at undetermined cube positions (always visible).
+    // In build mode, skip the cursor position — BuildCursor renders it with a pulse.
+    const cursorKey = buildCursor ? posKey(buildCursor) : null;
+    for (const [key] of undeterminedCubes) {
+      if (seen.has(key)) continue;
+      if (mode === "build" && key === cursorKey) continue;
+      const block = blocks.get(key);
+      if (!block) continue;
+      result.push({
+        key,
+        threePos: tqecToThree(block.pos, block.type) as [number, number, number],
+      });
+    }
+
+    return result;
+  }, [blocks, undeterminedCubes, mode, buildCursor]);
 
   if (positions.length === 0) return null;
 


### PR DESCRIPTION
## Summary
- Moved undetermined cube ghost rendering from `BuildCursor` into `OpenPipeGhosts` so ghost blocks appear in all modes (place, select, delete, build), not just build mode
- Simplified `BuildCursor` to only render the pulsing cursor
- Made ghost block fill slightly grey (`0xdddddd`) and edges black for better visibility

## Test plan
- [ ] Enter build mode, build a chain with WASD — undetermined cubes show ghost blocks
- [ ] Switch to select/place/delete mode — ghost blocks remain visible
- [ ] Re-enter build mode — cursor still pulses, ghost blocks don't duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)