### PR TITLE
Add cycle-block feature for build mode

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -329,8 +329,8 @@ export default function App() {
             case "undo":
               store.undoBuildStep();
               return;
-            case "cycleCubeType":
-              store.cycleCubeType();
+            case "cycleBlock":
+              store.cycleBlock();
               return;
             case "toggleHadamard":
               store.toggleHadamard();

--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -332,8 +332,8 @@ export default function App() {
             case "cycleBlock":
               store.cycleBlock();
               return;
-            case "toggleHadamard":
-              store.toggleHadamard();
+            case "cyclePipe":
+              store.cyclePipe();
               return;
             case "exitBuild":
               store.setMode("place");

--- a/piper_draw/gui/src/components/BuildModeHints.tsx
+++ b/piper_draw/gui/src/components/BuildModeHints.tsx
@@ -14,7 +14,7 @@ export function BuildModeHints({ onCustomize }: { onCustomize: () => void }) {
     [`${bindings.moveUp.displayLabel}/${bindings.moveDown.displayLabel}`, "Move Z"],
     [bindings.undo.displayLabel, "Undo step"],
     [bindings.cycleBlock.displayLabel, "Cycle block"],
-    [bindings.toggleHadamard.displayLabel, "Hadamard"],
+    [bindings.cyclePipe.displayLabel, "Cycle pipe"],
     [bindings.exitBuild.displayLabel, "Exit build"],
   ];
 

--- a/piper_draw/gui/src/components/BuildModeHints.tsx
+++ b/piper_draw/gui/src/components/BuildModeHints.tsx
@@ -13,7 +13,7 @@ export function BuildModeHints({ onCustomize }: { onCustomize: () => void }) {
     ],
     [`${bindings.moveUp.displayLabel}/${bindings.moveDown.displayLabel}`, "Move Z"],
     [bindings.undo.displayLabel, "Undo step"],
-    [bindings.cycleCubeType.displayLabel, "Cycle type"],
+    [bindings.cycleBlock.displayLabel, "Cycle block"],
     [bindings.toggleHadamard.displayLabel, "Hadamard"],
     [bindings.exitBuild.displayLabel, "Exit build"],
   ];

--- a/piper_draw/gui/src/components/OpenPipeGhosts.tsx
+++ b/piper_draw/gui/src/components/OpenPipeGhosts.tsx
@@ -70,8 +70,11 @@ export function OpenPipeGhosts() {
     const seen = new Set<string>();
 
     // Ghost cubes at open pipe endpoints (positions with no block)
+    // In build mode, skip the cursor position — BuildCursor renders it with a pulse.
+    const cursorKey = buildCursor ? posKey(buildCursor) : null;
     for (const pos of getOpenPipeEndpoints(blocks)) {
       const key = posKey(pos);
+      if (mode === "build" && key === cursorKey) continue;
       seen.add(key);
       result.push({
         key,
@@ -81,7 +84,6 @@ export function OpenPipeGhosts() {
 
     // Ghost cubes at undetermined cube positions (always visible).
     // In build mode, skip the cursor position — BuildCursor renders it with a pulse.
-    const cursorKey = buildCursor ? posKey(buildCursor) : null;
     for (const [key] of undeterminedCubes) {
       if (seen.has(key)) continue;
       if (mode === "build" && key === cursorKey) continue;

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -1,6 +1,6 @@
 import { useBlockStore } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
-import { CUBE_TYPES, PIPE_VARIANTS, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, PIPE_TYPE_TO_VARIANT, pipeVariantPair } from "../types";
+import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, PIPE_TYPE_TO_VARIANT } from "../types";
 import type { BlockType, CubeType, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
@@ -132,9 +132,28 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
     if (!lastStep.pipe) return null;
     const pipeBlock = s.blocks.get(lastStep.pipe.key);
     if (!pipeBlock || !isPipeType(pipeBlock.type)) return null;
-    const variant = PIPE_TYPE_TO_VARIANT[pipeBlock.type as PipeType];
-    const [a, b] = pipeVariantPair(variant);
-    return `${a},${b}`;
+    const base = (pipeBlock.type as string).replace("H", "");
+    const openAxis = base.indexOf("O") as 0 | 1 | 2;
+    const pipeCoords: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];
+    // Check each variant's pipe type against neighbor cube constraints
+    const valid: string[] = [];
+    for (const v of PIPE_VARIANTS) {
+      const candidate = VARIANT_AXIS_MAP[v][openAxis];
+      const tmp = new Map(s.blocks);
+      tmp.set(lastStep.pipe.key, { pos: pipeBlock.pos, type: candidate });
+      let ok = true;
+      for (const offset of [-1, 2]) {
+        const nc: [number, number, number] = [pipeCoords[0], pipeCoords[1], pipeCoords[2]];
+        nc[openAxis] += offset;
+        const nKey = posKey({ x: nc[0], y: nc[1], z: nc[2] });
+        const neighbor = tmp.get(nKey);
+        if (!neighbor || isPipeType(neighbor.type) || neighbor.type === "Y") continue;
+        const opts = determineCubeOptions(neighbor.pos, tmp);
+        if (!opts.determined && opts.options.length === 0) { ok = false; break; }
+      }
+      if (ok) valid.push(v);
+    }
+    return valid.join(",");
   });
   const buildValidPipeVariants = buildValidPipeVariantsStr != null ? new Set(buildValidPipeVariantsStr.split(",")) : null;
   const hoveredGridPos = useBlockStore((s) => s.hoveredGridPos);

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useBlockStore } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
-import { CUBE_TYPES, PIPE_VARIANTS, isPipeType, pipeAxisFromPos } from "../types";
-import type { BlockType, Position3D } from "../types";
+import { CUBE_TYPES, PIPE_VARIANTS, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions } from "../types";
+import type { BlockType, CubeType, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
 import * as THREE from "three";
@@ -40,13 +40,14 @@ const btnStyle = (active: boolean) => ({
   fontWeight: "normal" as const,
 });
 
-const blockBtnStyle = (active: boolean) => ({
+const blockBtnStyle = (active: boolean, disabled?: boolean) => ({
   ...btnStyle(active),
   display: "flex" as const,
   flexDirection: "column" as const,
   alignItems: "center" as const,
   justifyContent: "flex-start" as const,
   padding: "4px 8px",
+  ...(disabled ? { opacity: 0.3, pointerEvents: "none" as const } : {}),
 });
 
 // ---------------------------------------------------------------------------
@@ -77,6 +78,46 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
   const deleteSelected = useBlockStore((s) => s.deleteSelected);
 
   const buildCursor = useBlockStore((s) => s.buildCursor);
+  const buildCursorBlockType = useBlockStore((s) => {
+    if (s.mode !== "build" || !s.buildCursor) return null;
+    // Undetermined cubes should not highlight any button
+    if (s.undeterminedCubes.has(posKey(s.buildCursor))) return null;
+    const block = s.blocks.get(posKey(s.buildCursor));
+    return block && !isPipeType(block.type) ? block.type : null;
+  });
+  // Returns a stable string of valid cube types (comma-separated) to avoid
+  // infinite re-renders from creating new Set objects in the selector.
+  const buildValidTypesStr = useBlockStore((s): string | null => {
+    if (s.mode !== "build" || !s.buildCursor) return null;
+    const cursor = s.buildCursor;
+    const coords: [number, number, number] = [cursor.x, cursor.y, cursor.z];
+    let pipeCount = 0;
+    let yValid = true;
+    for (let axis = 0; axis < 3; axis++) {
+      for (const offset of [1, -2]) {
+        const nc: [number, number, number] = [coords[0], coords[1], coords[2]];
+        nc[axis] += offset;
+        const n = s.blocks.get(posKey({ x: nc[0], y: nc[1], z: nc[2] }));
+        if (n && isPipeType(n.type)) {
+          const openAxis = n.type.replace("H", "").indexOf("O");
+          if (openAxis === axis) {
+            pipeCount++;
+            if (openAxis !== 2) yValid = false;
+          }
+        }
+      }
+    }
+    if (pipeCount > 1) return "";
+    const opts: string[] = pipeCount === 0
+      ? [...CUBE_TYPES]
+      : (() => {
+          const result = determineCubeOptions(cursor, s.blocks);
+          return result.determined ? [result.type] : [...result.options];
+        })();
+    if (yValid) opts.push("Y");
+    return opts.join(",");
+  });
+  const buildValidTypes = buildValidTypesStr != null ? new Set(buildValidTypesStr.split(",").filter(Boolean)) : null;
   const hoveredGridPos = useBlockStore((s) => s.hoveredGridPos);
 
   const previewImages = usePreviewImages(controlsRef);
@@ -223,7 +264,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
       <div style={{ width: 1, background: "#ddd" }} />
 
       {/* Blocks group (ZXCubes + Y) */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px", opacity: mode === "build" ? 0.4 : 1, pointerEvents: mode === "build" ? "none" : "auto" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px", pointerEvents: mode === "build" ? "none" : "auto" }}>
         <span style={groupLabelStyle}>Blocks</span>
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
           {CUBE_TYPES.map((ct) => (
@@ -233,7 +274,11 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
                 setCubeType(ct as BlockType);
                 setMode("place");
               }}
-              style={blockBtnStyle(cubeType === ct && mode === "place")}
+              style={blockBtnStyle(
+                (cubeType === ct && mode === "place") ||
+                (mode === "build" && buildCursorBlockType === ct),
+                mode === "build" && buildValidTypes != null && !buildValidTypes.has(ct),
+              )}
             >
               {ct}
               <div style={previewWrapStyle}>{previewImg(ct)}</div>
@@ -244,7 +289,11 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
               setCubeType("Y");
               setMode("place");
             }}
-            style={blockBtnStyle(cubeType === "Y" && mode === "place")}
+            style={blockBtnStyle(
+              (cubeType === "Y" && mode === "place") ||
+              (mode === "build" && buildCursorBlockType === "Y"),
+              mode === "build" && buildValidTypes != null && !buildValidTypes.has("Y" as CubeType),
+            )}
           >
             Y
             <div style={previewWrapStyle}>{previewImg("Y")}</div>

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -1,7 +1,7 @@
 import { useBlockStore } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
-import { CUBE_TYPES, PIPE_VARIANTS, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions } from "../types";
-import type { BlockType, CubeType, Position3D } from "../types";
+import { CUBE_TYPES, PIPE_VARIANTS, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, PIPE_TYPE_TO_VARIANT, pipeVariantPair } from "../types";
+import type { BlockType, CubeType, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
 import * as THREE from "three";
@@ -118,6 +118,25 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
     return opts.join(",");
   });
   const buildValidTypes = buildValidTypesStr != null ? new Set(buildValidTypesStr.split(",").filter(Boolean)) : null;
+  const buildActivePipeVariant = useBlockStore((s): PipeVariant | null => {
+    if (s.mode !== "build" || s.buildHistory.length === 0) return null;
+    const lastStep = s.buildHistory[s.buildHistory.length - 1];
+    if (!lastStep.pipe) return null;
+    const pipeBlock = s.blocks.get(lastStep.pipe.key);
+    if (!pipeBlock || !isPipeType(pipeBlock.type)) return null;
+    return PIPE_TYPE_TO_VARIANT[pipeBlock.type as PipeType];
+  });
+  const buildValidPipeVariantsStr = useBlockStore((s): string | null => {
+    if (s.mode !== "build" || s.buildHistory.length === 0) return null;
+    const lastStep = s.buildHistory[s.buildHistory.length - 1];
+    if (!lastStep.pipe) return null;
+    const pipeBlock = s.blocks.get(lastStep.pipe.key);
+    if (!pipeBlock || !isPipeType(pipeBlock.type)) return null;
+    const variant = PIPE_TYPE_TO_VARIANT[pipeBlock.type as PipeType];
+    const [a, b] = pipeVariantPair(variant);
+    return `${a},${b}`;
+  });
+  const buildValidPipeVariants = buildValidPipeVariantsStr != null ? new Set(buildValidPipeVariantsStr.split(",")) : null;
   const hoveredGridPos = useBlockStore((s) => s.hoveredGridPos);
 
   const previewImages = usePreviewImages(controlsRef);
@@ -305,7 +324,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
       <div style={{ width: 1, background: "#ddd" }} />
 
       {/* Pipes group */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px", opacity: mode === "build" ? 0.4 : 1, pointerEvents: mode === "build" ? "none" : "auto" }}>
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px", pointerEvents: mode === "build" ? "none" : "auto" }}>
         <span style={groupLabelStyle}>Pipes</span>
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
           {PIPE_VARIANTS.map((v) => (
@@ -315,7 +334,11 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
                 setPipeVariant(v);
                 setMode("place");
               }}
-              style={blockBtnStyle(pipeVariant === v && mode === "place")}
+              style={blockBtnStyle(
+                (pipeVariant === v && mode === "place") ||
+                (mode === "build" && buildActivePipeVariant === v),
+                mode === "build" && (buildValidPipeVariants == null || !buildValidPipeVariants.has(v)),
+              )}
             >
               {v}
               <div style={previewWrapStyle}>{previewImg(v)}</div>

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -77,8 +77,10 @@ type UndoCommand =
   | { kind: "hadamard-toggle"; pipeKey: string; oldType: PipeType; newType: PipeType;
       retyped?: Array<{ cubeKey: string; oldType: CubeType; newType: CubeType;
         oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo }> }
-  | { kind: "cube-cycle"; cubeKey: string; oldType: CubeType; newType: CubeType;
-      oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }> };
+  | { kind: "cube-cycle"; cubeKey: string; cubePos: Position3D;
+      oldPlacedType: CubeType | "Y" | null; newPlacedType: CubeType | "Y";
+      oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }>;
+      oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo };
 
 interface BlockStore {
   blocks: Map<string, Block>;
@@ -125,7 +127,7 @@ interface BlockStore {
   // Build mode actions
   buildMove: (direction: BuildDirection) => boolean;
   undoBuildStep: () => void;
-  cycleCubeType: () => void;
+  cycleBlock: () => void;
   toggleHadamard: () => void;
   moveBuildCursor: (pos: Position3D) => void;
   clearCameraSnap: () => void;
@@ -467,10 +469,14 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
         const newUndetermined = new Map(state.undeterminedCubes);
 
+        // Remove current cube
         const cubeBlock = blocks.get(cmd.cubeKey);
         if (cubeBlock) {
           ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, cubeBlock));
-          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, { pos: cubeBlock.pos, type: cmd.oldType }));
+        }
+        // Re-add old cube
+        if (cmd.oldPlacedType) {
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, { pos: cmd.cubePos, type: cmd.oldPlacedType }));
         }
         // Revert pipe updates
         if (cmd.oldPipes) {
@@ -482,12 +488,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             }
           }
         }
