### PR TITLE
More visible pulsing + clear selection on mode change

### DIFF
--- a/piper_draw/gui/src/components/BuildCursor.tsx
+++ b/piper_draw/gui/src/components/BuildCursor.tsx
@@ -1,7 +1,7 @@
-import { useRef, useMemo } from "react";
+import { useMemo } from "react";
 import * as THREE from "three";
-import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
+import { usePulseScale } from "../hooks/usePulseScale";
 import { tqecToThree } from "../types";
 
 const cursorMaterial = new THREE.MeshBasicMaterial({
@@ -25,13 +25,7 @@ const noRaycast = () => {};
 
 /** Pulsing cursor at the build position */
 function CursorBox({ position }: { position: [number, number, number] }) {
-  const groupRef = useRef<THREE.Group>(null!);
-
-  useFrame(({ clock }) => {
-    if (!groupRef.current) return;
-    const pulse = 1.06 + 0.03 * Math.sin(clock.getElapsedTime() * 4);
-    groupRef.current.scale.setScalar(pulse);
-  });
+  const groupRef = usePulseScale();
 
   return (
     <group ref={groupRef} position={position}>

--- a/piper_draw/gui/src/components/InvalidBlockHighlights.tsx
+++ b/piper_draw/gui/src/components/InvalidBlockHighlights.tsx
@@ -1,8 +1,8 @@
-import { useRef, useMemo } from "react";
+import { useMemo } from "react";
 import * as THREE from "three";
-import { useFrame } from "@react-three/fiber";
 import { useValidationStore } from "../stores/validationStore";
 import { useBlockStore } from "../stores/blockStore";
+import { usePulseScale } from "../hooks/usePulseScale";
 import { tqecToThree, yBlockZOffset, blockThreeSize, posKey } from "../types";
 import type { BlockType, Position3D } from "../types";
 
@@ -57,14 +57,8 @@ function parseKey(key: string): Position3D | null {
 
 /** Pulsing red ghost cube for the currently selected error */
 function PulsingErrorBlock({ position, blockType }: { position: [number, number, number]; blockType: BlockType }) {
-  const groupRef = useRef<THREE.Group>(null!);
+  const groupRef = usePulseScale();
   const { box } = getHighlightGeo(blockType);
-
-  useFrame(({ clock }) => {
-    if (!groupRef.current) return;
-    const pulse = 1.06 + 0.03 * Math.sin(clock.getElapsedTime() * 4);
-    groupRef.current.scale.setScalar(pulse);
-  });
 
   return (
     <group ref={groupRef} position={position}>

--- a/piper_draw/gui/src/components/SelectionHighlights.tsx
+++ b/piper_draw/gui/src/components/SelectionHighlights.tsx
@@ -1,7 +1,7 @@
-import { useRef, useMemo } from "react";
+import { useMemo } from "react";
 import * as THREE from "three";
-import { useFrame } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
+import { usePulseScale } from "../hooks/usePulseScale";
 import { tqecToThree, yBlockZOffset, blockThreeSize, posKey } from "../types";
 import type { Block, BlockType } from "../types";
 
@@ -45,15 +45,9 @@ function PulsingHighlight({
   block: Block;
   zo: number;
 }) {
-  const groupRef = useRef<THREE.Group>(null!);
+  const groupRef = usePulseScale();
   const [tx, ty, tz] = tqecToThree(block.pos, block.type, zo);
   const { box, edges } = getHighlightGeo(block.type);
-
-  useFrame(({ clock }) => {
-    if (!groupRef.current) return;
-    const pulse = 1.0 + 0.02 * Math.sin(clock.getElapsedTime() * 4);
-    groupRef.current.scale.setScalar(pulse);
-  });
 
   return (
     <group ref={groupRef} position={[tx, ty, tz]}>

--- a/piper_draw/gui/src/hooks/usePulseScale.ts
+++ b/piper_draw/gui/src/hooks/usePulseScale.ts
@@ -1,0 +1,24 @@
+import { useRef } from "react";
+import * as THREE from "three";
+import { useFrame } from "@react-three/fiber";
+
+// Shared pulse parameters so every pulsing element looks the same.
+// Range: PULSE_BASE ± PULSE_AMPLITUDE = 1.02–1.18 — never below 1.02
+// so the highlight always stays larger than the underlying block.
+export const PULSE_BASE = 1.1;
+export const PULSE_AMPLITUDE = 0.08;
+export const PULSE_SPEED = 3;
+
+export function usePulseScale(
+  base = PULSE_BASE,
+  amplitude = PULSE_AMPLITUDE,
+  speed = PULSE_SPEED,
+) {
+  const groupRef = useRef<THREE.Group>(null!);
+  useFrame(({ clock }) => {
+    if (!groupRef.current) return;
+    const s = base + amplitude * Math.sin(clock.getElapsedTime() * speed);
+    groupRef.current.scale.setScalar(s);
+  });
+  return groupRef;
+}

--- a/piper_draw/gui/src/stores/blockStore.test.ts
+++ b/piper_draw/gui/src/stores/blockStore.test.ts
@@ -309,12 +309,12 @@ describe("blockStore", () => {
       expect(useBlockStore.getState().selectedKeys.size).toBe(0);
     });
 
-    it("preserves selection when switching to delete mode", () => {
+    it("clears selection when switching to delete mode", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.setState({ mode: "select" });
       useBlockStore.getState().selectBlock({ x: 0, y: 0, z: 0 }, false);
       useBlockStore.getState().setMode("delete");
-      expect(useBlockStore.getState().selectedKeys.size).toBe(1);
+      expect(useBlockStore.getState().selectedKeys.size).toBe(0);
     });
   });
 

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -269,7 +269,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       hoveredBlockType: null,
       hoveredInvalid: false,
       hoveredInvalidReason: null,
-      ...(mode === "place" ? { selectedKeys: new Set<string>() } : {}),
+      ...(mode !== "select" ? { selectedKeys: new Set<string>() } : {}),
     });
   },
   setCubeType: (cubeType) => set({ cubeType, pipeVariant: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),


### PR DESCRIPTION
## Summary
- Addresses #77 (pulses too subtle): unified pulse range bumped to 1.02–1.18 (peak ~2×, never smaller than the underlying block), slowed from ~0.64 Hz to ~0.48 Hz, and all three pulse sites (build cursor, selected validation error, selection highlight) now share a new `usePulseScale` hook.
- Fixes a bug where selecting blocks then switching to delete mode left the blue highlights behind; `setMode` now clears `selectedKeys` whenever leaving select mode.

## Test plan
- [ ] Build mode: cursor cube pulses noticeably larger, not too frantic
- [ ] Select a validation error: red highlight pulses with the same rhythm as the build cursor
- [ ] Select blocks → switch to delete mode: blue highlights go away immediately
- [ ] `npm test` passes (blockStore tests updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)