### PR TITLE
Allow replacing blocks in place mode

### DIFF
--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -243,8 +243,8 @@ function TypedInstances({
       if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex, existingKey)) {
         store.setHoveredGridPos(adj, dstType, true, undefined, adjReplace);
       } else if (existingKey && store.blocks.get(existingKey)!.type === dstType) {
-        // Same type — no replacement needed, show as invalid
-        store.setHoveredGridPos(adj, dstType, true, undefined, true);
+        // Same type — no replacement needed, hide ghost
+        store.setHoveredGridPos(null);
       } else if (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
         store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube", adjReplace);
       } else if (!isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks)) {

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -237,20 +237,22 @@ function TypedInstances({
         store.setHoveredGridPos(null);
         return;
       }
-      const existingKey = store.blocks.has(posKey(adj)) ? posKey(adj) : undefined;
+      const adjKey = posKey(adj);
+      const existingKey = store.blocks.has(adjKey) ? adjKey : undefined;
+      const adjReplace = !!(existingKey && store.blocks.get(existingKey)!.type !== dstType);
       if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex, existingKey)) {
-        store.setHoveredGridPos(adj, dstType, true);
+        store.setHoveredGridPos(adj, dstType, true, undefined, adjReplace);
       } else if (existingKey && store.blocks.get(existingKey)!.type === dstType) {
         // Same type — no replacement needed, show as invalid
-        store.setHoveredGridPos(adj, dstType, true);
+        store.setHoveredGridPos(adj, dstType, true, undefined, true);
       } else if (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube");
+        store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube", adjReplace);
       } else if (!isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Cube colors don't match the adjacent pipe");
+        store.setHoveredGridPos(adj, dstType, true, "Cube colors don't match the adjacent pipe", adjReplace);
       } else if (hasYCubePipeAxisConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Y cube cannot be next to an X-open or Y-open pipe");
+        store.setHoveredGridPos(adj, dstType, true, "Y cube cannot be next to an X-open or Y-open pipe", adjReplace);
       } else {
-        store.setHoveredGridPos(adj, dstType);
+        store.setHoveredGridPos(adj, dstType, false, undefined, adjReplace);
       }
     }
   };

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -195,12 +195,35 @@ function TypedInstances({
       // Read the actual block type from the instance, not the group prop
       store.setHoveredGridPos(b[e.instanceId].pos, b[e.instanceId].type);
     } else {
+      // Place mode: check if we can replace the hovered block itself
+      const hovered = b[e.instanceId];
+      let replaceType: BlockType = store.cubeType;
+      if (store.pipeVariant) {
+        const resolved = resolvePipeType(store.pipeVariant, hovered.pos);
+        if (resolved) replaceType = resolved;
+      }
+      if (isValidPos(hovered.pos, replaceType) && replaceType !== hovered.type) {
+        const hovKey = posKey(hovered.pos);
+        if (hasBlockOverlap(hovered.pos, replaceType, store.blocks, store.spatialIndex, hovKey)) {
+          store.setHoveredGridPos(hovered.pos, replaceType, true, undefined, true);
+        } else if (isPipeType(replaceType) && hasPipeColorConflict(replaceType, hovered.pos, store.blocks)) {
+          store.setHoveredGridPos(hovered.pos, replaceType, true, "Pipe colors don't match the adjacent cube", true);
+        } else if (!isPipeType(replaceType) && replaceType !== "Y" && hasCubeColorConflict(replaceType as CubeType, hovered.pos, store.blocks)) {
+          store.setHoveredGridPos(hovered.pos, replaceType, true, "Cube colors don't match the adjacent pipe", true);
+        } else if (hasYCubePipeAxisConflict(replaceType, hovered.pos, store.blocks)) {
+          store.setHoveredGridPos(hovered.pos, replaceType, true, "Y cube cannot be next to an X-open or Y-open pipe", true);
+        } else {
+          store.setHoveredGridPos(hovered.pos, replaceType, false, undefined, true);
+        }
+        return;
+      }
+
       if (!e.face) return;
 
-      // Determine the destination block type
+      // Determine the destination block type for adjacent placement
       let dstType: BlockType = store.cubeType;
       if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, store.pipeVariant);
+        const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, e.face.normal, store.pipeVariant);
         if (!resolved) {
           store.setHoveredGridPos(null);
           return;
@@ -208,13 +231,17 @@ function TypedInstances({
         dstType = resolved;
       }
 
-      const adj = getAdjacentPos(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, dstType);
+      const adj = getAdjacentPos(hovered.pos, hovered.type, e.face.normal, dstType);
 
       if (!isValidPos(adj, dstType)) {
         store.setHoveredGridPos(null);
         return;
       }
-      if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex)) {
+      const existingKey = store.blocks.has(posKey(adj)) ? posKey(adj) : undefined;
+      if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex, existingKey)) {
+        store.setHoveredGridPos(adj, dstType, true);
+      } else if (existingKey && store.blocks.get(existingKey)!.type === dstType) {
+        // Same type — no replacement needed, show as invalid
         store.setHoveredGridPos(adj, dstType, true);
       } else if (isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
         store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube");
@@ -249,16 +276,29 @@ function TypedInstances({
     if (store.mode === "delete") {
       store.removeBlock(b[e.instanceId].pos);
     } else {
+      // Place mode: try replacing the clicked block if the selected type
+      // is valid at the clicked block's position
+      const clicked = b[e.instanceId];
+      let replaceType: BlockType = store.cubeType;
+      if (store.pipeVariant) {
+        const resolved = resolvePipeType(store.pipeVariant, clicked.pos);
+        if (resolved) replaceType = resolved;
+      }
+      if (isValidPos(clicked.pos, replaceType) && replaceType !== clicked.type) {
+        store.addBlock(clicked.pos);
+        return;
+      }
+
       if (!e.face) return;
 
       let dstType: BlockType = store.cubeType;
       if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, store.pipeVariant);
+        const resolved = resolvePipeTypeFromFace(clicked.pos, clicked.type, e.face.normal, store.pipeVariant);
         if (!resolved) return;
         dstType = resolved;
       }
 
-      const adj = getAdjacentPos(b[e.instanceId].pos, b[e.instanceId].type, e.face.normal, dstType);
+      const adj = getAdjacentPos(clicked.pos, clicked.type, e.face.normal, dstType);
       store.addBlock(adj);
     }
   };