-        // Restore undetermined index
-        const info = newUndetermined.get(cmd.cubeKey);
-        if (info) {
-          const idx = info.options.indexOf(cmd.oldType);
-          if (idx >= 0) newUndetermined.set(cmd.cubeKey, { ...info, currentIndex: idx });
-        }
+        // Restore undetermined state
+        if (cmd.oldUndetermined) newUndetermined.set(cmd.cubeKey, cmd.oldUndetermined);
+        else newUndetermined.delete(cmd.cubeKey);
         return { blocks, hiddenFaces, history: newHistory, future: [cmd, ...state.future].slice(0, MAX_HISTORY), undeterminedCubes: newUndetermined, hoveredGridPos: null };
       }
 
@@ -652,11 +655,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
         const newUndetermined = new Map(state.undeterminedCubes);
 
+        // Remove current cube
         const cubeBlock = blocks.get(cmd.cubeKey);
         if (cubeBlock) {
           ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, cubeBlock));
-          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, { pos: cubeBlock.pos, type: cmd.newType }));
         }
+        // Re-add new cube
+        ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.cubeKey, { pos: cmd.cubePos, type: cmd.newPlacedType }));
         if (cmd.oldPipes) {
           for (const pu of cmd.oldPipes) {
             const pb = blocks.get(pu.key);
@@ -666,11 +671,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             }
           }
         }
