### PR TITLE
chore: switch PR target to dev branch

### DIFF
--- a/.github/workflows/gui-pr-tests.yml
+++ b/.github/workflows/gui-pr-tests.yml
@@ -3,6 +3,7 @@ name: GUI PR Checks
 on:
   pull_request:
     branches:
+      - dev
       - main
 
 jobs:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,27 @@
+name: Python Tests
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  python-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@6b9c6063abd6010835c3544edc914d3eb8de8ea3 # v6
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.14
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Run tests
+        run: uv run pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to piper-draw
+
+## Branching strategy
+
+- **`dev`** is the integration branch. All pull requests should target `dev`.
+- **`main`** is the stable/release branch. Changes are merged from `dev` into `main` for releases.
+
+## How to contribute
+
+1. Create a feature branch from `dev`:
+   ```sh
+   git checkout dev
+   git pull origin dev
+   git checkout -b your-branch-name
+   ```
+2. Make your changes and commit them.
+3. Push your branch and open a pull request **targeting `dev`** (not `main`).
+4. Ensure CI checks pass before requesting review.
+
+## Development setup
+
+See the [README](README.md#getting-started) for prerequisites and setup instructions.
+
+## Testing
+
+Run the test suite before submitting your PR:
+
+```sh
+uv run pytest
+cd piper_draw/gui && npm run test
+```
+
+See the [README testing section](README.md#testing) for details on test conventions.


### PR DESCRIPTION
## Summary

Switches the project's branching strategy from main-only to a dev-first workflow:

- **CI/CD:** GUI PR tests now trigger on PRs to both `dev` and `main` (previously `main` only)
- **Python CI:** New workflow runs Python tests (`uv run pytest`) on push to `main`, acting as a release gate
- **Contributor guidelines:** New `CONTRIBUTING.md` documents the dev-first branching strategy, how to create feature branches, and how to run tests
- **GitHub default branch:** Changed from `main` to `dev` so new PRs target `dev` by default

## Pre-Landing Review
No issues found. 1 auto-fix from adversarial review (added `main` to GUI test branches so release merges are also tested).

## Test plan
- [x] All Python tests pass (42 tests)
- [x] All GUI tests pass (124 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)