### PR TITLE
Fix Y half-cube placement and pipe snapping

### DIFF
--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -4,6 +4,7 @@ import type { ThreeEvent } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
 import {
   tqecToThree,
+  yBlockZOffset,
   createBlockGeometry,
   createBlockEdges,
   blockThreeSize,
@@ -80,10 +81,12 @@ function TypedInstances({
   cubeType,
   blocks,
   hiddenFaces,
+  allBlocks,
 }: {
   cubeType: BlockType;
   blocks: Block[];
   hiddenFaces: FaceMask;
+  allBlocks: Map<string, Block>;
 }) {
   const meshRef = useRef<THREE.InstancedMesh>(null!);
   const blocksRef = useRef(blocks);
@@ -115,12 +118,15 @@ function TypedInstances({
   const templatePositions = edgeTemplate.getAttribute("position").array as Float32Array;
   const vertCount = templatePositions.length / 3;
 
+  const isY = cubeType === "Y";
+
   const batchedEdgesGeo = useMemo(() => {
     if (blocks.length === 0) return null;
     const totalVerts = blocks.length * vertCount;
     const positions = new Float32Array(totalVerts * 3);
     for (let i = 0; i < blocks.length; i++) {
-      const [tx, ty, tz] = tqecToThree(blocks[i].pos, cubeType);
+      const zo = isY ? yBlockZOffset(blocks[i].pos, allBlocks) : 0;
+      const [tx, ty, tz] = tqecToThree(blocks[i].pos, cubeType, zo);
       const offset = i * vertCount * 3;
       for (let v = 0; v < vertCount; v++) {
         const vi = v * 3;
@@ -132,7 +138,7 @@ function TypedInstances({
     const geo = new THREE.BufferGeometry();
     geo.setAttribute("position", new THREE.BufferAttribute(positions, 3));
     return geo;
-  }, [blocks, cubeType, templatePositions, vertCount]);
+  }, [blocks, cubeType, templatePositions, vertCount, isY, allBlocks]);
 
   // Dispose old batched edge geometry
   useEffect(() => {
@@ -158,7 +164,8 @@ function TypedInstances({
     let minX = Infinity, minY = Infinity, minZ = Infinity;
     let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
     for (let i = 0; i < blocks.length; i++) {
-      const [tx, ty, tz] = tqecToThree(blocks[i].pos, cubeType);
+      const zo = isY ? yBlockZOffset(blocks[i].pos, allBlocks) : 0;
+      const [tx, ty, tz] = tqecToThree(blocks[i].pos, cubeType, zo);
       dummy.makeTranslation(tx, ty, tz);
       mesh.setMatrixAt(i, dummy);
       if (tx < minX) minX = tx; if (tx > maxX) maxX = tx;
@@ -322,6 +329,7 @@ export function BlockInstances() {
           cubeType={group.type}
           hiddenFaces={group.hiddenFaces}
           blocks={group.blocks}
+          allBlocks={blocks}
         />
       ))}
     </>

--- a/piper_draw/gui/src/components/GhostBlock.tsx
+++ b/piper_draw/gui/src/components/GhostBlock.tsx
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
-import { tqecToThree, getHiddenFaceMaskForPos } from "../types";
+import { tqecToThree, yBlockZOffset, getHiddenFaceMaskForPos } from "../types";
 import { getCachedGeometry, getCachedEdges, getCachedFullBox } from "./BlockInstances";
 
 const noRaycast = () => {};
@@ -59,7 +59,8 @@ function GhostBlockInner() {
   const ghostGeometry = getCachedGeometry(activeType, previewHiddenFaces);
   const ghostEdges = getCachedEdges(activeType, previewHiddenFaces);
 
-  const [x, y, z] = tqecToThree(hoveredGridPos, activeType);
+  const zo = activeType === "Y" ? yBlockZOffset(hoveredGridPos, blocks) : 0;
+  const [x, y, z] = tqecToThree(hoveredGridPos, activeType, zo);
   const isDelete = mode === "delete";
   const isInvalid = !isDelete && hoveredInvalid;
 

--- a/piper_draw/gui/src/components/InvalidBlockHighlights.tsx
+++ b/piper_draw/gui/src/components/InvalidBlockHighlights.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import * as THREE from "three";
 import { useValidationStore } from "../stores/validationStore";
 import { useBlockStore } from "../stores/blockStore";
-import { tqecToThree, blockThreeSize, posKey } from "../types";
+import { tqecToThree, yBlockZOffset, blockThreeSize, posKey } from "../types";
 import type { BlockType } from "../types";
 
 const highlightMaterial = new THREE.MeshBasicMaterial({
@@ -57,7 +57,8 @@ export function InvalidBlockHighlights() {
   return (
     <>
       {invalidBlocks.map((block) => {
-        const [tx, ty, tz] = tqecToThree(block.pos, block.type);
+        const zo = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+        const [tx, ty, tz] = tqecToThree(block.pos, block.type, zo);
         const { box, edges } = getHighlightGeo(block.type);
         return (
           <group key={posKey(block.pos)} position={[tx, ty, tz]}>

--- a/piper_draw/gui/src/components/OpenPipeGhosts.tsx
+++ b/piper_draw/gui/src/components/OpenPipeGhosts.tsx
@@ -1,8 +1,19 @@
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import * as THREE from "three";
+import type { ThreeEvent } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { tqecToThree, posKey, isPipeType } from "../types";
-import type { Position3D, Block } from "../types";
+import {
+  tqecToThree,
+  posKey,
+  isPipeType,
+  isValidPos,
+  hasBlockOverlap,
+  hasPipeColorConflict,
+  hasCubeColorConflict,
+  hasYCubePipeAxisConflict,
+  resolvePipeType,
+} from "../types";
+import type { Position3D, Block, BlockType, CubeType } from "../types";
 
 const ghostMaterial = new THREE.MeshBasicMaterial({
   color: 0xdddddd,
@@ -55,9 +66,90 @@ function getOpenPipeEndpoints(blocks: Map<string, Block>): Position3D[] {
 }
 
 /**
+ * Interactive ghost cube at an open pipe endpoint.
+ * In place mode, hovering shows the placement preview and clicking places the block.
+ */
+function InteractiveGhost({ pos, threePos }: { pos: Position3D; threePos: [number, number, number] }) {
+  const handlePointerMove = useCallback((e: ThreeEvent<PointerEvent>) => {
+    e.stopPropagation();
+    const store = useBlockStore.getState();
+    if (store.mode !== "place") return;
+
+    let blockType: BlockType = store.cubeType;
+    if (store.pipeVariant) {
+      const resolved = resolvePipeType(store.pipeVariant, pos);
+      if (!resolved) { store.setHoveredGridPos(pos, undefined, true); return; }
+      blockType = resolved;
+    }
+
+    if (!isValidPos(pos, blockType) || hasBlockOverlap(pos, blockType, store.blocks, store.spatialIndex)) {
+      store.setHoveredGridPos(pos, blockType, true);
+    } else if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) {
+      store.setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube");
+    } else if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
+      store.setHoveredGridPos(pos, blockType, true, "Cube colors don't match the adjacent pipe");
+    } else if (hasYCubePipeAxisConflict(blockType, pos, store.blocks)) {
+      store.setHoveredGridPos(pos, blockType, true, "Y cube cannot be next to an X-open or Y-open pipe");
+    } else {
+      store.setHoveredGridPos(pos, blockType);
+    }
+  }, [pos]);
+
+  const handleClick = useCallback((e: ThreeEvent<MouseEvent>) => {
+    e.stopPropagation();
+    if (e.delta > 2) return;
+    const store = useBlockStore.getState();
+    if (store.mode !== "place") return;
+    store.addBlock(pos);
+  }, [pos]);
+
+  const handlePointerLeave = useCallback(() => {
+    useBlockStore.getState().setHoveredGridPos(null);
+  }, []);
+
+  return (
+    <group position={threePos}>
+      <mesh
+        geometry={defaultBox}
+        material={ghostMaterial}
+        onPointerMove={handlePointerMove}
+        onClick={handleClick}
+        onPointerLeave={handlePointerLeave}
+      />
+      <lineSegments
+        geometry={defaultEdges}
+        material={ghostLineMaterial}
+        raycast={noRaycast}
+      />
+    </group>
+  );
+}
+
+/**
+ * Non-interactive ghost cube (for delete/select/build modes).
+ */
+function StaticGhost({ threePos }: { threePos: [number, number, number] }) {
+  return (
+    <group position={threePos}>
+      <mesh
+        geometry={defaultBox}
+        material={ghostMaterial}
+        raycast={noRaycast}
+      />
+      <lineSegments
+        geometry={defaultEdges}
+        material={ghostLineMaterial}
+        raycast={noRaycast}
+      />
+    </group>
+  );
+}
+
+/**
  * Renders white semi-transparent ghost cubes at open pipe endpoints
- * and at undetermined cube positions. These are visualization-only —
- * not interactive, not exported.
+ * and at undetermined cube positions. In place mode, ghosts at open
+ * pipe endpoints are interactive — hovering shows the placement preview
+ * and clicking places the block.
  */
 export function OpenPipeGhosts() {
   const blocks = useBlockStore((s) => s.blocks);
@@ -65,54 +157,53 @@ export function OpenPipeGhosts() {
   const mode = useBlockStore((s) => s.mode);
   const buildCursor = useBlockStore((s) => s.buildCursor);
 
-  const positions = useMemo(() => {
-    const result: Array<{ key: string; threePos: [number, number, number] }> = [];
+  const isPlaceMode = mode === "place";
+
+  const { pipeEndpoints, undetermined } = useMemo(() => {
+    const pipeEndpoints: Array<{ key: string; pos: Position3D; threePos: [number, number, number] }> = [];
+    const undetermined: Array<{ key: string; threePos: [number, number, number] }> = [];
     const seen = new Set<string>();
 
-    // Ghost cubes at open pipe endpoints (positions with no block)
+    // Ghost cubes at open pipe endpoints
     for (const pos of getOpenPipeEndpoints(blocks)) {
       const key = posKey(pos);
       seen.add(key);
-      result.push({
+      pipeEndpoints.push({
         key,
+        pos,
         threePos: tqecToThree(pos, "XZZ") as [number, number, number],
       });
     }
 
-    // Ghost cubes at undetermined cube positions (always visible).
-    // In build mode, skip the cursor position — BuildCursor renders it with a pulse.
+    // Ghost cubes at undetermined cube positions
     const cursorKey = buildCursor ? posKey(buildCursor) : null;
     for (const [key] of undeterminedCubes) {
       if (seen.has(key)) continue;
       if (mode === "build" && key === cursorKey) continue;
       const block = blocks.get(key);
       if (!block) continue;
-      result.push({
+      undetermined.push({
         key,
         threePos: tqecToThree(block.pos, block.type) as [number, number, number],
       });
     }
 
-    return result;
+    return { pipeEndpoints, undetermined };
   }, [blocks, undeterminedCubes, mode, buildCursor]);
 
-  if (positions.length === 0) return null;
+  if (pipeEndpoints.length === 0 && undetermined.length === 0) return null;
 
   return (
     <>
-      {positions.map(({ key, threePos }) => (
-        <group key={key} position={threePos}>
-          <mesh
-            geometry={defaultBox}
-            material={ghostMaterial}
-            raycast={noRaycast}
-          />
-          <lineSegments
-            geometry={defaultEdges}
-            material={ghostLineMaterial}
-            raycast={noRaycast}
-          />
-        </group>
+      {pipeEndpoints.map(({ key, pos, threePos }) =>
+        isPlaceMode ? (
+          <InteractiveGhost key={key} pos={pos} threePos={threePos} />
+        ) : (
+          <StaticGhost key={key} threePos={threePos} />
+        )
+      )}
+      {undetermined.map(({ key, threePos }) => (
+        <StaticGhost key={key} threePos={threePos} />
       ))}
     </>
   );

--- a/piper_draw/gui/src/components/SelectionHighlights.tsx
+++ b/piper_draw/gui/src/components/SelectionHighlights.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
-import { tqecToThree, blockThreeSize, posKey } from "../types";
+import { tqecToThree, yBlockZOffset, blockThreeSize, posKey } from "../types";
 import type { BlockType } from "../types";
 
 const highlightMaterial = new THREE.MeshBasicMaterial({
@@ -58,7 +58,8 @@ export function SelectionHighlights() {
   return (
     <>
       {selectedBlocks.map((block) => {
-        const [tx, ty, tz] = tqecToThree(block.pos, block.type);
+        const zo = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+        const [tx, ty, tz] = tqecToThree(block.pos, block.type, zo);
         const { box, edges } = getHighlightGeo(block.type);
         return (
           <group key={posKey(block.pos)} position={[tx, ty, tz]}>

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -197,9 +197,19 @@ export function blockThreeSize(blockType: BlockType): [number, number, number] {
  * Blocks fill grid cells: TQEC position (x,y,z) occupies from
  * (x,y,z) to (x+sx,y+sy,z+sz). Three.js center is offset by +half-size.
  */
-export function tqecToThree(pos: Position3D, blockType?: BlockType): [number, number, number] {
+export function tqecToThree(pos: Position3D, blockType?: BlockType, zOffset = 0): [number, number, number] {
   const [sx, sy, sz] = blockType ? blockTqecSize(blockType) : [1, 1, 1];
-  return [pos.x + sx / 2, pos.z + sz / 2, -(pos.y + sy / 2)];
+  return [pos.x + sx / 2, pos.z + sz / 2 + zOffset, -(pos.y + sy / 2)];
+}
+
+/**
+ * Visual Z offset for Y blocks: +0.5 when a pipe sits directly above (z+1),
+ * so the half-cube renders flush against the pipe's open face.
+ */
+export function yBlockZOffset(pos: Position3D, blocks: Map<string, Block>): number {
+  const aboveKey = posKey({ x: pos.x, y: pos.y, z: pos.z + 1 });
+  const above = blocks.get(aboveKey);
+  return above != null && isPipeType(above.type) ? 0.5 : 0;
 }
 
 // ---------------------------------------------------------------------------
@@ -1074,6 +1084,12 @@ export function cameraAzimuthForDirection(dir: BuildDirection): number | null {
  *   (0, ±1, 0) → TQEC Z ± srcSizeZ / dstSizeZ
  *   (0, 0, ±1) → TQEC Y ∓ srcSizeY / dstSizeY
  */
+/** Grid-snapping size: Y blocks occupy the same grid cell as regular cubes. */
+function blockGridSize(blockType: BlockType): [number, number, number] {
+  if (blockType === "Y") return [1, 1, 1];
+  return blockTqecSize(blockType);
+}
+
 export function getAdjacentPos(
   srcPos: Position3D,
   srcType: BlockType,
@@ -1084,8 +1100,8 @@ export function getAdjacentPos(
   const ny = Math.round(normal.y);
   const nz = Math.round(normal.z);
 
-  const srcSize = blockTqecSize(srcType);
-  const dstSize = blockTqecSize(dstType);
+  const srcSize = blockGridSize(srcType);
+  const dstSize = blockGridSize(dstType);
 
   const x = srcPos.x + (nx > 0 ? srcSize[0] : nx < 0 ? -dstSize[0] : 0);
   const y = srcPos.y + (nz < 0 ? srcSize[1] : nz > 0 ? -dstSize[1] : 0);

--- a/piper_draw/gui/src/utils/projection.ts
+++ b/piper_draw/gui/src/utils/projection.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
 import type { Block } from "../types";
-import { tqecToThree } from "../types";
+import { tqecToThree, yBlockZOffset } from "../types";
 
 const _vec3 = new THREE.Vector3();
 
@@ -22,7 +22,8 @@ export function getBlockKeysInScreenRect(
 
   const result: string[] = [];
   for (const [key, block] of blocks) {
-    const [tx, ty, tz] = tqecToThree(block.pos, block.type);
+    const zo = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+    const [tx, ty, tz] = tqecToThree(block.pos, block.type, zo);
     _vec3.set(tx, ty, tz);
     _vec3.project(camera);
     // Skip blocks behind camera


### PR DESCRIPTION
## Summary
- Fix `getAdjacentPos` producing fractional positions for Y blocks by using grid-aligned sizes instead of TQEC sizes
- Make open pipe endpoint ghost cubes interactive in place mode so users can click them to place blocks (previously non-interactive, making it impossible to place below a pipe from the default camera angle)
- Add visual Z offset for Y blocks below pipes so they render flush against the pipe's open face instead of floating at the bottom of the grid cell

## Test plan
- [ ] Place a Y block on the ground plane — should work as before
- [ ] Place a pipe, then hover the ghost cube at the open end — Y block preview should appear
- [ ] Click to place a Y block below a pipe — should snap to the top half of the grid cell, flush with the pipe
- [ ] Place a Y block above a pipe — should render at the bottom of the cell (no offset needed, already flush)
- [ ] Verify DAE export/import still round-trips correctly with Y blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)