--- a/piper_draw/gui/src/components/GhostBlock.tsx
+++ b/piper_draw/gui/src/components/GhostBlock.tsx
@@ -39,6 +39,19 @@ const invalidLineMaterial = new THREE.LineBasicMaterial({
   opacity: 0.4,
   depthWrite: false,
 });
+const replaceMaterial = new THREE.MeshLambertMaterial({
+  vertexColors: true,
+  transparent: true,
+  opacity: 0.85,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+});
+const replaceLineMaterial = new THREE.LineBasicMaterial({
+  color: "#000000",
+  transparent: true,
+  opacity: 0.85,
+  depthWrite: false,
+});
 
 /**
  * Inner component — only mounts when hoveredGridPos is non-null.
@@ -50,6 +63,7 @@ function GhostBlockInner() {
   const cubeType = useBlockStore((s) => s.cubeType);
   const hoveredBlockType = useBlockStore((s) => s.hoveredBlockType);
   const hoveredInvalid = useBlockStore((s) => s.hoveredInvalid);
+  const hoveredReplace = useBlockStore((s) => s.hoveredReplace);
   const blocks = useBlockStore((s) => s.blocks);
   const spatialIndex = useBlockStore((s) => s.spatialIndex);
 
@@ -62,6 +76,16 @@ function GhostBlockInner() {
   const [x, y, z] = tqecToThree(hoveredGridPos, activeType);
   const isDelete = mode === "delete";
   const isInvalid = !isDelete && hoveredInvalid;
+  const isReplace = !isDelete && hoveredReplace;
+
+  let meshMat = isInvalid ? invalidMaterial : ghostMaterial;
+  let lineMat = isInvalid ? invalidLineMaterial : validLineMaterial;
+  let scale = isInvalid ? 1.005 : 1;
+  if (isReplace && !isInvalid) {
+    meshMat = replaceMaterial;
+    lineMat = replaceLineMaterial;
+    scale = 1.01;
+  }
 
   return (
     <group position={[x, y, z]}>
@@ -71,14 +95,14 @@ function GhostBlockInner() {
           <primitive object={deleteMaterial} attach="material" />
         </mesh>
       ) : (
-        <group scale={isInvalid ? 1.005 : 1}>
+        <group scale={scale}>
           <mesh>
             <primitive object={ghostGeometry} attach="geometry" />
-            <primitive object={isInvalid ? invalidMaterial : ghostMaterial} attach="material" />
+            <primitive object={meshMat} attach="material" />
           </mesh>
           <lineSegments>
             <primitive object={ghostEdges} attach="geometry" />
-            <primitive object={isInvalid ? invalidLineMaterial : validLineMaterial} attach="material" />
+            <primitive object={lineMat} attach="material" />
           </lineSegments>
         </group>
       )}

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -3,7 +3,7 @@ import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
 import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { snapGroundPos, hasBlockOverlap, hasCubeColorConflict, hasPipeColorConflict, hasYCubePipeAxisConflict, isValidPos, isPipeType, resolvePipeType } from "../types";
+import { snapGroundPos, hasBlockOverlap, hasCubeColorConflict, hasPipeColorConflict, hasYCubePipeAxisConflict, isValidPos, isPipeType, resolvePipeType, posKey } from "../types";
 import type { CubeType } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
 
@@ -42,16 +42,21 @@ export function GridPlane() {
       blockType = resolved;
     }
 
-    if (!isValidPos(pos, blockType) || hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex)) {
-      setHoveredGridPos(pos, blockType, true);
+    const existing = store.blocks.get(posKey(pos));
+    const existingKey = existing ? posKey(pos) : undefined;
+    const isReplace = !!(existing && existing.type !== blockType);
+    if (!isValidPos(pos, blockType) || hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex, existingKey)) {
+      setHoveredGridPos(pos, blockType, true, undefined, isReplace);
+    } else if (existing && existing.type === blockType) {
+      setHoveredGridPos(pos, blockType, true, undefined, true);
     } else if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) {
-      setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube");
+      setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube", isReplace);
     } else if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
-      setHoveredGridPos(pos, blockType, true, "Cube colors don't match the adjacent pipe");
+      setHoveredGridPos(pos, blockType, true, "Cube colors don't match the adjacent pipe", isReplace);
     } else if (hasYCubePipeAxisConflict(blockType, pos, store.blocks)) {
-      setHoveredGridPos(pos, blockType, true, "Y cube cannot be next to an X-open or Y-open pipe");
+      setHoveredGridPos(pos, blockType, true, "Y cube cannot be next to an X-open or Y-open pipe", isReplace);
     } else {
-      setHoveredGridPos(pos, blockType);
+      setHoveredGridPos(pos, blockType, false, undefined, isReplace);
     }
   };
 

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -48,7 +48,7 @@ export function GridPlane() {
     if (!isValidPos(pos, blockType) || hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex, existingKey)) {
       setHoveredGridPos(pos, blockType, true, undefined, isReplace);
     } else if (existing && existing.type === blockType) {
-      setHoveredGridPos(pos, blockType, true, undefined, true);
+      setHoveredGridPos(null);
     } else if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube", isReplace);
     } else if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {

--- a/piper_draw/gui/src/stores/blockStore.test.ts
+++ b/piper_draw/gui/src/stores/blockStore.test.ts
@@ -34,10 +34,38 @@ describe("blockStore", () => {
       expect(useBlockStore.getState().blocks.size).toBe(0);
     });
 
-    it("rejects placement that overlaps an existing block", () => {
+    it("skips placement of the same block type at an occupied position", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       expect(useBlockStore.getState().blocks.size).toBe(1);
+      expect(useBlockStore.getState().history.length).toBe(1);
+    });
+
+    it("replaces an existing block with a different valid type", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
+      useBlockStore.setState({ cubeType: "ZXZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.size).toBe(1);
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXZ");
+    });
+
+    it("undo after replace restores the original block", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ cubeType: "ZXZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXZ");
+      useBlockStore.getState().undo();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
+    });
+
+    it("redo after undone replace re-applies the replacement", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ cubeType: "ZXZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().undo();
+      useBlockStore.getState().redo();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXZ");
     });
 
     it("resolves pipe variant to correct PipeType based on position", () => {

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -259,8 +259,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       ...(mode === "place" ? { selectedKeys: new Set<string>() } : {}),
     });
   },
-  setCubeType: (cubeType) => set({ cubeType, pipeVariant: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null }),
-  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null }),
+  setCubeType: (cubeType) => set({ cubeType, pipeVariant: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),
+  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),
   setHoveredGridPos: (pos, blockType, invalid, reason, replace) => set((state) => {
     const bt = blockType ?? null;
     const inv = invalid ?? false;
@@ -309,11 +309,14 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, existing);
         const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, key, block);
         const cmd: UndoCommand = { kind: "replace", key, oldBlock: existing, newBlock: block };
+        const newUndetermined = new Map(state.undeterminedCubes);
+        newUndetermined.delete(key);
         return {
           blocks,
           hiddenFaces,
           history: [...state.history, cmd].slice(-MAX_HISTORY),
           future: [],
+          undeterminedCubes: newUndetermined,
         };
       }
 

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -226,6 +226,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           cursorPos = cmd.block.pos;
           break;
         }
+        if (cmd.kind === "replace" && !isPipeType(cmd.newBlock.type) && cmd.newBlock.type !== "Y") {
+          cursorPos = cmd.newBlock.pos;
+          break;
+        }
         if (cmd.kind === "build-step") {
           if (cmd.step.cube) { cursorPos = cmd.step.cube.block.pos; break; }
           if (cmd.step.originCube) { cursorPos = cmd.step.originCube.block.pos; break; }

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -78,7 +78,8 @@ type UndoCommand =
       retyped?: Array<{ cubeKey: string; oldType: CubeType; newType: CubeType;
         oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo }> }
   | { kind: "cube-cycle"; cubeKey: string; oldType: CubeType; newType: CubeType;
-      oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }> };
+      oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }> }
+  | { kind: "replace"; key: string; oldBlock: Block; newBlock: Block };
 
 interface BlockStore {
   blocks: Map<string, Block>;
@@ -93,6 +94,7 @@ interface BlockStore {
   hoveredBlockType: BlockType | null;
   hoveredInvalid: boolean;
   hoveredInvalidReason: string | null;
+  hoveredReplace: boolean;
   selectedKeys: Set<string>;
 
   // Build mode state
@@ -107,7 +109,7 @@ interface BlockStore {
   setMode: (mode: Mode) => void;
   setCubeType: (cubeType: BlockType) => void;
   setPipeVariant: (variant: PipeVariant) => void;
-  setHoveredGridPos: (pos: Position3D | null, blockType?: BlockType, invalid?: boolean, reason?: string) => void;
+  setHoveredGridPos: (pos: Position3D | null, blockType?: BlockType, invalid?: boolean, reason?: string, replace?: boolean) => void;
   addBlock: (pos: Position3D) => void;
   removeBlock: (pos: Position3D) => void;
   undo: () => void;
@@ -183,6 +185,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   hoveredBlockType: null,
   hoveredInvalid: false,
   hoveredInvalidReason: null,
+  hoveredReplace: false,
   selectedKeys: new Set(),
 
   // Build mode state
@@ -254,10 +257,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   },
   setCubeType: (cubeType) => set({ cubeType, pipeVariant: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null }),
   setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null }),
-  setHoveredGridPos: (pos, blockType, invalid, reason) => set((state) => {
+  setHoveredGridPos: (pos, blockType, invalid, reason, replace) => set((state) => {
     const bt = blockType ?? null;
     const inv = invalid ?? false;
     const rsn = reason ?? null;
+    const rep = replace ?? false;
     // Skip no-op updates to avoid unnecessary re-renders
     if (
       state.hoveredGridPos?.x === pos?.x &&
@@ -265,9 +269,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       state.hoveredGridPos?.z === pos?.z &&
       state.hoveredBlockType === bt &&
       state.hoveredInvalid === inv &&
-      state.hoveredInvalidReason === rsn
+      state.hoveredInvalidReason === rsn &&
+      state.hoveredReplace === rep
     ) return state;
-    return { hoveredGridPos: pos, hoveredBlockType: bt, hoveredInvalid: inv, hoveredInvalidReason: rsn };
+    return { hoveredGridPos: pos, hoveredBlockType: bt, hoveredInvalid: inv, hoveredInvalidReason: rsn, hoveredReplace: rep };
   }),
 
   addBlock: (pos) =>
@@ -282,15 +287,32 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         blockType = resolved;
       }
 
+      const key = posKey(pos);
+      const existing = state.blocks.get(key);
+
       // Validate position parity
       if (!isValidPos(pos, blockType)) return state;
-      if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex)) return state;
+      if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex, existing ? key : undefined)) return state;
       if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
       if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
       if (hasYCubePipeAxisConflict(blockType, pos, state.blocks)) return state;
 
-      const key = posKey(pos);
       const block: Block = { pos, type: blockType };
+
+      if (existing) {
+        // Skip if same type — nothing to replace
+        if (existing.type === blockType) return state;
+        const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, existing);
+        const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, key, block);
+        const cmd: UndoCommand = { kind: "replace", key, oldBlock: existing, newBlock: block };
+        return {
+          blocks,
+          hiddenFaces,
+          history: [...state.history, cmd].slice(-MAX_HISTORY),
+          future: [],
+        };
+      }
+
       const { blocks, hiddenFaces } = doAdd(state.blocks, state.spatialIndex, state.hiddenFaces, key, block);
       const cmd: UndoCommand = { kind: "add", key, block };
 
@@ -491,6 +513,18 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         return { blocks, hiddenFaces, history: newHistory, future: [cmd, ...state.future].slice(0, MAX_HISTORY), undeterminedCubes: newUndetermined, hoveredGridPos: null };
       }
 
+      if (cmd.kind === "replace") {
+        const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, cmd.key, cmd.newBlock);
+        const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, cmd.key, cmd.oldBlock);
+        return {
+          blocks,
+          hiddenFaces,
+          history: newHistory,
+          future: [cmd, ...state.future].slice(0, MAX_HISTORY),
+          hoveredGridPos: null,
+        };
+      }
+
       // cmd.kind === "clear" — restore saved state, rebuild spatial index
       const newIndex = buildSpatialIndex(cmd.savedBlocks);
       return {
@@ -672,6 +706,18 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           if (idx >= 0) newUndetermined.set(cmd.cubeKey, { ...info, currentIndex: idx });
         }
         return { blocks, hiddenFaces, history: [...state.history, cmd], future: newFuture, undeterminedCubes: newUndetermined, hoveredGridPos: null };
+      }
+
+      if (cmd.kind === "replace") {
+        const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, cmd.key, cmd.oldBlock);
+        const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, cmd.key, cmd.newBlock);
+        return {
+          blocks,
+          hiddenFaces,
+          history: [...state.history, cmd],
+          future: newFuture,
+          hoveredGridPos: null,
+        };
       }
 
       // cmd.kind === "clear" — save current state, then clear

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -734,13 +734,15 @@ export function recomputeAffectedHiddenFaces(
 // Overlap detection
 // ---------------------------------------------------------------------------
 
-/** Check if placing a block at pos with the given type overlaps any existing block. */
-export function hasBlockOverlap(pos: Position3D, type: BlockType, blocks: Map<string, Block>, index?: SpatialIndex): boolean {
+/** Check if placing a block at pos with the given type overlaps any existing block.
+ *  When `excludeKey` is provided, the block with that key is skipped (used for replacement). */
+export function hasBlockOverlap(pos: Position3D, type: BlockType, blocks: Map<string, Block>, index?: SpatialIndex, excludeKey?: string): boolean {
   const sz = blockTqecSize(type);
   const candidates = index
     ? getNearbyBlocks(index, pos, sz, 0)
     : Array.from(blocks.values());
   for (const block of candidates) {
+    if (excludeKey !== undefined && posKey(block.pos) === excludeKey) continue;
     const bs = blockTqecSize(block.type);
     if (
       pos.x < block.pos.x + bs[0] && pos.x + sz[0] > block.pos.x &&


### PR DESCRIPTION
## Summary
- Clicking on an existing block in place mode now replaces it with the selected type (if valid at that position)
- Adds `excludeKey` to `hasBlockOverlap` so the existing block is excluded from overlap checks during replacement
- Replacement has full undo/redo support via a new `"replace"` undo command
- Ghost block preview uses higher opacity (0.85) and slight scale-up (1.01) when replacing, so the new block is clearly visible on top of the existing one
- Consistent replacement visuals whether the mouse is directly on the block or on the adjacent grid plane

## Test plan
- [x] Unit tests: replacement, same-type skip, undo, redo
- [x] Manual: place a cube, select a different cube type, hover over it — ghost should show clearly on top
- [x] Manual: click to replace — block type changes
- [x] Manual: undo/redo after replacement
- [x] Manual: hover slightly off the block onto the grid — same visual treatment

🤖 Generated with [Claude Code](https://claude.com/claude-code)