-        const info = newUndetermined.get(cmd.cubeKey);
-        if (info) {
-          const idx = info.options.indexOf(cmd.newType);
-          if (idx >= 0) newUndetermined.set(cmd.cubeKey, { ...info, currentIndex: idx });
-        }
+        // Restore undetermined state
+        if (cmd.newUndetermined) newUndetermined.set(cmd.cubeKey, cmd.newUndetermined);
+        else newUndetermined.delete(cmd.cubeKey);
         return { blocks, hiddenFaces, history: [...state.history, cmd], future: newFuture, undeterminedCubes: newUndetermined, hoveredGridPos: null };
       }
 
@@ -1127,80 +1130,158 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     });
   },
 
-  cycleCubeType: () =>
+  cycleBlock: () =>
     set((state) => {
       if (state.mode !== "build" || !state.buildCursor) return state;
-      const cursorKey = posKey(state.buildCursor);
-      const info = state.undeterminedCubes.get(cursorKey);
-      if (!info || info.options.length <= 1) return state;
+      const cursor = state.buildCursor;
+      const cursorKey = posKey(cursor);
+      const coords: [number, number, number] = [cursor.x, cursor.y, cursor.z];
 
-      const block = state.blocks.get(cursorKey);
-      if (!block) return state;
-
-      const oldType = block.type as CubeType;
-      const newIndex = (info.currentIndex + 1) % info.options.length;
-      const newType = info.options[newIndex];
-
-      // Replace cube block with new type
-      let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
-      ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, block));
-      const newBlock: Block = { pos: state.buildCursor, type: newType };
-      ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
-
-      // Update adjacent pipes to match new cube type, validating far-end compatibility
-      const pipeUpdates: Array<{ key: string; oldType: PipeType; newType: PipeType }> = [];
-      const coords: [number, number, number] = [state.buildCursor.x, state.buildCursor.y, state.buildCursor.z];
-
-      // First pass: check all pipe updates are valid before mutating
+      // Count adjacent pipes and check if Y is valid (only Z-open pipes)
+      let pipeCount = 0;
+      let yValid = true;
       for (let axis = 0; axis < 3; axis++) {
         for (const pipeOffset of [1, -2]) {
           const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
           nCoords[axis] += pipeOffset;
-          const nKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
-          const neighbor = blocks.get(nKey);
-          if (!neighbor || !isPipeType(neighbor.type)) continue;
-
-          const base = neighbor.type.replace("H", "");
-          const hadamard = neighbor.type.length > 3;
-          const openAxis = base.indexOf("O");
-          if (openAxis !== axis) continue;
-
-          const newPipe = inferPipeType(newType, axis as 0 | 1 | 2);
-          if (!newPipe) {
-            // Can't create valid pipe on this axis with new type — reject cycle
-            // Revert the cube change
-            ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
-            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, block));
-            return state;
+          const n = state.blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
+          if (n && isPipeType(n.type)) {
+            const openAxis = n.type.replace("H", "").indexOf("O");
+            if (openAxis === axis) {
+              pipeCount++;
+              if (openAxis !== 2) yValid = false;
+            }
           }
-          const newPipeType = hadamard ? (newPipe + "H") as PipeType : newPipe;
-          if (newPipeType === neighbor.type) continue;
+        }
+      }
+      if (pipeCount > 1) return state;
 
