### PR TITLE
Add customizable key bindings for build mode

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -21,7 +21,10 @@ import { InvalidBlockHighlights } from "./components/InvalidBlockHighlights";
 import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
+import { BuildModeHints } from "./components/BuildModeHints";
+import { KeybindEditor } from "./components/KeybindEditor";
 import { useBlockStore } from "./stores/blockStore";
+import { useKeybindStore, buildActionForKey, actionToWasdKey } from "./stores/keybindStore";
 import { wasdToBuildDirection, tqecToThree } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 
@@ -281,6 +284,7 @@ export default function App() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const controlsRef = useRef<any>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
+  const [keybindEditorOpen, setKeybindEditorOpen] = useState(false);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -290,35 +294,38 @@ export default function App() {
 
       // Build mode keys (no modifier)
       if (!ctrl && store.mode === "build") {
-        if (["w", "a", "s", "d"].includes(key) || key === "arrowup" || key === "arrowdown") {
+        const bindings = useKeybindStore.getState().bindings;
+        const action = buildActionForKey(bindings, key);
+        if (action) {
           e.preventDefault();
-          const controls = controlsRef.current;
-          if (!controls) return;
-          const azimuth = controls.getAzimuthalAngle();
-          const dirKey = key as "w" | "a" | "s" | "d" | "arrowup" | "arrowdown";
-          const direction = wasdToBuildDirection(dirKey, azimuth);
-          store.buildMove(direction);
-          return;
-        }
-        if (key === "q") {
-          e.preventDefault();
-          store.undoBuildStep();
-          return;
-        }
-        if (key === "r") {
-          e.preventDefault();
-          store.cycleCubeType();
-          return;
-        }
-        if (key === "h") {
-          e.preventDefault();
-          store.toggleHadamard();
-          return;
-        }
-        if (key === "escape") {
-          e.preventDefault();
-          store.setMode("place");
-          return;
+          switch (action) {
+            case "moveForward":
+            case "moveBack":
+            case "moveLeft":
+            case "moveRight":
+            case "moveUp":
+            case "moveDown": {
+              const controls = controlsRef.current;
+              if (!controls) return;
+              const azimuth = controls.getAzimuthalAngle();
+              const dirKey = actionToWasdKey(action);
+              const direction = wasdToBuildDirection(dirKey, azimuth);
+              store.buildMove(direction);
+              return;
+            }
+            case "undo":
+              store.undoBuildStep();
+              return;
+            case "cycleCubeType":
+              store.cycleCubeType();
+              return;
+            case "toggleHadamard":
+              store.toggleHadamard();
+              return;
+            case "exitBuild":
+              store.setMode("place");
+              return;
+          }
         }
       }
 
@@ -381,6 +388,8 @@ export default function App() {
         <FpsDisplay spanRef={fpsRef} />
       </div>
       <SelectModeHints />
+      <BuildModeHints onCustomize={() => setKeybindEditorOpen(true)} />
+      {keybindEditorOpen && <KeybindEditor onClose={() => setKeybindEditorOpen(false)} />}
       <PlacementWarning toolbarRef={toolbarRef} />
       <Canvas
         camera={{ position: [14, 14, -14], fov: 35 }}

--- a/piper_draw/gui/src/components/BuildModeHints.tsx
+++ b/piper_draw/gui/src/components/BuildModeHints.tsx
@@ -1,0 +1,74 @@
+import { useBlockStore } from "../stores/blockStore";
+import { useKeybindStore } from "../stores/keybindStore";
+
+export function BuildModeHints({ onCustomize }: { onCustomize: () => void }) {
+  const mode = useBlockStore((s) => s.mode);
+  const bindings = useKeybindStore((s) => s.bindings);
+  if (mode !== "build") return null;
+
+  const hints = [
+    [
+      `${bindings.moveForward.displayLabel}/${bindings.moveLeft.displayLabel}/${bindings.moveBack.displayLabel}/${bindings.moveRight.displayLabel}`,
+      "Move XY",
+    ],
+    [`${bindings.moveUp.displayLabel}/${bindings.moveDown.displayLabel}`, "Move Z"],
+    [bindings.undo.displayLabel, "Undo step"],
+    [bindings.cycleCubeType.displayLabel, "Cycle type"],
+    [bindings.toggleHadamard.displayLabel, "Hadamard"],
+    [bindings.exitBuild.displayLabel, "Exit build"],
+  ];
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 60,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1,
+        display: "flex",
+        gap: "6px",
+        alignItems: "center",
+        background: "rgba(0,0,0,0.7)",
+        color: "#fff",
+        padding: "6px 14px",
+        borderRadius: "8px",
+        fontSize: "12px",
+        fontFamily: "sans-serif",
+        pointerEvents: "none",
+        boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {hints.map(([key, action], i) => (
+        <span key={key} style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+          {i > 0 && <span style={{ color: "rgba(255,255,255,0.3)" }}>|</span>}
+          <kbd
+            style={{
+              background: "rgba(255,255,255,0.15)",
+              padding: "1px 5px",
+              borderRadius: "3px",
+              fontSize: "11px",
+            }}
+          >
+            {key}
+          </kbd>
+          <span style={{ color: "rgba(255,255,255,0.7)" }}>{action}</span>
+        </span>
+      ))}
+      <span style={{ color: "rgba(255,255,255,0.3)" }}>|</span>
+      <span
+        onClick={onCustomize}
+        style={{
+          color: "rgba(255,255,255,0.5)",
+          cursor: "pointer",
+          pointerEvents: "auto",
+          textDecoration: "underline",
+          fontSize: "11px",
+        }}
+      >
+        Customize
+      </span>
+    </div>
+  );
+}

--- a/piper_draw/gui/src/components/KeybindEditor.tsx
+++ b/piper_draw/gui/src/components/KeybindEditor.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from "react";
+import type { BuildAction } from "../stores/keybindStore";
+import {
+  BUILD_ACTIONS,
+  ACTION_LABELS,
+  useKeybindStore,
+  isDefaultBindings,
+  keyToDisplayLabel,
+} from "../stores/keybindStore";
+
+export function KeybindEditor({ onClose }: { onClose: () => void }) {
+  const bindings = useKeybindStore((s) => s.bindings);
+  const setBinding = useKeybindStore((s) => s.setBinding);
+  const resetToDefaults = useKeybindStore((s) => s.resetToDefaults);
+  const [listening, setListening] = useState<BuildAction | null>(null);
+
+  // Capture key when in listening mode
+  useEffect(() => {
+    if (!listening) return;
+    const handler = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      const key = e.key.toLowerCase();
+      // Ignore modifier-only presses
+      if (["control", "shift", "alt", "meta"].includes(key)) return;
+      setBinding(listening, key);
+      setListening(null);
+    };
+    window.addEventListener("keydown", handler, true); // capture phase
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [listening, setBinding]);
+
+  // Close on Escape when not listening
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !listening) {
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handler, true);
+    return () => window.removeEventListener("keydown", handler, true);
+  }, [listening, onClose]);
+
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) onClose();
+    },
+    [onClose],
+  );
+
+  const showReset = !isDefaultBindings(bindings);
+
+  return (
+    <div
+      onClick={handleBackdropClick}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 100,
+        background: "rgba(0,0,0,0.4)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <div
+        style={{
+          background: "#fff",
+          borderRadius: "12px",
+          padding: "20px 24px",
+          minWidth: 320,
+          maxWidth: 400,
+          boxShadow: "0 8px 32px rgba(0,0,0,0.2)",
+        }}
+      >
+        {/* Header */}
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16 }}>
+          <h3 style={{ margin: 0, fontSize: 15, fontWeight: 600 }}>Build Mode Key Bindings</h3>
+          <button
+            onClick={onClose}
+            style={{
+              background: "none",
+              border: "none",
+              fontSize: 18,
+              cursor: "pointer",
+              color: "#666",
+              padding: "0 4px",
+            }}
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Binding rows */}
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          {BUILD_ACTIONS.map((action) => {
+            const binding = bindings[action];
+            const isListeningThis = listening === action;
+            return (
+              <div
+                key={action}
+                style={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  alignItems: "center",
+                  padding: "6px 8px",
+                  borderRadius: 6,
+                  background: isListeningThis ? "#e8f0fe" : "#f8f8f8",
+                }}
+              >
+                <span style={{ fontSize: 13, color: "#333" }}>{ACTION_LABELS[action]}</span>
+                <button
+                  onClick={() => setListening(isListeningThis ? null : action)}
+                  style={{
+                    minWidth: 60,
+                    padding: "4px 10px",
+                    border: isListeningThis ? "2px solid #4285f4" : "1px solid #ccc",
+                    borderRadius: 4,
+                    background: isListeningThis ? "#fff" : "#fff",
+                    cursor: "pointer",
+                    fontSize: 13,
+                    fontFamily: "monospace",
+                    color: isListeningThis ? "#4285f4" : "#333",
+                    textAlign: "center",
+                  }}
+                >
+                  {isListeningThis ? "Press a key…" : keyToDisplayLabel(binding.key)}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Footer */}
+        {showReset && (
+          <div style={{ marginTop: 14, textAlign: "right" }}>
+            <button
+              onClick={resetToDefaults}
+              style={{
+                background: "none",
+                border: "1px solid #ccc",
+                borderRadius: 6,
+                padding: "5px 12px",
+                fontSize: 12,
+                cursor: "pointer",
+                color: "#555",
+              }}
+            >
+              Reset to defaults
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/piper_draw/gui/src/stores/keybindStore.ts
+++ b/piper_draw/gui/src/stores/keybindStore.ts
@@ -1,0 +1,142 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type BuildAction =
+  | "moveForward"
+  | "moveBack"
+  | "moveLeft"
+  | "moveRight"
+  | "moveUp"
+  | "moveDown"
+  | "undo"
+  | "cycleCubeType"
+  | "toggleHadamard"
+  | "exitBuild";
+
+export type KeyBinding = {
+  key: string; // e.key.toLowerCase() value
+  displayLabel: string; // Human-readable label for tooltips
+};
+
+export const BUILD_ACTIONS: BuildAction[] = [
+  "moveForward",
+  "moveBack",
+  "moveLeft",
+  "moveRight",
+  "moveUp",
+  "moveDown",
+  "undo",
+  "cycleCubeType",
+  "toggleHadamard",
+  "exitBuild",
+];
+
+export const ACTION_LABELS: Record<BuildAction, string> = {
+  moveForward: "Move forward",
+  moveBack: "Move back",
+  moveLeft: "Move left",
+  moveRight: "Move right",
+  moveUp: "Move up",
+  moveDown: "Move down",
+  undo: "Undo step",
+  cycleCubeType: "Cycle type",
+  toggleHadamard: "Hadamard",
+  exitBuild: "Exit build",
+};
+
+export function keyToDisplayLabel(key: string): string {
+  switch (key) {
+    case "arrowup": return "↑";
+    case "arrowdown": return "↓";
+    case "arrowleft": return "←";
+    case "arrowright": return "→";
+    case "escape": return "Esc";
+    case " ": return "Space";
+    case "enter": return "Enter";
+    case "backspace": return "Backspace";
+    case "delete": return "Delete";
+    case "tab": return "Tab";
+    default: return key.length === 1 ? key.toUpperCase() : key;
+  }
+}
+
+export const DEFAULT_BINDINGS: Record<BuildAction, KeyBinding> = {
+  moveForward: { key: "w", displayLabel: "W" },
+  moveBack: { key: "s", displayLabel: "S" },
+  moveLeft: { key: "a", displayLabel: "A" },
+  moveRight: { key: "d", displayLabel: "D" },
+  moveUp: { key: "arrowup", displayLabel: "↑" },
+  moveDown: { key: "arrowdown", displayLabel: "↓" },
+  undo: { key: "q", displayLabel: "Q" },
+  cycleCubeType: { key: "r", displayLabel: "R" },
+  toggleHadamard: { key: "h", displayLabel: "H" },
+  exitBuild: { key: "escape", displayLabel: "Esc" },
+};
+
+/** Reverse lookup: key string → BuildAction (or null if unbound) */
+export function buildActionForKey(
+  bindings: Record<BuildAction, KeyBinding>,
+  key: string,
+): BuildAction | null {
+  for (const action of BUILD_ACTIONS) {
+    if (bindings[action].key === key) return action;
+  }
+  return null;
+}
+
+/** Maps a movement action back to canonical WASD key for wasdToBuildDirection() */
+export function actionToWasdKey(
+  action: BuildAction,
+): "w" | "a" | "s" | "d" | "arrowup" | "arrowdown" {
+  switch (action) {
+    case "moveForward": return "w";
+    case "moveBack": return "s";
+    case "moveLeft": return "a";
+    case "moveRight": return "d";
+    case "moveUp": return "arrowup";
+    case "moveDown": return "arrowdown";
+    default: throw new Error(`Not a movement action: ${action}`);
+  }
+}
+
+interface KeybindState {
+  bindings: Record<BuildAction, KeyBinding>;
+  setBinding: (action: BuildAction, key: string) => void;
+  resetToDefaults: () => void;
+}
+
+export const useKeybindStore = create<KeybindState>()(
+  persist(
+    (set) => ({
+      bindings: { ...DEFAULT_BINDINGS },
+
+      setBinding: (action, key) =>
+        set((state) => {
+          const displayLabel = keyToDisplayLabel(key);
+          const newBindings = { ...state.bindings };
+
+          // If another action uses this key, swap it
+          const conflicting = buildActionForKey(newBindings, key);
+          if (conflicting && conflicting !== action) {
+            newBindings[conflicting] = { ...newBindings[action] };
+          }
+
+          newBindings[action] = { key, displayLabel };
+          return { bindings: newBindings };
+        }),
+
+      resetToDefaults: () => set({ bindings: { ...DEFAULT_BINDINGS } }),
+    }),
+    {
+      name: "piper-draw-keybinds",
+      version: 1,
+    },
+  ),
+);
+
+export function isDefaultBindings(bindings: Record<BuildAction, KeyBinding>): boolean {
+  for (const action of BUILD_ACTIONS) {
+    if (bindings[action].key !== DEFAULT_BINDINGS[action].key) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- Adds a keybind store (`keybindStore.ts`) with localStorage persistence so users can remap all build-mode keyboard shortcuts (WASD, arrows, Q, R, H, Esc)
- Adds build-mode tooltip hints at the bottom of the screen, matching the existing select-mode hint style
- Adds a modal key binding editor (opened via "Customize" link in the hints bar) with click-to-rebind, conflict swapping, and a "Reset to defaults" button
- Refactors the hard-coded key handler in `App.tsx` to use the configurable bindings from the store

## Test plan
- [ ] Enter build mode and verify tooltip hints appear at bottom center
- [ ] Click "Customize" to open the editor, rebind a key, and verify it works
- [ ] Refresh the page and confirm custom bindings persist
- [ ] Change a binding, verify "Reset to defaults" appears, click it and confirm revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)