### PR TITLE
Auto-switch to Hadamard pipe when building towards incompatible block

### DIFF
--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -25,6 +25,8 @@ import {
   CUBE_TYPES,
   PIPE_VARIANTS,
   VARIANT_AXIS_MAP,
+  toggleHadamard,
+  swapPipeVariant,
 } from "../types";
 
 export type Mode = "place" | "delete" | "select" | "build";
@@ -1006,7 +1008,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     }
 
     // Infer pipe type from source
-    const pipeType = inferPipeType(srcType, direction.tqecAxis);
+    let pipeType = inferPipeType(srcType, direction.tqecAxis);
     if (!pipeType) return false;
 
     // Validate pipe position and overlap
@@ -1038,7 +1040,30 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       } else if (destOptions.options.length > 0) {
         destTypeChange = { key: destKey, prevType: currentDestType, newType: destOptions.options[0] };
       } else {
-        return reject("Cube colors don't match the adjacent pipe"); // No valid type exists for dest with this pipe
+        // No valid dest type with current pipe — try Hadamard variant.
+        // For positive direction, source is at the head (not swapped by H) so
+        // a simple H toggle preserves the source match.
+        // For negative direction, source is at the tail (swapped by H) so we
+        // need the swapped-base + H variant to keep source colours intact.
+        const hPipeType: PipeType = direction.sign > 0
+          ? toggleHadamard(pipeType)
+          : (swapPipeVariant(pipeType) + "H") as PipeType;
+
+        tmpBlocks.set(pipeKey, { pos: pipePos, type: hPipeType });
+        const destOpts2 = determineCubeOptions(destPos, tmpBlocks);
+        if (destOpts2.determined) {
+          pipeType = hPipeType;
+          if (destOpts2.type !== currentDestType) {
+            destTypeChange = { key: destKey, prevType: currentDestType, newType: destOpts2.type };
+          }
+        } else if (destOpts2.options.includes(currentDestType)) {
+          pipeType = hPipeType;
+        } else if (destOpts2.options.length > 0) {
+          pipeType = hPipeType;
+          destTypeChange = { key: destKey, prevType: currentDestType, newType: destOpts2.options[0] };
+        } else {
+          return reject("Cube colors don't match the adjacent pipe");
+        }
       }
     } else {
       // Validate destination position and check for overlap with non-cube blocks

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -145,6 +145,11 @@ export function pipeVariantPair(v: PipeVariant): [PipeVariant, PipeVariant] {
   return v.endsWith("H") ? [v.slice(0, -1) as PipeVariant, v] : [v, (v + "H") as PipeVariant];
 }
 
+/** Toggle the Hadamard flag on a pipe type: OZX ↔ OZXH, etc. */
+export function toggleHadamard(pt: PipeType): PipeType {
+  return (pt.endsWith("H") ? pt.slice(0, -1) : pt + "H") as PipeType;
+}
+
 export function resolvePipeType(variant: PipeVariant, pos: Position3D): PipeType | null {
   const axis = pipeAxisFromPos(pos);
   if (axis === null) return null;


### PR DESCRIPTION
## Summary
- In build mode, when moving towards an existing block whose colors don't match the inferred non-Hadamard pipe, the system now automatically tries the Hadamard variant before rejecting the move
- For positive build directions, toggles the H flag on the same pipe base; for negative directions, uses the swapped-base + H variant so the source end stays compatible
- Adds a `toggleHadamard` utility to `types/index.ts`

## Test plan
- [ ] Place blocks and build towards an existing block where non-H pipe colors don't match — should auto-place hadamard pipe
- [ ] Verify this works in all 6 directions (±x, ±y, ±z)
- [ ] Verify undo correctly reverses the hadamard pipe placement
- [ ] Verify truly incompatible moves still show the error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)