### PR TITLE
Restore Free Build toggle button in Toolbar

### DIFF
--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -69,6 +69,8 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
   const clearAll = useBlockStore((s) => s.clearAll);
   const loadBlocks = useBlockStore((s) => s.loadBlocks);
   const blocksEmpty = useBlockStore((s) => s.blocks.size === 0);
+  const freeBuild = useBlockStore((s) => s.freeBuild);
+  const toggleFreeBuild = useBlockStore((s) => s.toggleFreeBuild);
   const selectedCount = useBlockStore((s) => {
     if (s.selectedKeys.size === 0) return 0;
     let count = 0;
@@ -305,6 +307,20 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
           }}
         >
           {validationStatus === "loading" ? "Verifying..." : "Verify"}
+        </button>
+        <button
+          onClick={toggleFreeBuild}
+          title="Disable color-matching checks when placing blocks"
+          style={{
+            ...btnStyle(false),
+            fontSize: "10px",
+            padding: "2px 6px",
+            borderColor: freeBuild ? "#e67e22" : "#ccc",
+            background: freeBuild ? "#fdebd0" : "#fff",
+            color: freeBuild ? "#a04000" : "#333",
+          }}
+        >
+          Free Build {freeBuild ? "ON" : "OFF"}
         </button>
       </div>
 


### PR DESCRIPTION
## Summary
- The Free Build ON/OFF toggle button was accidentally removed from the Toolbar in #58
- Restores the `freeBuild` / `toggleFreeBuild` store selectors and the button UI in the Undo/Redo/Clear column

## Test plan
- [ ] Verify the "Free Build OFF" button appears in the toolbar
- [ ] Click it and confirm it toggles to "Free Build ON" with orange styling
- [ ] Place blocks with Free Build ON and verify color-matching validation is bypassed

🤖 Generated with [Claude Code](https://claude.com/claude-code)