### PR TITLE
Fix zoom-out clipping on large diagrams (#73)

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -407,7 +407,7 @@ export default function App() {
       {keybindEditorOpen && <KeybindEditor onClose={() => setKeybindEditorOpen(false)} />}
       <PlacementWarning toolbarRef={toolbarRef} />
       <Canvas
-        camera={{ position: [14, 14, -14], fov: 35 }}
+        camera={{ position: [14, 14, -14], fov: 35, near: 0.1, far: 100000 }}
         gl={{ logarithmicDepthBuffer: true, toneMapping: THREE.ACESFilmicToneMapping }}
         onContextMenu={(e) => e.preventDefault()}
       >
@@ -429,7 +429,7 @@ export default function App() {
           <OrientationGizmo />
         </GizmoHelper>
         <ThreeStateBridge stateRef={threeStateRef} />
-        <OrbitControls ref={controlsRef} makeDefault />
+        <OrbitControls ref={controlsRef} makeDefault maxDistance={50000} />
       </Canvas>
       <MarqueeSelect threeStateRef={threeStateRef} controlsRef={controlsRef} />
     </>


### PR DESCRIPTION
## Summary
- Closes #73 (zoom-out disappearance portion).
- `<Canvas>` used R3F's default camera (`far = 2000`) and `<OrbitControls>` had no `maxDistance`, so dollying out pushed the scene past the far plane and the whole diagram vanished. Logarithmic depth buffer was already enabled, so raising `far` is safe.
- Set `near: 0.1, far: 100000` on the camera and `maxDistance: 50000` on OrbitControls as a sane upper bound.

## Follow-ups (not in this PR)
Issue #73 also asks to check RAM buildup. Audit done, not fixed here:
- `blockStore.history` / `future` retain full `Map<string, Block>` snapshots for `clear` / `load` commands (cap 100). On a 10k-block diagram that's ~50 MB of retention.
- `PreviewRenderer` regenerates 19 base64 PNG data URLs per throttled camera rotation (~15 fps).
- `batchedEdgesGeo` reallocates a fresh `Float32Array` on every blocks change (disposed correctly, but GC pressure at scale).

Happy to do these in a follow-up PR if desired.

## Test plan
- [x] `npm test` — 124/124 passing
- [x] `tsc -b` — clean
- [x] Dev server loads, no new console errors
- [ ] Manual: place a large diagram, zoom all the way out, confirm it stays visible