### PR TITLE
Editable X/Y/Z inputs in Position toolbar

### DIFF
--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -126,6 +126,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
   const deleteSelected = useBlockStore((s) => s.deleteSelected);
 
   const buildCursor = useBlockStore((s) => s.buildCursor);
+  const moveBuildCursor = useBlockStore((s) => s.moveBuildCursor);
   const buildCursorBlockType = useBlockStore((s) => {
     if (s.mode !== "build" || !s.buildCursor) return null;
     // Undetermined cubes should not highlight any button
@@ -460,9 +461,11 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
       <div style={{ width: 1, background: "#ddd" }} />
       <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", fontFamily: "monospace", fontSize: "12px", color: "#555", lineHeight: "1.6", minWidth: 90 }}>
         <span style={groupLabelStyle}>Position</span>
-        {(() => {
-          const pos: Position3D | null = mode === "build" ? buildCursor : hoveredGridPos;
-          const bt: BlockType | null = mode === "build" ? null : useBlockStore.getState().hoveredBlockType;
+        {mode === "build" && buildCursor ? (
+          <PositionEditor pos={buildCursor} onCommit={moveBuildCursor} />
+        ) : (() => {
+          const pos: Position3D | null = hoveredGridPos;
+          const bt: BlockType | null = useBlockStore.getState().hoveredBlockType;
           if (!pos) return <><span>X: —</span><span>Y: —</span><span>Z: —</span></>;
           const isPipe = bt ? isPipeType(bt) : pipeAxisFromPos(pos) !== null;
           if (isPipe) {
@@ -483,6 +486,76 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
       </div>
     </div>
   );
+}
+
+// ---------------------------------------------------------------------------
+// PositionEditor — editable X/Y/Z inputs for the build cursor
+// ---------------------------------------------------------------------------
+
+function PositionEditor({ pos, onCommit }: { pos: Position3D; onCommit: (p: Position3D) => void }) {
+  const [draft, setDraft] = useState<{ x?: string; y?: string; z?: string }>({});
+
+  const valueOf = (k: "x" | "y" | "z") => draft[k] ?? String(pos[k] / 3);
+
+  const commit = () => {
+    const parse = (s: string): number | null => {
+      if (s.trim() === "") return null;
+      const n = Number(s);
+      return Number.isInteger(n) ? n : null;
+    };
+    const nx = draft.x !== undefined ? parse(draft.x) : pos.x / 3;
+    const ny = draft.y !== undefined ? parse(draft.y) : pos.y / 3;
+    const nz = draft.z !== undefined ? parse(draft.z) : pos.z / 3;
+    if (nx === null || ny === null || nz === null) {
+      setDraft({});
+      return;
+    }
+    if (nx * 3 !== pos.x || ny * 3 !== pos.y || nz * 3 !== pos.z) {
+      onCommit({ x: nx * 3, y: ny * 3, z: nz * 3 });
+    }
+    setDraft({});
+  };
+
+  const onContainerBlur = (e: React.FocusEvent<HTMLDivElement>) => {
+    // Focus moving to another input inside the group → don't commit yet
+    if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
+    commit();
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      commit();
+      e.currentTarget.blur();
+    } else if (e.key === "Escape") {
+      setDraft({});
+      e.currentTarget.blur();
+    }
+  };
+
+  const axisRow = (k: "x" | "y" | "z") => (
+    <label key={k} style={{ display: "flex", alignItems: "center", gap: 4 }}>
+      {k.toUpperCase()}:
+      <input
+        type="number"
+        step={1}
+        value={valueOf(k)}
+        onChange={(e) => setDraft((d) => ({ ...d, [k]: e.target.value }))}
+        onKeyDown={onKeyDown}
+        style={{
+          width: 42,
+          fontFamily: "monospace",
+          fontSize: 12,
+          padding: "1px 2px",
+          border: "1px solid #ccc",
+          borderRadius: 2,
+          background: "#fff",
+          color: "#333",
+        }}
+      />
+    </label>
+  );
+
+  return <div onBlur={onContainerBlur}>{axisRow("x")}{axisRow("y")}{axisRow("z")}</div>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- In build mode, the X/Y/Z values in the Position panel become integer inputs that jump the build cursor to the typed coordinates.
- All three axes commit together — on Enter or when focus leaves the input group — so editing x, y, and z in sequence triggers one `moveBuildCursor` call (one camera animation), not three.
- Escape discards the draft; invalid/empty input resets without moving. Non-build modes keep the existing read-only display (including pipe `0 → 2` ranges).

## Test plan
- [ ] In build mode, click X, type a value, press Enter — cursor jumps, camera animates once.
- [ ] Click X, type, Tab to Y, type, Tab to Z, type, click outside — single camera animation, final position matches all three typed values.
- [ ] Press Escape while editing — draft is discarded, no jump.
- [ ] Type non-integer (e.g. `abc`, `1.5`) and blur — no jump, no crash.
- [ ] Switch to place/select/delete — Position panel shows read-only text as before (pipe hover still shows ranges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)