### PR TITLE
Rename AI code policy to statement, add scan results

### DIFF
--- a/AI_CODE_STATEMENT.md
+++ b/AI_CODE_STATEMENT.md
@@ -28,6 +28,26 @@ This codebase was developed with significant assistance from AI coding tools (Cl
 
 **Result:** 8 internal clones found across 12 files (2.79% duplication rate). All duplications are within the project itself (test setup boilerplate and repeated utility logic). No cross-project similarity was flagged.
 
+### Web Source Similarity Scan (Codequiry)
+
+**Date:** 2026-04-15
+**Tool:** [Codequiry](https://codequiry.com) (API v1)
+
+**Scan 1 — Group Similarity (test_type=9):**
+- 5,201 lines scanned against ~25.8 billion indexed sources
+- Local matches: 0.00%
+- Web matches: 0.00%
+- Matches found: 0
+- AI detection score: 32%
+
+**Scan 2 — Web + Group Similarity (test_type=1):**
+- 5,201 lines scanned against ~25.5 billion indexed sources (GitHub, StackOverflow, Gist)
+- Local matches: 0.00%
+- Web matches: 2.91% (144 matches across ~2.1M similar files)
+- AI detection score: 32%
+
+**Result:** Near-zero web similarity. The 2.91% web match rate with 144 matches across millions of indexed files indicates common patterns (e.g., standard React/TypeScript idioms), not copied code. The 32% AI detection score is consistent with the disclosed AI-assisted development.
+
 ### Secret and Credential Scan (gitleaks v8)
 
 **Date:** 2026-04-15
@@ -52,7 +72,8 @@ All npm dependencies use permissive or weak copyleft licenses:
 
 - **scancode-toolkit** detects license text and copyright notices. It does not perform semantic code similarity analysis.
 - **jscpd** detects token-level code clones. It does not detect functionally equivalent but structurally different code.
-- Neither tool can guarantee that AI-generated code is entirely free of similarity to existing works. No tool can provide this guarantee for human-written code either.
+- **Codequiry** compares against a large web index but a low match percentage does not guarantee zero overlap with all existing code.
+- No tool can guarantee that AI-generated code is entirely free of similarity to existing works. No tool can provide this guarantee for human-written code either.
 - These scans reflect the state of the codebase at the time they were run. They should be re-run periodically and before major releases.
 
 ## Re-running Scans


### PR DESCRIPTION
## Summary
- Renames `AI_CODE_POLICY.md` to `AI_CODE_STATEMENT.md`
- Adds Codequiry web source similarity scan results (0% local matches, 2.91% web similarity)
- Adds Codequiry AI detection score (32%, consistent with disclosed AI usage)
- Adds limitation note for Codequiry

## Test plan
- [ ] Review document for accuracy and tone

🤖 Generated with [Claude Code](https://claude.com/claude-code)