### PR TITLE
Improve select mode camera control hints

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -135,10 +135,12 @@ function SelectModeHints() {
   const mode = useBlockStore((s) => s.mode);
   if (mode !== "select") return null;
 
+  const altKey = isMac ? "⌥ Option+" : "Alt+";
   const hints = [
     ["Click", "Select"],
     ["Drag", "Box select"],
-    ["Alt+Drag", "Orbit"],
+    [`${altKey}Drag`, "Orbit"],
+    ["Right Drag", "Pan"],
     ["Shift+Click", "Add/remove"],
     [`${modKey}A`, "Select all"],
     ["Delete", "Delete selected"],


### PR DESCRIPTION
## Summary
- Add missing "Right Drag → Pan" hint to the select mode hint bar so users know they can pan the camera
- Show "⌥ Option+Drag" on Mac instead of "Alt+Drag" for orbit, since Mac keyboards label the key as Option

## Test plan
- [ ] Switch to select mode and verify the hint bar shows the new pan hint and platform-aware orbit label
- [ ] Confirm right-drag pans and Option+drag orbits in select mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)