### PR TITLE
Use lowercase "tqec" in Verify button label

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For now we follow the naming convention of cubes and pipes of TQEC. See [the ter
 The user can then press the **Export to Collada (.dae)** button.
 This package contains a test that verifies the exported `.dae` file is correctly understood by the TQEC package.
 
-The **Verify (TQEC)** button sends the current diagram to a FastAPI backend that builds a [`tqec.BlockGraph`](https://github.com/tqec/tqec) and reports per-cube validation errors.
+The **Verify (tqec)** button sends the current diagram to a FastAPI backend that builds a [`tqec.BlockGraph`](https://github.com/tqec/tqec) and reports per-cube validation errors.
 
 ## Getting started
 
@@ -37,7 +37,7 @@ The **Verify (TQEC)** button sends the current diagram to a FastAPI backend that
 ### Usage
 - Assemble stack elements with drag-and-drop.
 - Export the design via the Collada export button to generate a `.dae` file.
-- Click **Verify (TQEC)** to run server-side validation via the [tqec](https://github.com/tqec/tqec) package; any errors are shown inline on the offending cubes.
+- Click **Verify (tqec)** to run server-side validation via the [tqec](https://github.com/tqec/tqec) package; any errors are shown inline on the offending cubes.
 - Run the provided validation test to check `.dae` compatibility.
 - Use the **Templates** button in the toolbar to load a bundled example diagram (CNOT, CZ, move + rotation, three CNOTs, Steane encoding) and edit it as a starting point.
 

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -355,7 +355,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
               "#fff",
           }}
         >
-          {validationStatus === "loading" ? "Verifying..." : "Verify (TQEC)"}
+          {validationStatus === "loading" ? "Verifying..." : "Verify (tqec)"}
         </button>
         <button
           onClick={toggleFreeBuild}


### PR DESCRIPTION
Renames the **Verify (TQEC)** button to **Verify (tqec)** to match the upstream [tqec](https://github.com/tqec/tqec) repo's lowercase convention. Also updates the two matching references in `README.md` for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)