-          // Validate new pipe against the far-end cube
-          const tmpBlocks = new Map(blocks);
-          tmpBlocks.set(nKey, { pos: neighbor.pos, type: newPipeType });
-          if (hasPipeColorConflict(newPipeType, neighbor.pos, tmpBlocks)) {
-            // Conflict with far-end cube — reject cycle
-            ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
-            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, block));
-            return state;
+      // Determine valid cube type options
+      const cubeOptions: (CubeType | "Y")[] = pipeCount === 0
+        ? [...CUBE_TYPES]
+        : (() => {
+            const result = determineCubeOptions(cursor, state.blocks);
+            return result.determined ? [result.type] : result.options;
+          })();
+      if (yValid) cubeOptions.push("Y");
+      if (cubeOptions.length === 0) return state;
+
+      // Cycle: undetermined → type1 → type2 → ... → Y (if valid) → undetermined
+      // "undetermined" is represented by null in the cycle list.
+      // When at undetermined, the block stays as-is but is in undeterminedCubes.
+      const cycle: (CubeType | "Y" | null)[] = [null, ...cubeOptions];
+
+      // Find current position in cycle
+      const existingBlock = state.blocks.get(cursorKey);
+      const isUndetermined = state.undeterminedCubes.has(cursorKey);
+      const existingType = existingBlock && !isPipeType(existingBlock.type)
+        ? existingBlock.type as CubeType | "Y" : null;
+
+      let currentIdx: number;
+      if (!existingBlock || isUndetermined) {
+        // No block or undetermined → position 0 (undetermined)
+        currentIdx = 0;
+      } else {
+        // Determined block → find in cycle
+        currentIdx = cycle.indexOf(existingType);
+        if (currentIdx < 0) currentIdx = 0;
+      }
+
+      const nextIdx = (currentIdx + 1) % cycle.length;
+      const nextType = cycle[nextIdx];
+      const isNextUndetermined = nextIdx === 0;
+
+      let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+      const oldUndetermined = state.undeterminedCubes.get(cursorKey);
+      const pipeUpdates: Array<{ key: string; oldType: PipeType; newType: PipeType }> = [];
+
+      // Remove existing cube if present
+      if (existingBlock) {
+        ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, existingBlock));
+      }
+
+      // Determine what block to place
+      let placeType: CubeType | "Y";
+      if (isNextUndetermined) {
+        // Cycling back to undetermined — place first valid CubeType as placeholder
+        const firstCube = cubeOptions.find((t): t is CubeType => t !== "Y");
+        if (!firstCube) return state; // only Y is valid, can't be undetermined
+        placeType = firstCube;
+      } else {
+        placeType = nextType!;
+      }
+
+      const newBlock: Block = { pos: cursor, type: placeType };
+      ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
+
+      // Update adjacent pipes to match new cube type (skip for Y — Y doesn't change pipes)
+      if (placeType !== "Y") {
+        for (let axis = 0; axis < 3; axis++) {
+          for (const pipeOffset of [1, -2]) {
+            const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+            nCoords[axis] += pipeOffset;
+            const nKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
+            const neighbor = blocks.get(nKey);
+            if (!neighbor || !isPipeType(neighbor.type)) continue;
+
+            const base = neighbor.type.replace("H", "");
+            const hadamard = neighbor.type.length > 3;
+            const openAxis = base.indexOf("O");
+            if (openAxis !== axis) continue;
+
+            const newPipe = inferPipeType(placeType, axis as 0 | 1 | 2);
+            if (!newPipe) {
+              // Can't create valid pipe — reject cycle, revert
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
+              if (existingBlock) {
+                ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, existingBlock));
+              }
+              return state;
+            }
+            const newPipeType = hadamard ? (newPipe + "H") as PipeType : newPipe;
+            if (newPipeType === neighbor.type) continue;
+
+            // Validate against far-end cube
+            const tmpBlocks = new Map(blocks);
+            tmpBlocks.set(nKey, { pos: neighbor.pos, type: newPipeType });
+            if (hasPipeColorConflict(newPipeType, neighbor.pos, tmpBlocks)) {
+              // Conflict — reject cycle, revert
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
+              if (existingBlock) {
+                ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, existingBlock));
+              }
+              return state;
+            }
+            pipeUpdates.push({ key: nKey, oldType: neighbor.type as PipeType, newType: newPipeType });
           }
