### PR TITLE
Label Verify button as TQEC-backed and note backend in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ For now we follow the naming convention of cubes and pipes of TQEC. See [the ter
 The user can then press the **Export to Collada (.dae)** button.
 This package contains a test that verifies the exported `.dae` file is correctly understood by the TQEC package.
 
+The **Verify (TQEC)** button sends the current diagram to a FastAPI backend that builds a [`tqec.BlockGraph`](https://github.com/tqec/tqec) and reports per-cube validation errors.
+
 ## Getting started
 
 ### Prerequisites
@@ -35,6 +37,7 @@ This package contains a test that verifies the exported `.dae` file is correctly
 ### Usage
 - Assemble stack elements with drag-and-drop.
 - Export the design via the Collada export button to generate a `.dae` file.
+- Click **Verify (TQEC)** to run server-side validation via the [tqec](https://github.com/tqec/tqec) package; any errors are shown inline on the offending cubes.
 - Run the provided validation test to check `.dae` compatibility.
 
 ### Testing

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -291,6 +291,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
         <button
           onClick={runValidation}
           disabled={blocksEmpty || validationStatus === "loading"}
+          title="Server-side validation via the TQEC library"
           style={{
             ...btnStyle(false),
             opacity: blocksEmpty ? 0.4 : 1,
@@ -306,7 +307,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
               "#fff",
           }}
         >
-          {validationStatus === "loading" ? "Verifying..." : "Verify"}
+          {validationStatus === "loading" ? "Verifying..." : "Verify (TQEC)"}
         </button>
         <button
           onClick={toggleFreeBuild}


### PR DESCRIPTION
## Summary
- Renames the toolbar "Verify" button to "Verify (TQEC)" and adds a `title` tooltip ("Server-side validation via the TQEC library") so users can see at a glance that validation runs through the tqec backend.
- Adds two short notes in `README.md` (under *v0 Features* and *Getting started → Usage*) pointing at the tqec-powered `/api/validate` endpoint.

Closes #69.

## Test plan
- [ ] `npm run dev`, hover the button — tooltip reads the new text; label shows "Verify (TQEC)" / "Verifying…".
- [ ] Build an invalid diagram, click the button, confirm per-cube errors still surface.
- [ ] `uv run pytest tests/test_server.py` passes (backend unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)