### PR TITLE
fix: confirm Clear + autosave diagram to localStorage (#76)

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -27,11 +27,14 @@ import { KeybindEditor } from "./components/KeybindEditor";
 import { HelpPanel } from "./components/HelpPanel";
 import { useBlockStore } from "./stores/blockStore";
 import { useKeybindStore, buildActionForKey, actionToWasdKey } from "./stores/keybindStore";
-import { wasdToBuildDirection, tqecToThree } from "./types";
+import { wasdToBuildDirection, tqecToThree, type Block } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 
 const GRID_SNAP = 3;
+
+const AUTOSAVE_KEY = "piper-draw:autosave:v1";
+const AUTOSAVE_DEBOUNCE_MS = 500;
 
 /**
  * Shader-based ground grid: dark grey cells at block positions (mod 3 ≡ 0),
@@ -376,6 +379,44 @@ export default function App() {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem(AUTOSAVE_KEY);
+      if (raw) {
+        const parsed = JSON.parse(raw);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          useBlockStore.getState().hydrateBlocks(new Map<string, Block>(parsed));
+        }
+      }
+    } catch {
+      localStorage.removeItem(AUTOSAVE_KEY);
+    }
+  }, []);
+
+  useEffect(() => {
+    let timeout: ReturnType<typeof setTimeout> | null = null;
+    const flush = (blocks: Map<string, Block>) => {
+      try {
+        localStorage.setItem(AUTOSAVE_KEY, JSON.stringify(Array.from(blocks.entries())));
+      } catch {
+        // Quota exceeded or storage unavailable — ignore.
+      }
+    };
+    const unsub = useBlockStore.subscribe((state, prev) => {
+      if (state.blocks === prev.blocks) return;
+      if (timeout !== null) clearTimeout(timeout);
+      const snapshot = state.blocks;
+      timeout = setTimeout(() => flush(snapshot), AUTOSAVE_DEBOUNCE_MS);
+    });
+    return () => {
+      if (timeout !== null) {
+        clearTimeout(timeout);
+        flush(useBlockStore.getState().blocks);
+      }
+      unsub();
+    };
   }, []);
 
   return (

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -318,7 +318,11 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
           Redo
         </button>
         <button
-          onClick={clearAll}
+          onClick={() => {
+            if (!window.confirm("Are you sure you want to delete the whole diagram?")) return;
+            clearAll();
+            onResetCamera();
+          }}
           disabled={blocksEmpty}
           style={{ ...btnStyle(false), opacity: blocksEmpty ? 0.4 : 1, cursor: blocksEmpty ? "default" : "pointer" }}
         >

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -121,6 +121,7 @@ interface BlockStore {
   undo: () => void;
   redo: () => void;
   loadBlocks: (blocks: Map<string, Block>) => void;
+  hydrateBlocks: (blocks: Map<string, Block>) => void;
   clearAll: () => void;
   canUndo: () => boolean;
   canRedo: () => boolean;
@@ -180,6 +181,29 @@ function doRemove(
   newHidden.delete(key);
   for (const [k, v] of affected) newHidden.set(k, v);
   return { blocks: newBlocks, hiddenFaces: newHidden };
+}
+
+function computeDerivedFromBlocks(blocks: Map<string, Block>): {
+  spatialIndex: SpatialIndex;
+  hiddenFaces: Map<string, FaceMask>;
+  undeterminedCubes: Map<string, UndeterminedCubeInfo>;
+} {
+  const spatialIndex = buildSpatialIndex(blocks);
+  const hiddenFaces: Map<string, FaceMask> = new Map();
+  for (const [key, block] of blocks) {
+    const mask = getHiddenFaceMaskForPos(block.pos, block.type, blocks, spatialIndex);
+    if (mask !== 0) hiddenFaces.set(key, mask);
+  }
+  const undeterminedCubes = new Map<string, UndeterminedCubeInfo>();
+  for (const [key, block] of blocks) {
+    if (isPipeType(block.type) || block.type === "Y") continue;
+    const opts = determineCubeOptions(block.pos, blocks);
+    if (!opts.determined && opts.options.length > 1) {
+      const idx = Math.max(0, opts.options.indexOf(block.type as CubeType));
+      undeterminedCubes.set(key, { options: [...opts.options], currentIndex: idx });
+    }
+  }
+  return { spatialIndex, hiddenFaces, undeterminedCubes };
 }
 
 export const useBlockStore = create<BlockStore>((set, get) => ({
@@ -798,39 +822,38 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   loadBlocks: (incoming) =>
     set((state) => {
       if (incoming.size === 0 && state.blocks.size === 0) return state;
-      const newIndex = buildSpatialIndex(incoming);
-      const newHidden: Map<string, FaceMask> = new Map();
-      for (const [key, block] of incoming) {
-        const mask = getHiddenFaceMaskForPos(block.pos, block.type, incoming, newIndex);
-        if (mask !== 0) newHidden.set(key, mask);
-      }
-      // Recompute undetermined state from loaded blocks
-      const newUndetermined = new Map<string, UndeterminedCubeInfo>();
-      for (const [key, block] of incoming) {
-        if (isPipeType(block.type) || block.type === "Y") continue;
-        const opts = determineCubeOptions(block.pos, incoming);
-        if (!opts.determined && opts.options.length > 1) {
-          const idx = Math.max(0, opts.options.indexOf(block.type as CubeType));
-          newUndetermined.set(key, { options: [...opts.options], currentIndex: idx });
-        }
-      }
+      const { spatialIndex, hiddenFaces, undeterminedCubes } = computeDerivedFromBlocks(incoming);
       const cmd: UndoCommand = {
         kind: "load",
         savedBlocks: state.blocks,
         savedHiddenFaces: state.hiddenFaces,
         savedUndetermined: state.undeterminedCubes,
         newBlocks: incoming,
-        newIndex,
-        newHiddenFaces: newHidden,
+        newIndex: spatialIndex,
+        newHiddenFaces: hiddenFaces,
       };
       return {
         blocks: incoming,
-        spatialIndex: newIndex,
-        hiddenFaces: newHidden,
+        spatialIndex,
+        hiddenFaces,
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
         hoveredGridPos: null,
-        undeterminedCubes: newUndetermined,
+        undeterminedCubes,
+      };
+    }),
+
+  hydrateBlocks: (incoming) =>
+    set((state) => {
+      if (incoming.size === 0) return state;
+      const { spatialIndex, hiddenFaces } = computeDerivedFromBlocks(incoming);
+      return {
+        blocks: incoming,
+        spatialIndex,
+        hiddenFaces,
+        hoveredGridPos: null,
+        selectedKeys: new Set<string>(),
+        undeterminedCubes: new Map(),
       };
     }),
 

--- a/scripts/generate_templates.py
+++ b/scripts/generate_templates.py
@@ -23,7 +23,12 @@ TEMPLATES = [
     ("cz.dae", "CZ", gallery.cz, "Logical CZ gate."),
     ("move_rotation.dae", "Move + Rotation", gallery.move_rotation, "Patch move and rotation."),
     ("three_cnots.dae", "Three CNOTs", gallery.three_cnots, "Three logical CNOTs in sequence."),
-    ("steane_encoding.dae", "Steane Encoding", gallery.steane_encoding, "Steane code encoding circuit compressed in spacetime."),
+    (
+        "steane_encoding.dae",
+        "Steane Encoding",
+        gallery.steane_encoding,
+        "Steane code encoding circuit compressed in spacetime.",
+    ),
 ]
 
 


### PR DESCRIPTION
Closes #76.

## Summary
- **Clear button confirmation** — the toolbar Clear now prompts `window.confirm("Are you sure you want to delete the whole diagram?")` before wiping. On confirm, it also snaps the camera back to the origin view (reusing the existing Origin button's `controlsRef.reset()`).
- **Autosave to `localStorage`** — diagram is persisted under the key `piper-draw:autosave:v1` on every change, debounced 500 ms to avoid thrashing during drag-builds. Restored automatically on page reload. Clearing writes an empty array so a Clear + reload stays empty.
- **New `hydrateBlocks` action** — rehydrates `blocks` + rebuilds `spatialIndex` / `hiddenFaces` without pushing to undo history (so Undo after reload can't empty the restored diagram) and without recomputing `undeterminedCubes` (so saved cubes keep their user-chosen type rather than rendering as ghosts). A new helper `computeDerivedFromBlocks` is also reused by `loadBlocks` to consolidate the shared derived-state logic.

## Scope & limits
- Only `blocks` is persisted. Camera, mode, selection, and undo history are **not** restored across reloads.
- `localStorage` is per-origin browser storage; private windows, different browsers/machines, or "clear site data" will wipe it. No file is written to disk.
- Corrupt JSON in the storage key is silently discarded and the app boots empty.

## Test plan
- [ ] Place several blocks. Click **Clear** — native confirm appears with the expected wording.
- [ ] Cancel the confirm — nothing happens.
- [ ] Confirm — diagram empties **and** camera snaps to the isometric origin view.
- [ ] With blocks present, reload the page — diagram is restored, cubes render solid (not ghost), pipe color constraints still enforced.
- [ ] After reload, **Undo** is disabled / does not bring back the previous session's blocks.
- [ ] Clear + confirm, then reload — diagram stays empty.
- [ ] Manually corrupt `localStorage['piper-draw:autosave:v1']` and reload — app boots cleanly, key is removed.
- [ ] `npm run build` passes; `npm test` passes (130 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)