+        }
 
-          pipeUpdates.push({ key: nKey, oldType: neighbor.type as PipeType, newType: newPipeType });
+        // Apply pipe mutations
+        for (const pu of pipeUpdates) {
+          const pipeBlock = blocks.get(pu.key)!;
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pipeBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pipeBlock.pos, type: pu.newType }));
         }
       }
 
-      // All valid — apply pipe mutations
-      for (const pu of pipeUpdates) {
-        const pipeBlock = blocks.get(pu.key)!;
-        ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pipeBlock));
-        ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pipeBlock.pos, type: pu.newType }));
+      // Update undetermined state
+      const newUndetermined = new Map(state.undeterminedCubes);
+      let newUndeterminedInfo: UndeterminedCubeInfo | undefined;
+      if (isNextUndetermined && cubeOptions.filter((t): t is CubeType => t !== "Y").length > 1) {
+        // Restore undetermined with all valid CubeType options
+        const opts = cubeOptions.filter((t): t is CubeType => t !== "Y");
+        newUndeterminedInfo = { options: opts, currentIndex: 0 };
+        newUndetermined.set(cursorKey, newUndeterminedInfo);
+      } else {
+        newUndetermined.delete(cursorKey);
       }
 
-      const newUndetermined = new Map(state.undeterminedCubes);
-      newUndetermined.set(cursorKey, { ...info, currentIndex: newIndex });
-
-      const cmd: UndoCommand = { kind: "cube-cycle", cubeKey: cursorKey, oldType, newType, oldPipes: pipeUpdates };
+      const cmd: UndoCommand = {
+        kind: "cube-cycle", cubeKey: cursorKey, cubePos: cursor,
+        oldPlacedType: existingType, newPlacedType: placeType,
+        oldPipes: pipeUpdates.length > 0 ? pipeUpdates : undefined,
+        oldUndetermined, newUndetermined: newUndeterminedInfo,
+      };
       return {
         blocks,
         hiddenFaces,

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -501,6 +501,29 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             else newUndetermined.delete(rd.cubeKey);
           }
         }
+        // Re-evaluate undetermined neighbors not in retyped list
+        if (pipeBlock) {
+          const base = cmd.oldType.replace("H", "");
+          const openAxis = base.indexOf("O");
+          const pc: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];
+          for (const offset of [-1, 2]) {
+            const nc: [number, number, number] = [pc[0], pc[1], pc[2]];
+            nc[openAxis] += offset;
+            const nKey = posKey({ x: nc[0], y: nc[1], z: nc[2] });
+            if (cmd.retyped?.some(r => r.cubeKey === nKey)) continue;
+            const cubeInfo = newUndetermined.get(nKey);
+            if (!cubeInfo) continue;
+            const neighbor = blocks.get(nKey);
+            if (!neighbor) continue;
+            const newOptions = determineCubeOptions(neighbor.pos, blocks);
+            if (newOptions.determined) {
+              newUndetermined.delete(nKey);
+            } else if (newOptions.options.length > 0) {
+              const idx = Math.max(0, newOptions.options.indexOf(neighbor.type as CubeType));
+              newUndetermined.set(nKey, { options: [...newOptions.options], currentIndex: idx });
+            }
+          }
+        }
         return { blocks, hiddenFaces, history: newHistory, future: [cmd, ...state.future].slice(0, MAX_HISTORY), undeterminedCubes: newUndetermined, hoveredGridPos: null };
       }
 
@@ -771,6 +794,16 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         const mask = getHiddenFaceMaskForPos(block.pos, block.type, incoming, newIndex);
         if (mask !== 0) newHidden.set(key, mask);
       }
+      // Recompute undetermined state from loaded blocks
+      const newUndetermined = new Map<string, UndeterminedCubeInfo>();
+      for (const [key, block] of incoming) {
+        if (isPipeType(block.type) || block.type === "Y") continue;
+        const opts = determineCubeOptions(block.pos, incoming);
+        if (!opts.determined && opts.options.length > 1) {
+          const idx = Math.max(0, opts.options.indexOf(block.type as CubeType));
+          newUndetermined.set(key, { options: [...opts.options], currentIndex: idx });
+        }
+      }
       const cmd: UndoCommand = {
         kind: "load",
         savedBlocks: state.blocks,
@@ -787,7 +820,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
         hoveredGridPos: null,
-        undeterminedCubes: new Map(),
+        undeterminedCubes: newUndetermined,
       };
     }),
 
@@ -1173,6 +1206,14 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const reverted: Block = { pos: step.prevCursorPos, type: sr.prevType };
           ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, sr.key, reverted));
         }
+        // Check if reverted source should now be undetermined (fewer pipe constraints)
+        const srcOpts = determineCubeOptions(step.prevCursorPos, blocks);
+        if (!srcOpts.determined && srcOpts.options.length > 1) {
+          const idx = Math.max(0, srcOpts.options.indexOf(sr.prevType));
+          newUndetermined.set(sr.key, { options: [...srcOpts.options], currentIndex: idx });
+        } else {
+          newUndetermined.delete(sr.key);
+        }
       }
 
       // Remove origin cube if this was first step
@@ -1346,14 +1387,18 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         }
       }
 
