### PR TITLE
Scale toolbar to fit narrow browser windows (fixes #48)

### DIFF
--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import { useBlockStore } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, PIPE_TYPE_TO_VARIANT } from "../types";
@@ -6,6 +7,48 @@ import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
 import * as THREE from "three";
 import { usePreviewImages } from "./PreviewRenderer";
+
+// ---------------------------------------------------------------------------
+// Responsive sizing
+// ---------------------------------------------------------------------------
+
+// Horizontal margin (px) kept between the toolbar and the viewport edges
+// when the toolbar is scaled down to fit a narrow window.
+const TOOLBAR_VIEWPORT_MARGIN_PX = 20;
+
+// Returns a CSS scale factor that keeps the toolbar at its natural size when
+// it fits in the viewport, and shrinks it just enough to fit when it doesn't.
+function useToolbarScale(toolbarRef: React.RefObject<HTMLDivElement | null>): number {
+  const [scale, setScale] = useState(1);
+  useEffect(() => {
+    let frame = 0;
+    const recompute = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        const node = toolbarRef.current;
+        if (!node) return;
+        // offsetWidth is the layout (untransformed) width — independent of
+        // the scale we apply, so this measurement is stable across renders.
+        const natural = node.offsetWidth;
+        if (natural === 0) return;
+        const available = window.innerWidth - TOOLBAR_VIEWPORT_MARGIN_PX;
+        setScale(Math.min(1, available / natural));
+      });
+    };
+    const node = toolbarRef.current;
+    const ro = node ? new ResizeObserver(recompute) : null;
+    if (node && ro) ro.observe(node);
+    window.addEventListener("resize", recompute);
+    recompute();
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener("resize", recompute);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [toolbarRef]);
+  return scale;
+}
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -56,6 +99,7 @@ const blockBtnStyle = (active: boolean, disabled?: boolean) => ({
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCamera: () => void; controlsRef: React.RefObject<any>; toolbarRef: React.RefObject<HTMLDivElement | null> }) {
+  const scale = useToolbarScale(toolbarRef);
   const mode = useBlockStore((s) => s.mode);
   const setMode = useBlockStore((s) => s.setMode);
   const cubeType = useBlockStore((s) => s.cubeType);
@@ -213,7 +257,8 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
         position: "fixed",
         top: 10,
         left: "50%",
-        transform: "translateX(-50%)",
+        transform: `translateX(-50%) scale(${scale})`,
+        transformOrigin: "top center",
         zIndex: 1,
         display: "flex",
         gap: "10px",


### PR DESCRIPTION
## Summary
- Fixes #48: parts of the toolbar were unreachable when the browser window was narrower than the toolbar's natural width.
- Adds a `useToolbarScale` hook that measures the toolbar's `offsetWidth` (via `ResizeObserver`) and tracks `window.innerWidth`, returning `min(1, (windowWidth - 20) / naturalWidth)`.
- The outer toolbar container applies `transform: translateX(-50%) scale(${scale})` with `transformOrigin: top center`, so the toolbar stays at its full original size when the window is wide enough and shrinks just enough to fit when it isn't. No layout, no wrapping, no breakpoints — single-row always.

## Tradeoff
At very narrow window widths the buttons get visually small (proportional shrink, never hidden). The toolbar always remains single-row and centered. If the smallest sizes become uncomfortable in practice, we can later add a floor (e.g. `Math.max(0.6, ...)`) and let the bar overflow / wrap below that.

## Test plan
- [ ] Open the app, drag the window from wide to narrow: toolbar stays at original size until the window is narrower than the toolbar, then shrinks proportionally.
- [ ] Verify all buttons remain clickable and on a single row at any width.
- [ ] Toggle Place / Select / Delete / Build modes — confirm Blocks and Pipes selectors still highlight and fire correctly while scaled.
- [ ] Resize while a long state is active (selection, Free Build ON, validation result) so the toolbar's natural width changes — scale should re-compute via the `ResizeObserver`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)