-      // Update undetermined state
+      // Update undetermined state — recompute from current blocks (pipes may have changed)
       const newUndetermined = new Map(state.undeterminedCubes);
       let newUndeterminedInfo: UndeterminedCubeInfo | undefined;
-      if (isNextUndetermined && cubeOptions.filter((t): t is CubeType => t !== "Y").length > 1) {
-        // Restore undetermined with all valid CubeType options
-        const opts = cubeOptions.filter((t): t is CubeType => t !== "Y");
-        newUndeterminedInfo = { options: opts, currentIndex: 0 };
-        newUndetermined.set(cursorKey, newUndeterminedInfo);
+      if (isNextUndetermined) {
+        const freshOpts = determineCubeOptions(cursor, blocks);
+        const freshCubeOpts = freshOpts.determined ? [] : freshOpts.options;
+        if (freshCubeOpts.length > 1) {
+          newUndeterminedInfo = { options: [...freshCubeOpts], currentIndex: 0 };
+          newUndetermined.set(cursorKey, newUndeterminedInfo);
+        } else {
+          newUndetermined.delete(cursorKey);
+        }
       } else {
         newUndetermined.delete(cursorKey);
       }

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -23,7 +23,6 @@ import {
   determineCubeOptions,
   cameraAzimuthForDirection,
   CUBE_TYPES,
-  PIPE_TYPES,
   PIPE_VARIANTS,
   VARIANT_AXIS_MAP,
 } from "../types";

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -20,11 +20,12 @@ import {
   computeDestCubePos,
   computePipePos,
   inferPipeType,
-  swapPipeVariant,
   determineCubeOptions,
   cameraAzimuthForDirection,
   CUBE_TYPES,
   PIPE_TYPES,
+  PIPE_VARIANTS,
+  VARIANT_AXIS_MAP,
 } from "../types";
 
 export type Mode = "place" | "delete" | "select" | "build";
@@ -64,6 +65,8 @@ export type BuildStep = {
   destUndetermined?: UndeterminedCubeInfo;
   /** If an existing destination cube was re-typed to accommodate the new pipe. */
   destTypeChange?: { key: string; prevType: CubeType; newType: CubeType };
+  /** If an existing undetermined destination became determined during this step. */
+  destDetermination?: { key: string; prevUndeterminedInfo: UndeterminedCubeInfo };
 };
 
 type UndoCommand =
@@ -74,7 +77,7 @@ type UndoCommand =
   | { kind: "load"; savedBlocks: Map<string, Block>; savedHiddenFaces: Map<string, FaceMask>; savedUndetermined: Map<string, UndeterminedCubeInfo>;
       newBlocks: Map<string, Block>; newIndex: SpatialIndex; newHiddenFaces: Map<string, FaceMask> }
   | { kind: "build-step"; step: BuildStep }
-  | { kind: "hadamard-toggle"; pipeKey: string; oldType: PipeType; newType: PipeType;
+  | { kind: "pipe-cycle"; pipeKey: string; oldType: PipeType; newType: PipeType;
       retyped?: Array<{ cubeKey: string; oldType: CubeType; newType: CubeType;
         oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo }> }
   | { kind: "cube-cycle"; cubeKey: string; cubePos: Position3D;
@@ -130,7 +133,7 @@ interface BlockStore {
   buildMove: (direction: BuildDirection) => boolean;
   undoBuildStep: () => void;
   cycleBlock: () => void;
-  toggleHadamard: () => void;
+  cyclePipe: () => void;
   moveBuildCursor: (pos: Position3D) => void;
   clearCameraSnap: () => void;
 }
@@ -429,6 +432,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, dtc.key, { pos: curDest.pos, type: dtc.prevType }));
           }
         }
+        // Restore dest undetermined state
+        if (step.destDetermination) {
+          newUndetermined.set(step.destDetermination.key, {
+            ...step.destDetermination.prevUndeterminedInfo,
+            options: [...step.destDetermination.prevUndeterminedInfo.options],
+          });
+        }
         // Remove pipe
         if (step.pipe) {
           ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, step.pipe.key, step.pipe.block));
@@ -471,7 +481,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         };
       }
 
-      if (cmd.kind === "hadamard-toggle") {
+      if (cmd.kind === "pipe-cycle") {
         let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
         const newUndetermined = new Map(state.undeterminedCubes);
 
@@ -649,6 +659,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, dtc.key, { pos: curDest.pos, type: dtc.newType }));
           }
         }
+        // Re-apply dest determination (existing dest became determined)
+        if (step.destDetermination) {
+          newUndetermined.delete(step.destDetermination.key);
+        }
         // Re-place dest cube
         if (step.cube) {
           ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, step.cube.key, step.cube.block));
@@ -669,7 +683,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         };
       }
 
-      if (cmd.kind === "hadamard-toggle") {
+      if (cmd.kind === "pipe-cycle") {
         let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
         const newUndetermined = new Map(state.undeterminedCubes);
 
@@ -1038,6 +1052,20 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, destTypeChange.key, newDest));
       }
 
+      // Clean up undetermined state for existing destination that's now determined
+      let destDetermination: BuildStep["destDetermination"];
+      if (existingDest && newUndetermined.has(destKey)) {
+        const destOptions = determineCubeOptions(destPos, blocks);
+        if (destOptions.determined) {
+          destDetermination = { key: destKey, prevUndeterminedInfo: newUndetermined.get(destKey)! };
+          newUndetermined.delete(destKey);
+        } else if (destOptions.options.length > 0) {
+          const curType = (destTypeChange ? destTypeChange.newType : existingDest.type) as CubeType;
+          const idx = Math.max(0, destOptions.options.indexOf(curType));
+          newUndetermined.set(destKey, { options: [...destOptions.options], currentIndex: idx });
+        }
+      }
+
       // Handle destination
       let cubeAdded: BuildStep["cube"] = null;
       let destUndetermined: UndeterminedCubeInfo | undefined;
@@ -1071,6 +1099,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         originUndetermined,
         destUndetermined,
         destTypeChange,
+        destDetermination,
       };
 
       const azimuth = cameraAzimuthForDirection(direction);
@@ -1344,7 +1373,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       };
     }),
 
-  toggleHadamard: () => {
+  cyclePipe: () => {
     const state = get();
     if (state.mode !== "build" || state.buildHistory.length === 0) return;
 
@@ -1357,38 +1386,42 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     if (!pipeBlock || !isPipeType(pipeBlock.type)) return;
 
     const oldPipeType = pipeBlock.type as PipeType;
-    const isHadamard = oldPipeType.length > 3;
-
-    // When building in a negative direction, the source cube is at the pipe's
-    // +2 end (swapped end for Hadamard). We need to swap the pipe variant so
-    // that the swapped end's constraints match the source cube.
     const oldBase = oldPipeType.replace("H", "");
-    const oldOpenAxis = oldBase.indexOf("O");
-    const srcAtSwappedEnd =
-      [lastStep.prevCursorPos.x, lastStep.prevCursorPos.y, lastStep.prevCursorPos.z][oldOpenAxis] ===
-      [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z][oldOpenAxis] + 2;
+    const openAxis = oldBase.indexOf("O") as 0 | 1 | 2;
+    const pipeCoords: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];
 
-    let newPipeType: PipeType;
-    if (isHadamard) {
-      // Removing Hadamard — if variant was swapped when toggling on, swap back
-      const reverted = srcAtSwappedEnd ? swapPipeVariant(oldBase) : oldBase;
-      newPipeType = reverted as PipeType;
-    } else {
-      // Adding Hadamard — swap variant if source is at the +2 (swapped) end
-      const swapped = srcAtSwappedEnd ? swapPipeVariant(oldBase) : oldBase;
-      newPipeType = (swapped + "H") as PipeType;
+    // Compute all candidate pipe types for this axis (one per toolbar variant)
+    const allCandidates = PIPE_VARIANTS.map(v => VARIANT_AXIS_MAP[v][openAxis]);
+
+    // Filter to valid candidates: both neighbor cubes must have valid options
+    const validPipes: PipeType[] = [];
+    for (const candidate of allCandidates) {
+      const tmpBlocks = new Map(state.blocks);
+      tmpBlocks.set(pipeKey, { pos: pipeBlock.pos, type: candidate });
+      let valid = true;
+      for (const offset of [-1, 2]) {
+        const nCoords: [number, number, number] = [pipeCoords[0], pipeCoords[1], pipeCoords[2]];
+        nCoords[openAxis] += offset;
+        const nKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
+        const neighbor = tmpBlocks.get(nKey);
+        if (!neighbor || isPipeType(neighbor.type) || neighbor.type === "Y") continue;
+        const options = determineCubeOptions(neighbor.pos, tmpBlocks);
+        if (!options.determined && options.options.length === 0) { valid = false; break; }
+      }
+      if (valid) validPipes.push(candidate);
     }
 
-    if (!(PIPE_TYPES as readonly string[]).includes(newPipeType)) return;
+    if (validPipes.length <= 1) return;
+
+    // Cycle to the next valid pipe type
+    const currentIdx = validPipes.indexOf(oldPipeType);
+    const newPipeType = validPipes[(currentIdx + 1) % validPipes.length];
+    if (newPipeType === oldPipeType) return;
 
     // --- Dry-run pass: validate all neighbors using a temp blocks map ---
     // No spatial index mutations happen here.
     const tmpBlocks = new Map(state.blocks);
     tmpBlocks.set(pipeKey, { pos: pipeBlock.pos, type: newPipeType });
-
-    const base = newPipeType.replace("H", "");
-    const openAxis = base.indexOf("O");
-    const pipeCoords: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];
 
     type RetypeEntry = { key: string; pos: Position3D; oldType: CubeType; newType: CubeType;
       oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo };
@@ -1473,7 +1506,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       lastH.pipe = { key: pipeKey, block: newPipeBlock };
       newBuildHistory[newBuildHistory.length - 1] = lastH;
 
-      const cmd: UndoCommand = { kind: "hadamard-toggle", pipeKey, oldType: oldPipeType, newType: newPipeType,
+      const cmd: UndoCommand = { kind: "pipe-cycle", pipeKey, oldType: oldPipeType, newType: newPipeType,
         retyped: retyped.length > 0 ? retyped : undefined };
       return {
         blocks,

--- a/piper_draw/gui/src/stores/keybindStore.ts
+++ b/piper_draw/gui/src/stores/keybindStore.ts
@@ -10,7 +10,7 @@ export type BuildAction =
   | "moveDown"
   | "undo"
   | "cycleBlock"
-  | "toggleHadamard"
+  | "cyclePipe"
   | "exitBuild";
 
 export type KeyBinding = {
@@ -27,7 +27,7 @@ export const BUILD_ACTIONS: BuildAction[] = [
   "moveDown",
   "undo",
   "cycleBlock",
-  "toggleHadamard",
+  "cyclePipe",
   "exitBuild",
 ];
 
@@ -40,7 +40,7 @@ export const ACTION_LABELS: Record<BuildAction, string> = {
   moveDown: "Move down",
   undo: "Undo step",
   cycleBlock: "Cycle block",
-  toggleHadamard: "Hadamard",
+  cyclePipe: "Cycle pipe",
   exitBuild: "Exit build",
 };
 
@@ -69,7 +69,7 @@ export const DEFAULT_BINDINGS: Record<BuildAction, KeyBinding> = {
   moveDown: { key: "arrowdown", displayLabel: "↓" },
   undo: { key: "q", displayLabel: "Q" },
   cycleBlock: { key: "c", displayLabel: "C" },
-  toggleHadamard: { key: "r", displayLabel: "R" },
+  cyclePipe: { key: "r", displayLabel: "R" },
   exitBuild: { key: "escape", displayLabel: "Esc" },
 };
 

--- a/piper_draw/gui/src/stores/keybindStore.ts
+++ b/piper_draw/gui/src/stores/keybindStore.ts
@@ -9,7 +9,7 @@ export type BuildAction =
   | "moveUp"
   | "moveDown"
   | "undo"
-  | "cycleCubeType"
+  | "cycleBlock"
   | "toggleHadamard"
   | "exitBuild";
 
@@ -26,7 +26,7 @@ export const BUILD_ACTIONS: BuildAction[] = [
   "moveUp",
   "moveDown",
   "undo",
-  "cycleCubeType",
+  "cycleBlock",
   "toggleHadamard",
   "exitBuild",
 ];
@@ -39,7 +39,7 @@ export const ACTION_LABELS: Record<BuildAction, string> = {
   moveUp: "Move up",
   moveDown: "Move down",
   undo: "Undo step",
-  cycleCubeType: "Cycle type",
+  cycleBlock: "Cycle block",
   toggleHadamard: "Hadamard",
   exitBuild: "Exit build",
 };
@@ -68,7 +68,7 @@ export const DEFAULT_BINDINGS: Record<BuildAction, KeyBinding> = {
   moveUp: { key: "arrowup", displayLabel: "↑" },
   moveDown: { key: "arrowdown", displayLabel: "↓" },
   undo: { key: "q", displayLabel: "Q" },
-  cycleCubeType: { key: "r", displayLabel: "R" },
+  cycleBlock: { key: "c", displayLabel: "C" },
   toggleHadamard: { key: "h", displayLabel: "H" },
   exitBuild: { key: "escape", displayLabel: "Esc" },
 };
@@ -129,7 +129,25 @@ export const useKeybindStore = create<KeybindState>()(
     }),
     {
       name: "piper-draw-keybinds",
-      version: 1,
+      version: 3,
+      migrate: () => {
+        // Always reset on version change to pick up renamed/added actions
+        return { bindings: { ...DEFAULT_BINDINGS } };
+      },
+      merge: (persisted, current) => {
+        // Only restore persisted bindings for actions that still exist,
+        // ensuring new/renamed actions always get their defaults.
+        const p = persisted as Partial<KeybindState>;
+        const merged = { ...(current as KeybindState).bindings };
+        if (p.bindings) {
+          for (const action of BUILD_ACTIONS) {
+            if (action in p.bindings) {
+              merged[action] = (p.bindings as Record<string, KeyBinding>)[action];
+            }
+          }
+        }
+        return { ...(current as KeybindState), bindings: merged };
+      },
     },
   ),
 );

--- a/piper_draw/gui/src/stores/keybindStore.ts
+++ b/piper_draw/gui/src/stores/keybindStore.ts
@@ -69,7 +69,7 @@ export const DEFAULT_BINDINGS: Record<BuildAction, KeyBinding> = {
   moveDown: { key: "arrowdown", displayLabel: "↓" },
   undo: { key: "q", displayLabel: "Q" },
   cycleBlock: { key: "c", displayLabel: "C" },
-  toggleHadamard: { key: "h", displayLabel: "H" },
+  toggleHadamard: { key: "r", displayLabel: "R" },
   exitBuild: { key: "escape", displayLabel: "Esc" },
 };
 
@@ -129,7 +129,7 @@ export const useKeybindStore = create<KeybindState>()(
     }),
     {
       name: "piper-draw-keybinds",
-      version: 3,
+      version: 4,
       migrate: () => {
         // Always reset on version change to pick up renamed/added actions
         return { bindings: { ...DEFAULT_BINDINGS } };

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -134,6 +134,17 @@ export const VARIANT_AXIS_MAP: Record<PipeVariant, [PipeType, PipeType, PipeType
   XZH: ["OXZH", "ZOXH", "XZOH"],
 };
 
+/** Reverse lookup: concrete PipeType → toolbar PipeVariant. */
+export const PIPE_TYPE_TO_VARIANT: Record<PipeType, PipeVariant> = Object.fromEntries(
+  (Object.entries(VARIANT_AXIS_MAP) as [PipeVariant, PipeType[]][])
+    .flatMap(([variant, types]) => types.map((t) => [t, variant]))
+) as Record<PipeType, PipeVariant>;
+
+/** Returns the [nonH, H] pair for a given pipe variant. */
+export function pipeVariantPair(v: PipeVariant): [PipeVariant, PipeVariant] {
+  return v.endsWith("H") ? [v.slice(0, -1) as PipeVariant, v] : [v, (v + "H") as PipeVariant];
+}
+
 export function resolvePipeType(variant: PipeVariant, pos: Position3D): PipeType | null {
   const axis = pipeAxisFromPos(pos);
   if (axis === null) return null;


### PR DESCRIPTION
## Summary
- Replaces the old `cycleCubeType` (R key) with `cycleBlock` (C key) that works at positions with 0-1 adjacent pipes
- Cycles through all valid block types (including Y cubes) plus an "undetermined" default state, which auto-determines when building in a direction
- Toolbar highlights the active block type and greys out invalid ones during build mode
- Ghost rendering at the cursor skips open pipe endpoint ghosts so only the pulsing cursor shows for undetermined/empty positions
- Keybind store migration handles the rename from `cycleCubeType` to `cycleBlock`

## Test plan
- [ ] Enter build mode, move to a position, press C — cycles through valid types + undetermined
- [ ] At undetermined, build in a direction — type auto-determined, new position is undetermined
- [ ] Toolbar highlights the selected block type; invalid types are greyed out
- [ ] Y cube appears in cycle when all adjacent pipes are Z-open
- [ ] Undo (Q) after cycling reverts correctly
- [ ] Press C at a position with 2+ pipes — nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)