### PR TITLE
feat: SketchUp-style elevation (iso) views

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -36,6 +36,7 @@ import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 import {
   ISO_INITIAL_ZOOM,
+  isoBuildDirection,
   isoCameraThree,
   isoGridMeshTransform,
   isoTargetThree,
@@ -480,9 +481,10 @@ export default function App() {
             case "moveDown": {
               const controls = controlsRef.current;
               if (!controls) return;
-              const azimuth = controls.getAzimuthalAngle();
               const dirKey = actionToWasdKey(action);
-              const direction = wasdToBuildDirection(dirKey, azimuth);
+              const direction = store.viewMode.kind === "iso"
+                ? isoBuildDirection(dirKey, store.viewMode.axis)
+                : wasdToBuildDirection(dirKey, controls.getAzimuthalAngle());
               store.buildMove(direction);
               return;
             }

--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -8,6 +8,8 @@ THREE.ColorManagement.enabled = false;
 import {
   OrbitControls,
   GizmoHelper,
+  PerspectiveCamera,
+  OrthographicCamera,
 } from "@react-three/drei";
 import { BlockInstances } from "./components/BlockInstances";
 import { GridPlane } from "./components/GridPlane";
@@ -22,111 +24,256 @@ import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
 import { MarqueeSelect, type ThreeState } from "./components/MarqueeSelect";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
+import { FoldOutCubeOverlay } from "./components/FoldOutCubeOverlay";
 import { BuildModeHints } from "./components/BuildModeHints";
 import { KeybindEditor } from "./components/KeybindEditor";
 import { HelpPanel } from "./components/HelpPanel";
 import { useBlockStore } from "./stores/blockStore";
 import { useKeybindStore, buildActionForKey, actionToWasdKey } from "./stores/keybindStore";
 import { wasdToBuildDirection, tqecToThree } from "./types";
+import type { ViewMode } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
+import {
+  ISO_INITIAL_ZOOM,
+  isoCameraThree,
+  isoGridMeshTransform,
+  isoTargetThree,
+  isoUpThree,
+} from "./utils/isoView";
 
 const GRID_SNAP = 3;
 
 /**
- * Shader-based ground grid: dark grey cells at block positions (mod 3 ≡ 0),
+ * Shader-based grid mesh: dark grey cells at block positions (mod 3 ≡ 0),
  * light grey cells at pipe positions (mod 3 ≡ 1), with light edges on each cell.
- * No separate grid lines — the edge border provides the visual structure.
+ * Uses two world-space basis vectors as uniforms so the same shader can render
+ * the floor (TQEC X/Y) or any iso-view plane.
  */
-const gridMaterial = new THREE.ShaderMaterial({
-  transparent: true,
-  depthWrite: false,
-  vertexShader: `
-    varying vec3 vWorldPos;
-    void main() {
-      vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
-      gl_Position = projectionMatrix * viewMatrix * vec4(vWorldPos, 1.0);
-    }
-  `,
-  fragmentShader: `
-    varying vec3 vWorldPos;
-    float pmod(float a, float b) { return a - b * floor(a / b); }
-    void main() {
-      // TQEC coords: x = Three.js x, y = -Three.js z
-      float tx = vWorldPos.x;
-      float ty = -vWorldPos.z;
-      float mx = pmod(floor(tx), 3.0);
-      float my = pmod(floor(ty), 3.0);
-
-      bool xBlock = mx < 0.5;
-      bool yBlock = my < 0.5;
-      // Pipes span 2 cells: mod 3 ≡ 1 and ≡ 2
-      bool xPipe = mx > 0.5;
-      bool yPipe = my > 0.5;
-
-      bool isBlock = xBlock && yBlock;
-      bool isPipe = (xPipe && yBlock) || (xBlock && yPipe);
-
-      if (!isBlock && !isPipe) discard;
-
-      // Edge detection: for pipe cells, treat the 2-unit span as one tile
-      // so the internal boundary between ≡ 1 and ≡ 2 cells is suppressed.
-      float fx = fract(tx);
-      float fy = fract(ty);
-      float edgeWidth = 0.03;
-
-      float edgeX, edgeY;
-      if (isPipe && xPipe) {
-        // Pipe spans x from pmod 1..3; remap to 0..2
-        float px = pmod(tx, 3.0) - 1.0;
-        edgeX = min(px, 2.0 - px);
-      } else {
-        edgeX = min(fx, 1.0 - fx);
+function makeGridMaterial(): THREE.ShaderMaterial {
+  return new THREE.ShaderMaterial({
+    transparent: true,
+    depthWrite: false,
+    uniforms: {
+      // World-space directions whose dot products with vWorldPos give the two
+      // in-plane TQEC coordinates used for the mod-3 checkerboard.
+      axisU: { value: new THREE.Vector3(1, 0, 0) },   // TQEC X
+      axisV: { value: new THREE.Vector3(0, 0, -1) },  // TQEC Y
+      // Center used for the distance fade (orbit target along the in-plane axes).
+      fadeCenter: { value: new THREE.Vector3(0, 0, 0) },
+    },
+    vertexShader: `
+      varying vec3 vWorldPos;
+      void main() {
+        vWorldPos = (modelMatrix * vec4(position, 1.0)).xyz;
+        gl_Position = projectionMatrix * viewMatrix * vec4(vWorldPos, 1.0);
       }
-      if (isPipe && yPipe) {
-        float py = pmod(ty, 3.0) - 1.0;
-        edgeY = min(py, 2.0 - py);
-      } else {
-        edgeY = min(fy, 1.0 - fy);
+    `,
+    fragmentShader: `
+      uniform vec3 axisU;
+      uniform vec3 axisV;
+      uniform vec3 fadeCenter;
+      varying vec3 vWorldPos;
+      float pmod(float a, float b) { return a - b * floor(a / b); }
+      void main() {
+        float tx = dot(axisU, vWorldPos);
+        float ty = dot(axisV, vWorldPos);
+        float mx = pmod(floor(tx), 3.0);
+        float my = pmod(floor(ty), 3.0);
+
+        bool xBlock = mx < 0.5;
+        bool yBlock = my < 0.5;
+        bool xPipe = mx > 0.5;
+        bool yPipe = my > 0.5;
+
+        bool isBlock = xBlock && yBlock;
+        bool isPipe = (xPipe && yBlock) || (xBlock && yPipe);
+
+        if (!isBlock && !isPipe) discard;
+
+        float fx = fract(tx);
+        float fy = fract(ty);
+        float edgeWidth = 0.03;
+
+        float edgeX, edgeY;
+        if (isPipe && xPipe) {
+          float px = pmod(tx, 3.0) - 1.0;
+          edgeX = min(px, 2.0 - px);
+        } else {
+          edgeX = min(fx, 1.0 - fx);
+        }
+        if (isPipe && yPipe) {
+          float py = pmod(ty, 3.0) - 1.0;
+          edgeY = min(py, 2.0 - py);
+        } else {
+          edgeY = min(fy, 1.0 - fy);
+        }
+
+        float edgeDist = min(edgeX, edgeY);
+        bool onEdge = edgeDist < edgeWidth;
+
+        if (onEdge) {
+          gl_FragColor = vec4(0.85, 0.85, 0.85, 0.35);
+        } else if (isBlock) {
+          gl_FragColor = vec4(0.45, 0.45, 0.45, 0.18);
+        } else {
+          gl_FragColor = vec4(0.65, 0.65, 0.65, 0.12);
+        }
+
+        // Fade by distance from center along in-plane axes only.
+        vec3 d = vWorldPos - fadeCenter;
+        float du = dot(axisU, d);
+        float dv = dot(axisV, d);
+        float dist = sqrt(du * du + dv * dv);
+        float fade = 1.0 - smoothstep(100.0, 300.0, dist);
+        gl_FragColor.a *= fade;
       }
+    `,
+  });
+}
 
-      float edgeDist = min(edgeX, edgeY);
-      bool onEdge = edgeDist < edgeWidth;
-
-      if (onEdge) {
-        // Light edge
-        gl_FragColor = vec4(0.85, 0.85, 0.85, 0.35);
-      } else if (isBlock) {
-        // Dark grey fill
-        gl_FragColor = vec4(0.45, 0.45, 0.45, 0.18);
-      } else {
-        // Light grey fill
-        gl_FragColor = vec4(0.65, 0.65, 0.65, 0.12);
-      }
-
-      // Fade with distance from origin for a clean look
-      float dist = length(vWorldPos.xz);
-      float fade = 1.0 - smoothstep(100.0, 300.0, dist);
-      gl_FragColor.a *= fade;
-    }
-  `,
-});
+const gridMaterial = makeGridMaterial();
 
 function CheckerboardGrid() {
   const ref = useRef<THREE.Mesh>(null!);
   const target = useRef(new THREE.Vector3());
-  useFrame(({ camera }) => {
-    if (!ref.current) return;
-    if (cameraGroundPoint(camera, target.current)) {
-      ref.current.position.x = Math.round(target.current.x / GRID_SNAP) * GRID_SNAP;
-      ref.current.position.z = Math.round(target.current.z / GRID_SNAP) * GRID_SNAP;
+  const viewMode = useBlockStore((s) => s.viewMode);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const controls = useThree((s) => s.controls) as any;
+
+  // Update shader uniforms whenever the active plane changes.
+  useEffect(() => {
+    const u = gridMaterial.uniforms;
+    if (viewMode.kind === "persp" || viewMode.axis === "z") {
+      u.axisU.value.set(1, 0, 0);
+      u.axisV.value.set(0, 0, -1);
+    } else if (viewMode.axis === "x") {
+      u.axisU.value.set(0, 0, -1);  // TQEC Y = -Three Z
+      u.axisV.value.set(0, 1, 0);   // TQEC Z =  Three Y
+    } else {
+      u.axisU.value.set(1, 0, 0);   // TQEC X
+      u.axisV.value.set(0, 1, 0);   // TQEC Z
     }
+  }, [viewMode]);
+
+  useFrame(({ camera }) => {
+    const mesh = ref.current;
+    if (!mesh) return;
+    const u = gridMaterial.uniforms;
+    if (viewMode.kind === "persp") {
+      if (cameraGroundPoint(camera, target.current)) {
+        mesh.position.x = Math.round(target.current.x / GRID_SNAP) * GRID_SNAP;
+        mesh.position.z = Math.round(target.current.z / GRID_SNAP) * GRID_SNAP;
+        mesh.position.y = 0.001;
+        u.fadeCenter.value.set(mesh.position.x, 0, mesh.position.z);
+      }
+      return;
+    }
+    // Iso mode: align mesh with active slice plane; follow orbit target along in-plane axes.
+    const ot: THREE.Vector3 | undefined = controls?.target;
+    const axis = viewMode.axis;
+    const slice = viewMode.slice;
+    if (axis === "x") {
+      mesh.position.x = slice + 0.001;
+      mesh.position.y = ot ? Math.round(ot.y / GRID_SNAP) * GRID_SNAP : 0;
+      mesh.position.z = ot ? Math.round(ot.z / GRID_SNAP) * GRID_SNAP : 0;
+    } else if (axis === "y") {
+      mesh.position.x = ot ? Math.round(ot.x / GRID_SNAP) * GRID_SNAP : 0;
+      mesh.position.y = ot ? Math.round(ot.y / GRID_SNAP) * GRID_SNAP : 0;
+      mesh.position.z = -slice - 0.001;
+    } else {
+      mesh.position.x = ot ? Math.round(ot.x / GRID_SNAP) * GRID_SNAP : 0;
+      mesh.position.y = slice + 0.001;
+      mesh.position.z = ot ? Math.round(ot.z / GRID_SNAP) * GRID_SNAP : 0;
+    }
+    u.fadeCenter.value.copy(mesh.position);
   });
+
+  const rotation: [number, number, number] = viewMode.kind === "persp"
+    ? [-Math.PI / 2, 0, 0]
+    : isoGridMeshTransform(viewMode.axis).rotation;
+
   return (
-    <mesh ref={ref} rotation-x={-Math.PI / 2} position={[0, 0.001, 0]}>
+    <mesh ref={ref} rotation={rotation}>
       <planeGeometry args={[500, 500]} />
       <primitive object={gridMaterial} attach="material" />
     </mesh>
+  );
+}
+
+/**
+ * Camera + controls that swap based on viewMode. PerspectiveCamera for free-orbit
+ * 3D mode; OrthographicCamera for axis-locked elevation views with rotation disabled.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function ViewportCamera({ controlsRef }: { controlsRef: React.RefObject<any> }) {
+  const viewMode = useBlockStore((s) => s.viewMode);
+  if (viewMode.kind === "persp") {
+    return (
+      <>
+        <PerspectiveCamera
+          makeDefault
+          position={[14, 14, -14]}
+          fov={35}
+          near={0.1}
+          far={100000}
+        />
+        <OrbitControls
+          ref={controlsRef}
+          makeDefault
+          enableRotate
+          maxDistance={50000}
+        />
+      </>
+    );
+  }
+  return <IsoViewport viewMode={viewMode} controlsRef={controlsRef} />;
+}
+
+function IsoViewport({
+  viewMode,
+  controlsRef,
+}: {
+  viewMode: Extract<ViewMode, { kind: "iso" }>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  controlsRef: React.RefObject<any>;
+}) {
+  const cameraRef = useRef<THREE.OrthographicCamera>(null);
+
+  // Position the orthographic camera + orbit target whenever the iso slice/axis changes.
+  useEffect(() => {
+    const cam = cameraRef.current;
+    const ctrl = controlsRef.current;
+    if (!cam) return;
+    const target = isoTargetThree(viewMode);
+    const pos = isoCameraThree(viewMode);
+    cam.up.copy(isoUpThree(viewMode.axis));
+    cam.position.copy(pos);
+    cam.lookAt(target);
+    cam.updateProjectionMatrix();
+    if (ctrl) {
+      ctrl.target.copy(target);
+      ctrl.update();
+    }
+  }, [viewMode, controlsRef]);
+
+  return (
+    <>
+      <OrthographicCamera
+        ref={cameraRef}
+        makeDefault
+        near={0.1}
+        far={100000}
+        zoom={ISO_INITIAL_ZOOM}
+      />
+      <OrbitControls
+        ref={controlsRef}
+        makeDefault
+        enableRotate={false}
+        maxZoom={500}
+        minZoom={2}
+      />
+    </>
   );
 }
 
@@ -193,13 +340,18 @@ function SelectModeHints() {
 
 /**
  * Snaps the camera to the build direction target when cameraSnapTarget changes.
- * Uses OrbitControls to set azimuthal angle and target position.
+ * In perspective mode, animates camera + orbit target. In iso mode, the camera
+ * is locked to the active slice — instead of moving the camera, advance the
+ * slice when the cursor moves along the depth axis (the IsoViewport effect
+ * then re-positions the ortho camera to follow).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> }) {
   const cameraSnapTarget = useBlockStore((s) => s.cameraSnapTarget);
   const lastBuildAxis = useBlockStore((s) => s.lastBuildAxis);
   const clearCameraSnap = useBlockStore((s) => s.clearCameraSnap);
+  const viewMode = useBlockStore((s) => s.viewMode);
+  const stepSlice = useBlockStore((s) => s.stepSlice);
   const { camera } = useThree();
   const prevTarget = useRef<{ azimuth: number | null; targetPos: { x: number; y: number; z: number } } | null>(null);
   const prevBuildAxis = useRef<number | null>(null);
@@ -208,6 +360,16 @@ function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> })
     if (!cameraSnapTarget || !controlsRef.current) return;
     if (prevTarget.current === cameraSnapTarget) return;
     prevTarget.current = cameraSnapTarget;
+
+    if (viewMode.kind === "iso") {
+      const target = cameraSnapTarget.targetPos;
+      const cursorDepth =
+        viewMode.axis === "x" ? target.x : viewMode.axis === "y" ? target.y : target.z;
+      const delta = cursorDepth - viewMode.slice;
+      if (delta !== 0) stepSlice(delta);
+      clearCameraSnap();
+      return;
+    }
 
     const controls = controlsRef.current;
     const [tx, ty, tz] = tqecToThree(cameraSnapTarget.targetPos, "XZZ");
@@ -356,6 +518,12 @@ export default function App() {
           }
           return;
         }
+        // Slice stepping in iso mode: [ decreases, ] increases.
+        if ((key === "[" || key === "]") && store.viewMode.kind === "iso") {
+          e.preventDefault();
+          store.stepSlice(key === "]" ? 3 : -3);
+          return;
+        }
         return;
       }
 
@@ -439,7 +607,6 @@ export default function App() {
       {keybindEditorOpen && <KeybindEditor onClose={() => setKeybindEditorOpen(false)} />}
       <PlacementWarning toolbarRef={toolbarRef} />
       <Canvas
-        camera={{ position: [14, 14, -14], fov: 35, near: 0.1, far: 100000 }}
         gl={{ logarithmicDepthBuffer: true, toneMapping: THREE.ACESFilmicToneMapping }}
         onContextMenu={(e) => e.preventDefault()}
       >
@@ -447,6 +614,7 @@ export default function App() {
         <ambientLight intensity={1.4} />
         <directionalLight position={[10, 10, 10]} intensity={1.0} />
         <BlockInstances />
+        <FoldOutCubeOverlay />
         <InvalidBlockHighlights />
         <SelectionHighlights />
         <BuildCursor />
@@ -461,7 +629,7 @@ export default function App() {
           <OrientationGizmo />
         </GizmoHelper>
         <ThreeStateBridge stateRef={threeStateRef} />
-        <OrbitControls ref={controlsRef} makeDefault maxDistance={50000} />
+        <ViewportCamera controlsRef={controlsRef} />
       </Canvas>
       <MarqueeSelect threeStateRef={threeStateRef} controlsRef={controlsRef} />
     </>

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -21,6 +21,10 @@ import {
   VARIANT_AXIS_MAP,
 } from "../types";
 import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant } from "../types";
+import { posInActiveSlice } from "../utils/isoView";
+
+const DIMMED_OPACITY = 0.18;
+const DIMMED_EDGE_OPACITY = 0.25;
 
 const MIN_CAPACITY = 64;
 
@@ -32,6 +36,12 @@ const geometryCache = new Map<string, THREE.BufferGeometry>();
 const fullBoxCache = new Map<BlockType, THREE.BoxGeometry>();
 const edgesCache = new Map<string, THREE.BufferGeometry>();
 const edgeLineMaterial = new THREE.LineBasicMaterial({ color: "#000000" });
+const dimmedEdgeLineMaterial = new THREE.LineBasicMaterial({
+  color: "#000000",
+  transparent: true,
+  opacity: DIMMED_EDGE_OPACITY,
+  depthWrite: false,
+});
 
 function resolvePipeTypeFromFace(
   srcPos: Position3D,
@@ -85,11 +95,13 @@ function TypedInstances({
   blocks,
   hiddenFaces,
   allBlocks,
+  dimmed,
 }: {
   cubeType: BlockType;
   blocks: Block[];
   hiddenFaces: FaceMask;
   allBlocks: Map<string, Block>;
+  dimmed: boolean;
 }) {
   const meshRef = useRef<THREE.InstancedMesh>(null!);
   const blocksRef = useRef(blocks);
@@ -111,8 +123,14 @@ function TypedInstances({
     () => new THREE.MeshLambertMaterial({
       vertexColors: true,
       side: THREE.DoubleSide,
+      transparent: dimmed,
+      opacity: dimmed ? DIMMED_OPACITY : 1,
+      depthWrite: !dimmed,
+      polygonOffset: true,
+      polygonOffsetFactor: 1,
+      polygonOffsetUnits: 1,
     }),
-    [],
+    [dimmed],
   );
   const dummy = useMemo(() => new THREE.Matrix4(), []);
 
@@ -328,7 +346,7 @@ function TypedInstances({
         onClick={handleClick}
       />
       {batchedEdgesGeo && (
-        <lineSegments geometry={batchedEdgesGeo} material={edgeLineMaterial} />
+        <lineSegments geometry={batchedEdgesGeo} material={dimmed ? dimmedEdgeLineMaterial : edgeLineMaterial} />
       )}
     </>
   );
@@ -338,20 +356,21 @@ export function BlockInstances() {
   const blocks = useBlockStore((s) => s.blocks);
   const hiddenFaces = useBlockStore((s) => s.hiddenFaces);
   const undeterminedCubes = useBlockStore((s) => s.undeterminedCubes);
+  const viewMode = useBlockStore((s) => s.viewMode);
 
   const grouped = useMemo(() => {
     type Group = {
       type: BlockType;
       hiddenFaces: FaceMask;
+      dimmed: boolean;
       blocks: Block[];
     };
-    // Hidden faces are pre-computed in the store — just group by (type, mask)
-    // Skip undetermined cubes (rendered by BuildCursor instead)
     const map = new Map<string, Group>();
     for (const block of blocks.values()) {
       if (undeterminedCubes.has(posKey(block.pos))) continue;
       const hf = hiddenFaces.get(posKey(block.pos)) ?? 0;
-      const key = `${block.type}:${hf}`;
+      const dimmed = viewMode.kind === "iso" && !posInActiveSlice(viewMode, block.pos);
+      const key = `${block.type}:${hf}:${dimmed ? 1 : 0}`;
       const existing = map.get(key);
       if (existing) {
         existing.blocks.push(block);
@@ -359,22 +378,24 @@ export function BlockInstances() {
         map.set(key, {
           type: block.type,
           hiddenFaces: hf,
+          dimmed,
           blocks: [block],
         });
       }
     }
     return map;
-  }, [blocks, hiddenFaces, undeterminedCubes]);
+  }, [blocks, hiddenFaces, undeterminedCubes, viewMode]);
 
   return (
     <>
-      {Array.from(grouped.values()).map((group) => (
+      {Array.from(grouped.entries()).map(([key, group]) => (
         <TypedInstances
-          key={`${group.type}:${group.hiddenFaces}`}
+          key={key}
           cubeType={group.type}
           hiddenFaces={group.hiddenFaces}
           blocks={group.blocks}
           allBlocks={blocks}
+          dimmed={group.dimmed}
         />
       ))}
     </>

--- a/piper_draw/gui/src/components/BuildCursor.tsx
+++ b/piper_draw/gui/src/components/BuildCursor.tsx
@@ -9,12 +9,16 @@ const cursorMaterial = new THREE.MeshBasicMaterial({
   transparent: true,
   opacity: 0.35,
   depthWrite: false,
+  depthTest: false,
   side: THREE.DoubleSide,
 });
 
 const cursorLineMaterial = new THREE.LineBasicMaterial({
   color: 0x333333,
   linewidth: 2,
+  transparent: true,
+  depthTest: false,
+  depthWrite: false,
 });
 
 // Default cube geometry for cursor (1x1x1 in Three.js)
@@ -33,11 +37,13 @@ function CursorBox({ position }: { position: [number, number, number] }) {
         geometry={defaultBox}
         material={cursorMaterial}
         raycast={noRaycast}
+        renderOrder={999}
       />
       <lineSegments
         geometry={defaultEdges}
         material={cursorLineMaterial}
         raycast={noRaycast}
+        renderOrder={1000}
       />
     </group>
   );

--- a/piper_draw/gui/src/components/FoldOutCube.tsx
+++ b/piper_draw/gui/src/components/FoldOutCube.tsx
@@ -1,0 +1,131 @@
+import * as THREE from "three";
+import {
+  FOLD_ANGLE,
+  colorForCubeFaceThreeAxis,
+  faceOrientationEuler,
+  foldRotationEuler,
+} from "../utils/isoFoldOut";
+import type { ThreeAxis } from "../utils/isoFoldOut";
+import type { FaceMask } from "../types";
+
+const noRaycast = () => {};
+const HALF = 0.5;
+
+const sharedFacePlane = new THREE.PlaneGeometry(1, 1);
+const sharedFaceEdges = new THREE.EdgesGeometry(sharedFacePlane);
+const foldEdgeMaterial = new THREE.LineBasicMaterial({ color: 0x000000 });
+const foldFaceMaterials = new Map<number, THREE.MeshBasicMaterial>();
+function foldFaceMaterial(color: THREE.Color): THREE.MeshBasicMaterial {
+  const key = color.getHex();
+  let mat = foldFaceMaterials.get(key);
+  if (!mat) {
+    mat = new THREE.MeshBasicMaterial({
+      color,
+      side: THREE.DoubleSide,
+      polygonOffset: true,
+      polygonOffsetFactor: 1,
+      polygonOffsetUnits: 1,
+    });
+    foldFaceMaterials.set(key, mat);
+  }
+  return mat;
+}
+
+function FoldFacePrimitive({ color }: { color: THREE.Color }) {
+  const mat = foldFaceMaterial(color);
+  return (
+    <>
+      <mesh raycast={noRaycast}>
+        <primitive object={sharedFacePlane} attach="geometry" />
+        <primitive object={mat} attach="material" />
+      </mesh>
+      <lineSegments raycast={noRaycast}>
+        <primitive object={sharedFaceEdges} attach="geometry" />
+        <primitive object={foldEdgeMaterial} attach="material" />
+      </lineSegments>
+    </>
+  );
+}
+
+function FoldFaceMesh({ axis, sign, topAxis, foldAngle, color }: {
+  axis: ThreeAxis; sign: 1 | -1; topAxis: ThreeAxis; foldAngle: number; color: THREE.Color;
+}) {
+  if (axis === topAxis) {
+    const pos: [number, number, number] = [0, 0, 0];
+    pos[topAxis] = HALF;
+    return (
+      <group position={pos} rotation={faceOrientationEuler(topAxis, 1)}>
+        <FoldFacePrimitive color={color} />
+      </group>
+    );
+  }
+  const pivot: [number, number, number] = [0, 0, 0];
+  pivot[topAxis] = HALF;
+  pivot[axis] = sign * HALF;
+  const facePosLocal: [number, number, number] = [0, 0, 0];
+  facePosLocal[topAxis] = -HALF;
+  return (
+    <group position={pivot}>
+      <group rotation={foldRotationEuler(axis, sign, topAxis, foldAngle)}>
+        <group position={facePosLocal} rotation={faceOrientationEuler(axis, sign)}>
+          <FoldFacePrimitive color={color} />
+        </group>
+      </group>
+    </group>
+  );
+}
+
+function faceMaskBit(axis: ThreeAxis, sign: 1 | -1): FaceMask {
+  return 1 << (axis * 2 + (sign === 1 ? 0 : 1));
+}
+
+/**
+ * Cube fold-out: top face plus 4 side faces tilted outward by FOLD_ANGLE around
+ * the edge each shares with the top. Used as the iso-mode ghost preview and as
+ * an overlay on placed cubes so the cube's type stays readable in iso views.
+ *
+ * `includeTop` — render the top face quad. Off for placed-cube overlay (the
+ * cube body's own top face already shows in the same color).
+ * `hiddenFaces` — skip splayed sides whose face is hidden (neighbor present),
+ * so the splayed face doesn't overlap the neighbor.
+ */
+export function FoldOutCubeFaces({
+  blockType,
+  topAxis,
+  includeTop = true,
+  hiddenFaces = 0,
+}: {
+  blockType: string;
+  topAxis: ThreeAxis;
+  includeTop?: boolean;
+  hiddenFaces?: FaceMask;
+}) {
+  const sides = ([0, 1, 2] as ThreeAxis[]).filter(a => a !== topAxis);
+  return (
+    <>
+      {includeTop && (
+        <FoldFaceMesh
+          axis={topAxis}
+          sign={1}
+          topAxis={topAxis}
+          foldAngle={0}
+          color={colorForCubeFaceThreeAxis(blockType, topAxis)}
+        />
+      )}
+      {sides.flatMap(a =>
+        ([1, -1] as const)
+          .filter(s => (hiddenFaces & faceMaskBit(a, s)) === 0)
+          .map(s => (
+            <FoldFaceMesh
+              key={`${a}-${s}`}
+              axis={a}
+              sign={s}
+              topAxis={topAxis}
+              foldAngle={FOLD_ANGLE}
+              color={colorForCubeFaceThreeAxis(blockType, a)}
+            />
+          ))
+      )}
+    </>
+  );
+}

--- a/piper_draw/gui/src/components/FoldOutCubeOverlay.tsx
+++ b/piper_draw/gui/src/components/FoldOutCubeOverlay.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import { useBlockStore } from "../stores/blockStore";
+import { tqecToThree, posKey, CUBE_TYPES } from "../types";
+import { isoTopThreeAxis } from "../utils/isoFoldOut";
+import { posInActiveSlice } from "../utils/isoView";
+import { FoldOutCubeFaces } from "./FoldOutCube";
+
+/**
+ * In iso mode, splay each placed cube's 4 side faces outward so the cube's
+ * type stays readable from the camera angle. Mirrors the ghost preview's
+ * fold-out so placement feels continuous: the splayed faces shown before
+ * placing stay visible after. Skips splayed sides where a neighbor block
+ * occupies the adjacent cell (per `hiddenFaces`) to avoid the splayed face
+ * overlapping the neighbor; off-slice cubes are skipped entirely (the dimmed
+ * cube body alone is enough context).
+ */
+export function FoldOutCubeOverlay() {
+  const blocks = useBlockStore((s) => s.blocks);
+  const hiddenFaces = useBlockStore((s) => s.hiddenFaces);
+  const undeterminedCubes = useBlockStore((s) => s.undeterminedCubes);
+  const viewMode = useBlockStore((s) => s.viewMode);
+
+  const entries = useMemo(() => {
+    if (viewMode.kind !== "iso") return [];
+    const out: Array<{
+      key: string;
+      pos: [number, number, number];
+      type: string;
+      hf: number;
+    }> = [];
+    for (const block of blocks.values()) {
+      if (!(CUBE_TYPES as readonly string[]).includes(block.type)) continue;
+      const k = posKey(block.pos);
+      if (undeterminedCubes.has(k)) continue;
+      if (!posInActiveSlice(viewMode, block.pos)) continue;
+      out.push({
+        key: k,
+        pos: tqecToThree(block.pos, block.type),
+        type: block.type,
+        hf: hiddenFaces.get(k) ?? 0,
+      });
+    }
+    return out;
+  }, [blocks, hiddenFaces, undeterminedCubes, viewMode]);
+
+  if (viewMode.kind !== "iso" || entries.length === 0) return null;
+  const topAxis = isoTopThreeAxis(viewMode.axis);
+
+  return (
+    <>
+      {entries.map((it) => (
+        <group key={it.key} position={it.pos}>
+          <FoldOutCubeFaces
+            blockType={it.type}
+            topAxis={topAxis}
+            includeTop={false}
+            hiddenFaces={it.hf}
+          />
+        </group>
+      ))}
+    </>
+  );
+}

--- a/piper_draw/gui/src/components/GhostBlock.tsx
+++ b/piper_draw/gui/src/components/GhostBlock.tsx
@@ -1,7 +1,18 @@
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
-import { tqecToThree, yBlockZOffset, getHiddenFaceMaskForPos } from "../types";
+import {
+  tqecToThree,
+  yBlockZOffset,
+  getHiddenFaceMaskForPos,
+  isPipeType,
+  pipeAxisFromPos,
+  axisIndex,
+  CUBE_TYPES,
+} from "../types";
+import { isoTopThreeAxis } from "../utils/isoFoldOut";
+import type { ThreeAxis } from "../utils/isoFoldOut";
 import { getCachedGeometry, getCachedEdges, getCachedFullBox } from "./BlockInstances";
+import { FoldOutCubeFaces } from "./FoldOutCube";
 
 const noRaycast = () => {};
 
@@ -52,6 +63,27 @@ const replaceLineMaterial = new THREE.LineBasicMaterial({
   opacity: 0.85,
   depthWrite: false,
 });
+// Iso-mode ghost for non-cube types (pipes, Y): opaque colored mesh + full-opacity
+// black edges, matching the toolbar preview style. Cube ghosts use the fold-out
+// instead so they don't go through these.
+const isoGhostMaterial = new THREE.MeshBasicMaterial({
+  vertexColors: true,
+  side: THREE.DoubleSide,
+  polygonOffset: true,
+  polygonOffsetFactor: 1,
+  polygonOffsetUnits: 1,
+});
+const isoLineMaterial = new THREE.LineBasicMaterial({ color: 0x000000 });
+// Iso-mode overlay for depth-axis pipe ghosts: draws the pipe's full extent on top
+// of any occluding geometry so the user can tell where the pipe goes (the cap alone
+// looks identical to a cube cap when seen end-on).
+const depthPipeOutlineMaterial = new THREE.LineBasicMaterial({
+  color: "#1f6feb",
+  transparent: true,
+  opacity: 0.55,
+  depthTest: false,
+  depthWrite: false,
+});
 
 /**
  * Inner component — only mounts when hoveredGridPos is non-null.
@@ -66,6 +98,7 @@ function GhostBlockInner() {
   const hoveredReplace = useBlockStore((s) => s.hoveredReplace);
   const blocks = useBlockStore((s) => s.blocks);
   const spatialIndex = useBlockStore((s) => s.spatialIndex);
+  const viewMode = useBlockStore((s) => s.viewMode);
 
   const activeType = hoveredBlockType ?? cubeType;
 
@@ -79,14 +112,42 @@ function GhostBlockInner() {
   const isInvalid = !isDelete && hoveredInvalid;
   const isReplace = !isDelete && hoveredReplace;
 
-  let meshMat = isInvalid ? invalidMaterial : ghostMaterial;
-  let lineMat = isInvalid ? invalidLineMaterial : validLineMaterial;
+  const isIso = viewMode.kind === "iso";
+  let meshMat: THREE.Material = isInvalid
+    ? invalidMaterial
+    : isIso
+      ? isoGhostMaterial
+      : ghostMaterial;
+  let lineMat: THREE.Material = isInvalid
+    ? invalidLineMaterial
+    : isIso
+      ? isoLineMaterial
+      : validLineMaterial;
   let scale = isInvalid ? 1.005 : 1;
   if (isReplace && !isInvalid) {
     meshMat = replaceMaterial;
     lineMat = replaceLineMaterial;
     scale = 1.01;
   }
+
+  // In iso mode, a pipe whose open axis matches the view's depth axis collapses end-on
+  // to a unit cap (visually identical to a cube). Render the full pipe edges with
+  // depthTest off so the user can see the pipe is there even if a cube occludes it.
+  const pipeAxis = isPipeType(activeType) ? pipeAxisFromPos(hoveredGridPos) : null;
+  const showDepthPipeOutline =
+    !isDelete &&
+    viewMode.kind === "iso" &&
+    pipeAxis !== null &&
+    pipeAxis === axisIndex(viewMode.axis);
+  const fullPipeEdges = showDepthPipeOutline ? getCachedEdges(activeType, 0) : null;
+
+  // Iso-mode cube preview: fan the 4 side faces outward so their colors are visible.
+  const showFoldOutCube =
+    !isDelete &&
+    !isInvalid &&
+    viewMode.kind === "iso" &&
+    (CUBE_TYPES as readonly string[]).includes(activeType);
+  const foldTopAxis: ThreeAxis = viewMode.kind === "iso" ? isoTopThreeAxis(viewMode.axis) : 0;
 
   return (
     <group position={[x, y, z]}>
@@ -97,14 +158,27 @@ function GhostBlockInner() {
         </mesh>
       ) : (
         <group scale={scale}>
-          <mesh>
-            <primitive object={ghostGeometry} attach="geometry" />
-            <primitive object={meshMat} attach="material" />
-          </mesh>
-          <lineSegments>
-            <primitive object={ghostEdges} attach="geometry" />
-            <primitive object={lineMat} attach="material" />
-          </lineSegments>
+          {!showFoldOutCube && (
+            <>
+              <mesh>
+                <primitive object={ghostGeometry} attach="geometry" />
+                <primitive object={meshMat} attach="material" />
+              </mesh>
+              <lineSegments>
+                <primitive object={ghostEdges} attach="geometry" />
+                <primitive object={lineMat} attach="material" />
+              </lineSegments>
+            </>
+          )}
+          {fullPipeEdges && (
+            <lineSegments scale={1.04} renderOrder={999}>
+              <primitive object={fullPipeEdges} attach="geometry" />
+              <primitive object={depthPipeOutlineMaterial} attach="material" />
+            </lineSegments>
+          )}
+          {showFoldOutCube && (
+            <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
+          )}
         </group>
       )}
     </group>

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -1,27 +1,62 @@
 import { useRef } from "react";
 import * as THREE from "three";
 import type { ThreeEvent } from "@react-three/fiber";
-import { useFrame } from "@react-three/fiber";
+import { useFrame, useThree } from "@react-three/fiber";
 import { useBlockStore } from "../stores/blockStore";
-import { snapGroundPos, hasBlockOverlap, hasCubeColorConflict, hasPipeColorConflict, hasYCubePipeAxisConflict, isValidPos, isPipeType, resolvePipeType, posKey } from "../types";
-import type { CubeType } from "../types";
+import {
+  snapGroundPos,
+  snapInPlane,
+  hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
+  hasYCubePipeAxisConflict,
+  isValidPos,
+  isPipeType,
+  resolvePipeType,
+  posKey,
+  axisIndex,
+} from "../types";
+import type { CubeType, Position3D, ViewMode } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
+import { snapIsoPos, isoGridMeshTransform } from "../utils/isoView";
 
 const PLANE_SIZE = 1000;
+
+/** Snap a Three.js world point to a valid TQEC position based on view mode. */
+function snapForViewMode(viewMode: ViewMode, point: THREE.Vector3, forPipe: boolean): Position3D {
+  if (viewMode.kind === "iso") return snapIsoPos(viewMode, point, forPipe, snapInPlane);
+  return snapGroundPos(point.x, -point.z, forPipe);
+}
 
 export function GridPlane() {
   const addBlock = useBlockStore((s) => s.addBlock);
   const mode = useBlockStore((s) => s.mode);
+  const viewMode = useBlockStore((s) => s.viewMode);
   const setHoveredGridPos = useBlockStore((s) => s.setHoveredGridPos);
   const meshRef = useRef<THREE.Mesh>(null!);
   const target = useRef(new THREE.Vector3());
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const controls = useThree((s) => s.controls) as any;
 
-  // Keep the invisible raycast plane centered under the camera's look point
+  // Keep the invisible raycast plane centered: under the camera in persp mode,
+  // following the orbit target along the in-plane axes in iso mode.
   useFrame(({ camera }) => {
-    if (!meshRef.current) return;
-    if (cameraGroundPoint(camera, target.current)) {
-      meshRef.current.position.x = Math.round(target.current.x);
-      meshRef.current.position.z = Math.round(target.current.z);
+    const mesh = meshRef.current;
+    if (!mesh) return;
+    if (viewMode.kind === "persp") {
+      if (cameraGroundPoint(camera, target.current)) {
+        mesh.position.set(Math.round(target.current.x), 0, Math.round(target.current.z));
+      }
+      return;
+    }
+    const ot: THREE.Vector3 | undefined = controls?.target;
+    const slice = viewMode.slice;
+    if (viewMode.axis === "x") {
+      mesh.position.set(slice, ot ? Math.round(ot.y) : 0, ot ? Math.round(ot.z) : 0);
+    } else if (viewMode.axis === "y") {
+      mesh.position.set(ot ? Math.round(ot.x) : 0, ot ? Math.round(ot.y) : 0, -slice);
+    } else {
+      mesh.position.set(ot ? Math.round(ot.x) : 0, slice, ot ? Math.round(ot.z) : 0);
     }
   });
 
@@ -31,8 +66,7 @@ export function GridPlane() {
 
     const store = useBlockStore.getState();
     const forPipe = store.pipeVariant !== null;
-    // e.point is in Three.js coords; convert to TQEC X/Y (ground plane z=0)
-    const pos = snapGroundPos(e.point.x, -e.point.z, forPipe);
+    const pos = snapForViewMode(viewMode, e.point, forPipe);
 
     // Determine actual block type for this position
     let blockType = store.cubeType;
@@ -71,7 +105,7 @@ export function GridPlane() {
 
     const store = useBlockStore.getState();
     const forPipe = store.pipeVariant !== null;
-    const pos = snapGroundPos(e.point.x, -e.point.z, forPipe);
+    const pos = snapForViewMode(viewMode, e.point, forPipe);
     addBlock(pos);
   };
 
@@ -80,22 +114,31 @@ export function GridPlane() {
   };
 
   if (mode === "delete") return null;
+
+  // Mesh orientation matches the active plane: floor in persp, slice plane in iso.
+  const rotation: [number, number, number] = viewMode.kind === "persp"
+    ? [-Math.PI / 2, 0, 0]
+    : isoGridMeshTransform(viewMode.axis).rotation;
+
   if (mode === "build") {
     return (
       <mesh
         ref={meshRef}
-        rotation-x={-Math.PI / 2}
-        position={[0, 0, 0]}
+        rotation={rotation}
         onClick={(e: ThreeEvent<MouseEvent>) => {
           e.stopPropagation();
           if (e.delta > 2) return;
-          const pos = snapGroundPos(e.point.x, -e.point.z, false);
-          useBlockStore.getState().moveBuildCursor(pos);
+          // Build mode places cubes; always snap to block positions (forPipe=false).
+          const pos = snapForViewMode(viewMode, e.point, false);
+          // For build we ignore the slice constraint on Z if needed; honor depth from snap.
+          // But ensure depth axis lands on a block coord.
+          const adjusted = enforceBlockDepth(viewMode, pos);
+          useBlockStore.getState().moveBuildCursor(adjusted);
         }}
         onPointerLeave={handlePointerLeave}
       >
         <planeGeometry args={[PLANE_SIZE, PLANE_SIZE]} />
-        <meshBasicMaterial visible={false} side={THREE.FrontSide} />
+        <meshBasicMaterial visible={false} side={THREE.DoubleSide} />
       </mesh>
     );
   }
@@ -103,13 +146,12 @@ export function GridPlane() {
     return (
       <mesh
         ref={meshRef}
-        rotation-x={-Math.PI / 2}
-        position={[0, 0, 0]}
+        rotation={rotation}
         onClick={handleClick}
         onPointerLeave={handlePointerLeave}
       >
         <planeGeometry args={[PLANE_SIZE, PLANE_SIZE]} />
-        <meshBasicMaterial visible={false} side={THREE.FrontSide} />
+        <meshBasicMaterial visible={false} side={THREE.DoubleSide} />
       </mesh>
     );
   }
@@ -117,14 +159,22 @@ export function GridPlane() {
   return (
     <mesh
       ref={meshRef}
-      rotation-x={-Math.PI / 2}
-      position={[0, 0, 0]}
+      rotation={rotation}
       onPointerMove={handlePointerMove}
       onClick={handleClick}
       onPointerLeave={handlePointerLeave}
     >
       <planeGeometry args={[PLANE_SIZE, PLANE_SIZE]} />
-      <meshBasicMaterial visible={false} side={THREE.FrontSide} />
+      <meshBasicMaterial visible={false} side={THREE.DoubleSide} />
     </mesh>
   );
+}
+
+/** Force the depth coord to a multiple of 3 (build cursor must land on a cube position). */
+function enforceBlockDepth(viewMode: ViewMode, pos: Position3D): Position3D {
+  if (viewMode.kind !== "iso") return pos;
+  const idx = axisIndex(viewMode.axis);
+  const coords = [pos.x, pos.y, pos.z];
+  coords[idx] = Math.round(coords[idx] / 3) * 3;
+  return { x: coords[0], y: coords[1], z: coords[2] };
 }

--- a/piper_draw/gui/src/components/PreviewRenderer.tsx
+++ b/piper_draw/gui/src/components/PreviewRenderer.tsx
@@ -6,7 +6,16 @@ import {
   createBlockEdges,
   blockThreeSize,
 } from "../types";
-import type { BlockType } from "../types";
+import type { BlockType, ViewMode } from "../types";
+import { useBlockStore } from "../stores/blockStore";
+import {
+  FOLD_ANGLE,
+  isoTopThreeAxis,
+  colorForCubeFaceThreeAxis,
+  faceOrientationEuler,
+  foldRotationEuler,
+} from "../utils/isoFoldOut";
+import type { ThreeAxis } from "../utils/isoFoldOut";
 
 /** All block types to render previews for, including pipe canonical forms. */
 const PREVIEW_TYPES: { key: string; blockType: BlockType }[] = [
@@ -21,13 +30,133 @@ const PREVIEW_TYPES: { key: string; blockType: BlockType }[] = [
 const RENDER_SIZE = 128; // high-res for crisp previews at any display size
 const FOV = 35;
 const THROTTLE_MS = 66; // ~15fps
+const HALF = 0.5;
 
 const vertexColorMaterial = new THREE.MeshBasicMaterial({ vertexColors: true, side: THREE.DoubleSide });
 const edgeMaterial = new THREE.LineBasicMaterial({ color: 0x000000 });
 
+const foldFaceMatCache = new Map<number, THREE.MeshBasicMaterial>();
+function foldFaceMaterial(color: THREE.Color): THREE.MeshBasicMaterial {
+  const key = color.getHex();
+  let mat = foldFaceMatCache.get(key);
+  if (!mat) {
+    mat = new THREE.MeshBasicMaterial({ color, side: THREE.DoubleSide });
+    foldFaceMatCache.set(key, mat);
+  }
+  return mat;
+}
+
+type Variant = "persp" | "iso-x" | "iso-y" | "iso-z";
+const FOLD_VARIANTS: Exclude<Variant, "persp">[] = ["iso-x", "iso-y", "iso-z"];
+
+function variantForViewMode(viewMode: ViewMode): Variant {
+  if (viewMode.kind === "persp") return "persp";
+  if (viewMode.axis === "x") return "iso-x";
+  if (viewMode.axis === "y") return "iso-y";
+  return "iso-z";
+}
+
+function variantTopAxis(variant: Exclude<Variant, "persp">): ThreeAxis {
+  if (variant === "iso-x") return isoTopThreeAxis("x");
+  if (variant === "iso-y") return isoTopThreeAxis("y");
+  return isoTopThreeAxis("z");
+}
+
+function variantKey(key: string, variant: Variant): string {
+  return `${key}|${variant}`;
+}
+
+type PreviewEntry = {
+  obj: THREE.Object3D;
+  edges: THREE.Object3D;
+  center: THREE.Vector3;
+  radius: number;
+};
+
+function buildRegularEntry(blockType: BlockType): PreviewEntry {
+  const previewBandHH = blockType.toString().endsWith("H") ? 0.16 : undefined;
+  const geo = createBlockGeometry(blockType, 0, previewBandHH);
+  const mesh = new THREE.Mesh(geo, vertexColorMaterial);
+
+  const edgeGeo = createBlockEdges(blockType, 0, previewBandHH);
+  const edges = new THREE.LineSegments(edgeGeo, edgeMaterial);
+
+  const [sx, sy, sz] = blockThreeSize(blockType);
+  const center = new THREE.Vector3(0, 0, 0);
+  const radius = Math.sqrt(sx * sx + sy * sy + sz * sz) / 2;
+
+  return { obj: mesh, edges, center, radius };
+}
+
+function addFoldOutFace(
+  meshGroup: THREE.Group,
+  edgeGroup: THREE.Group,
+  axis: ThreeAxis,
+  sign: 1 | -1,
+  topAxis: ThreeAxis,
+  foldAngle: number,
+  color: THREE.Color,
+): void {
+  const geo = new THREE.PlaneGeometry(1, 1);
+
+  let m: THREE.Matrix4;
+  if (axis === topAxis) {
+    const orient = new THREE.Matrix4().makeRotationFromEuler(
+      new THREE.Euler(...faceOrientationEuler(topAxis, 1)),
+    );
+    const pos: [number, number, number] = [0, 0, 0];
+    pos[topAxis] = HALF;
+    m = new THREE.Matrix4().makeTranslation(pos[0], pos[1], pos[2]).multiply(orient);
+  } else {
+    const orient = new THREE.Matrix4().makeRotationFromEuler(
+      new THREE.Euler(...faceOrientationEuler(axis, sign)),
+    );
+    const facePosLocal: [number, number, number] = [0, 0, 0];
+    facePosLocal[topAxis] = -HALF;
+    const facePosLocalMat = new THREE.Matrix4().makeTranslation(
+      facePosLocal[0], facePosLocal[1], facePosLocal[2],
+    );
+    const foldMat = new THREE.Matrix4().makeRotationFromEuler(
+      new THREE.Euler(...foldRotationEuler(axis, sign, topAxis, foldAngle)),
+    );
+    const pivot: [number, number, number] = [0, 0, 0];
+    pivot[axis] = sign * HALF;
+    pivot[topAxis] = HALF;
+    const pivotMat = new THREE.Matrix4().makeTranslation(pivot[0], pivot[1], pivot[2]);
+    m = new THREE.Matrix4()
+      .multiplyMatrices(pivotMat, foldMat)
+      .multiply(facePosLocalMat)
+      .multiply(orient);
+  }
+  geo.applyMatrix4(m);
+
+  meshGroup.add(new THREE.Mesh(geo, foldFaceMaterial(color)));
+  edgeGroup.add(new THREE.LineSegments(new THREE.EdgesGeometry(geo), edgeMaterial));
+}
+
+function buildFoldOutCubeEntry(blockType: string, topAxis: ThreeAxis): PreviewEntry {
+  const meshGroup = new THREE.Group();
+  const edgeGroup = new THREE.Group();
+
+  addFoldOutFace(meshGroup, edgeGroup, topAxis, 1, topAxis, 0, colorForCubeFaceThreeAxis(blockType, topAxis));
+
+  const sides = ([0, 1, 2] as ThreeAxis[]).filter(a => a !== topAxis);
+  for (const a of sides) {
+    for (const s of [1, -1] as const) {
+      addFoldOutFace(meshGroup, edgeGroup, a, s, topAxis, FOLD_ANGLE, colorForCubeFaceThreeAxis(blockType, a));
+    }
+  }
+
+  // After fold by π/6, max corner extends to ~1.18 from origin; pick a slightly smaller
+  // radius so the camera frames the cube body comparably to the regular preview.
+  return { obj: meshGroup, edges: edgeGroup, center: new THREE.Vector3(0, 0, 0), radius: 1.05 };
+}
+
 /**
  * Hook that renders 3D preview images for all toolbar block/pipe types,
- * synced to the main camera's orientation via controlsRef.
+ * synced to the main camera's orientation via controlsRef. In iso view modes,
+ * cubes are rendered as fold-out previews (4 side faces tilted outward from the
+ * camera-facing top) so the user can read the colors of every face.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function usePreviewImages(controlsRef: React.RefObject<any>) {
@@ -35,8 +164,9 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
   const rendererRef = useRef<THREE.WebGLRenderer | null>(null);
   const sceneRef = useRef<THREE.Scene | null>(null);
   const cameraRef = useRef<THREE.PerspectiveCamera | null>(null);
-  const meshesRef = useRef<Map<string, { mesh: THREE.Mesh; edges: THREE.LineSegments; center: THREE.Vector3; radius: number }>>(new Map());
+  const meshesRef = useRef<Map<string, PreviewEntry>>(new Map());
   const lastQuatRef = useRef(new THREE.Quaternion());
+  const lastVariantRef = useRef<Variant>("persp");
   const rafRef = useRef(0);
   const lastRenderRef = useRef(0);
   const dirVec = useRef(new THREE.Vector3());
@@ -60,20 +190,23 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
     const camera = new THREE.PerspectiveCamera(FOV, 1, 0.1, 100);
     cameraRef.current = camera;
 
-    // Pre-build meshes
+    // Pre-build entries: each block has a "persp" variant; cubes additionally
+    // have iso-x / iso-y / iso-z fold-out variants. Non-cube types share the
+    // single regular entry across all variants.
     for (const { key, blockType } of PREVIEW_TYPES) {
-      const previewBandHH = blockType.toString().endsWith("H") ? 0.16 : undefined;
-      const geo = createBlockGeometry(blockType, 0, previewBandHH);
-      const mesh = new THREE.Mesh(geo, vertexColorMaterial);
+      const isCube = (CUBE_TYPES as readonly string[]).includes(blockType);
+      const regular = buildRegularEntry(blockType);
+      meshesRef.current.set(variantKey(key, "persp"), regular);
 
-      const edgeGeo = createBlockEdges(blockType, 0, previewBandHH);
-      const edges = new THREE.LineSegments(edgeGeo, edgeMaterial);
-
-      const [sx, sy, sz] = blockThreeSize(blockType);
-      const center = new THREE.Vector3(0, 0, 0);
-      const radius = Math.sqrt(sx * sx + sy * sy + sz * sz) / 2;
-
-      meshesRef.current.set(key, { mesh, edges, center, radius });
+      if (isCube) {
+        for (const v of FOLD_VARIANTS) {
+          meshesRef.current.set(variantKey(key, v), buildFoldOutCubeEntry(blockType, variantTopAxis(v)));
+        }
+      } else {
+        for (const v of FOLD_VARIANTS) {
+          meshesRef.current.set(variantKey(key, v), regular);
+        }
+      }
     }
   }, []);
 
@@ -91,10 +224,13 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
       const mainCamera = controls.object as THREE.PerspectiveCamera;
       if (!mainCamera) return;
 
-      // Check if camera orientation changed
+      const variant = variantForViewMode(useBlockStore.getState().viewMode);
       const quat = mainCamera.quaternion;
-      if (lastQuatRef.current.angleTo(quat) < 0.005) return;
+      const quatChanged = lastQuatRef.current.angleTo(quat) >= 0.005;
+      const variantChanged = lastVariantRef.current !== variant;
+      if (!quatChanged && !variantChanged) return;
       lastQuatRef.current.copy(quat);
+      lastVariantRef.current = variant;
       lastRenderRef.current = now;
 
       const renderer = rendererRef.current!;
@@ -107,14 +243,14 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
       const newImages = new Map<string, string>();
 
       for (const { key } of PREVIEW_TYPES) {
-        const entry = meshesRef.current.get(key)!;
+        const entry = meshesRef.current.get(variantKey(key, variant))!;
 
-        // Swap preview mesh: remove previous, add current
+        // Swap preview object: remove previous, add current
         if (scene.children.length > 2) {
           scene.remove(scene.children[scene.children.length - 1]);
           scene.remove(scene.children[scene.children.length - 1]);
         }
-        scene.add(entry.mesh);
+        scene.add(entry.obj);
         scene.add(entry.edges);
 
         // Position camera to frame the block
@@ -133,9 +269,18 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
 
     return () => {
       cancelAnimationFrame(rafRef.current);
+      const seen = new Set<PreviewEntry>();
       for (const entry of meshesRef.current.values()) {
-        entry.mesh.geometry.dispose();
-        entry.edges.geometry.dispose();
+        if (seen.has(entry)) continue;
+        seen.add(entry);
+        entry.obj.traverse((node) => {
+          const mesh = node as THREE.Mesh;
+          if (mesh.isMesh) mesh.geometry.dispose();
+        });
+        entry.edges.traverse((node) => {
+          const ls = node as THREE.LineSegments;
+          if (ls.isLineSegments) ls.geometry.dispose();
+        });
       }
       meshesRef.current.clear();
       rendererRef.current?.dispose();

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -2,13 +2,12 @@ import { useEffect, useRef, useState } from "react";
 import { useBlockStore } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, PIPE_TYPE_TO_VARIANT } from "../types";
-import type { BlockType, CubeType, PipeType, PipeVariant, Position3D } from "../types";
+import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
-import { animateCamera } from "../utils/cameraAnim";
-import * as THREE from "three";
 import { usePreviewImages } from "./PreviewRenderer";
+import type { ViewMode } from "../types";
 
 // ---------------------------------------------------------------------------
 // Responsive sizing
@@ -235,11 +234,10 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
   const validationStatus = useValidationStore((s) => s.status);
   const runValidation = useValidationStore((s) => s.validate);
 
-  const setCameraPreset = (position: [number, number, number]) => {
-    const controls = controlsRef.current;
-    if (!controls) return;
-    animateCamera(controls, new THREE.Vector3(0, 0, 0), new THREE.Vector3(...position));
-  };
+  const viewMode = useBlockStore((s) => s.viewMode);
+  const setPerspView = useBlockStore((s) => s.setPerspView);
+  const setIsoView = useBlockStore((s) => s.setIsoView);
+  const stepSlice = useBlockStore((s) => s.stepSlice);
 
   const previewImg = (key: string) => {
     const src = previewImages.get(key);
@@ -288,17 +286,49 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
         </button>
       </div>
 
-      {/* View buttons */}
+      {/* View buttons: 3D (perspective + free orbit) and Iso (axis-locked elevation) */}
       <div style={{ display: "flex", flexDirection: "column", gap: "4px", justifyContent: "center" }}>
-        <button onClick={() => setCameraPreset([35, 35, 0.01])} style={{ ...btnStyle(false), whiteSpace: "nowrap" }}>
-          X View
+        <button
+          onClick={setPerspView}
+          style={{ ...btnStyle(viewMode.kind === "persp"), whiteSpace: "nowrap" }}
+          title="Free 3D perspective view with orbit"
+        >
+          3D
         </button>
-        <button onClick={() => setCameraPreset([0.01, 35, -35])} style={{ ...btnStyle(false), whiteSpace: "nowrap" }}>
-          Y View
-        </button>
-        <button onClick={() => setCameraPreset([0, 50, 0.01])} style={{ ...btnStyle(false), whiteSpace: "nowrap" }}>
-          Z View
-        </button>
+        <IsoMenu
+          viewMode={viewMode}
+          onPick={setIsoView}
+        />
+        {viewMode.kind === "iso" && (
+          <div style={{ display: "flex", gap: "2px", alignItems: "center" }}>
+            <button
+              onClick={() => stepSlice(-3)}
+              title="Move slice toward negative depth"
+              style={{ ...btnStyle(false), padding: "2px 6px", fontSize: "11px", flex: 1 }}
+            >
+              ◂
+            </button>
+            <span
+              title="Active slice on the depth axis (TQEC units / 3)"
+              style={{
+                fontFamily: "monospace",
+                fontSize: "11px",
+                color: "#555",
+                minWidth: 28,
+                textAlign: "center",
+              }}
+            >
+              {viewMode.slice / 3}
+            </span>
+            <button
+              onClick={() => stepSlice(3)}
+              title="Move slice toward positive depth"
+              style={{ ...btnStyle(false), padding: "2px 6px", fontSize: "11px", flex: 1 }}
+            >
+              ▸
+            </button>
+          </div>
+        )}
       </div>
 
       {/* Undo / Redo / Clear */}
@@ -477,6 +507,82 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
           return <><span>X: {pos.x / 3}</span><span>Y: {pos.y / 3}</span><span>Z: {pos.z / 3}</span></>;
         })()}
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Iso view menu — dropdown to pick which axis to view down
+// ---------------------------------------------------------------------------
+
+const ISO_AXIS_LABEL: Record<IsoAxis, string> = {
+  x: "Iso X",
+  y: "Iso Y",
+  z: "Iso Z",
+};
+
+function IsoMenu({ viewMode, onPick }: { viewMode: ViewMode; onPick: (axis: IsoAxis) => void }) {
+  const [open, setOpen] = useState(false);
+  const wrapRef = useRef<HTMLDivElement | null>(null);
+  const active = viewMode.kind === "iso";
+  const label = active ? ISO_AXIS_LABEL[viewMode.axis] : "Iso";
+
+  useEffect(() => {
+    if (!open) return;
+    const onDocClick = (e: MouseEvent) => {
+      if (!wrapRef.current?.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDocClick);
+    return () => document.removeEventListener("mousedown", onDocClick);
+  }, [open]);
+
+  const pick = (axis: IsoAxis) => {
+    onPick(axis);
+    setOpen(false);
+  };
+
+  return (
+    <div ref={wrapRef} style={{ position: "relative" }}>
+      <button
+        onClick={() => setOpen((v) => !v)}
+        style={{ ...btnStyle(active), whiteSpace: "nowrap", width: "100%" }}
+        title="Axis-locked orthographic elevation view"
+      >
+        {label} ▾
+      </button>
+      {open && (
+        <div
+          style={{
+            position: "absolute",
+            top: "calc(100% + 4px)",
+            left: 0,
+            background: "#fff",
+            border: "1px solid #ccc",
+            borderRadius: 4,
+            boxShadow: "0 2px 8px rgba(0,0,0,0.15)",
+            padding: 4,
+            minWidth: 90,
+            zIndex: 1000,
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+          }}
+        >
+          {(["x", "y", "z"] as IsoAxis[]).map((axis) => (
+            <button
+              key={axis}
+              onClick={() => pick(axis)}
+              style={{
+                ...btnStyle(active && viewMode.axis === axis),
+                textAlign: "left",
+                padding: "4px 10px",
+              }}
+            >
+              {ISO_AXIS_LABEL[axis]}
+            </button>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import type {
   Position3D, Block, BlockType, CubeType, PipeVariant, PipeType, SpatialIndex, FaceMask,
-  BuildDirection, UndeterminedCubeInfo,
+  BuildDirection, UndeterminedCubeInfo, ViewMode, IsoAxis,
 } from "../types";
 import {
   posKey,
@@ -141,6 +141,14 @@ interface BlockStore {
   // Free build (disables color-matching validation)
   freeBuild: boolean;
   toggleFreeBuild: () => void;
+
+  // View mode (perspective vs. orthographic elevation along an axis)
+  viewMode: ViewMode;
+  /** Per-axis last-used slice so toggling between iso views remembers position. */
+  lastIsoSlice: { x: number; y: number; z: number };
+  setPerspView: () => void;
+  setIsoView: (axis: IsoAxis) => void;
+  stepSlice: (delta: number) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -208,6 +216,24 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   freeBuild: false,
   toggleFreeBuild: () => set((s) => ({ freeBuild: !s.freeBuild })),
 
+  viewMode: { kind: "persp" },
+  lastIsoSlice: { x: 0, y: 0, z: 0 },
+  setPerspView: () =>
+    set((s) => (s.viewMode.kind === "persp" ? s : { viewMode: { kind: "persp" } })),
+  setIsoView: (axis) =>
+    set((s) => ({
+      viewMode: { kind: "iso", axis, slice: s.lastIsoSlice[axis] },
+    })),
+  stepSlice: (delta) =>
+    set((s) => {
+      if (s.viewMode.kind !== "iso") return s;
+      const slice = s.viewMode.slice + delta;
+      return {
+        viewMode: { ...s.viewMode, slice },
+        lastIsoSlice: { ...s.lastIsoSlice, [s.viewMode.axis]: slice },
+      };
+    }),
+
   setMode: (mode) => {
     const prev = get();
 
@@ -249,11 +275,16 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         }
       }
 
+      // In iso mode, seed a camera snap so the slice follows the cursor when
+      // it lands off-slab; in perspective we don't auto-animate on entry.
+      const cameraSnapTarget =
+        prev.viewMode.kind === "iso" ? { azimuth: null, targetPos: cursorPos } : null;
+
       set({
         mode,
         buildCursor: cursorPos,
         buildHistory: [],
-        cameraSnapTarget: null,
+        cameraSnapTarget,
         hoveredGridPos: null,
         hoveredBlockType: null,
         hoveredInvalid: false,

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -10,6 +10,27 @@ export interface Position3D {
   z: number;
 }
 
+// ---------------------------------------------------------------------------
+// View modes (perspective vs. orthographic elevation)
+// ---------------------------------------------------------------------------
+
+export type IsoAxis = "x" | "y" | "z";
+
+export type ViewMode =
+  | { kind: "persp" }
+  | { kind: "iso"; axis: IsoAxis; slice: number };
+
+/** TQEC axis index: 0=x, 1=y, 2=z. */
+export function axisIndex(axis: IsoAxis): 0 | 1 | 2 {
+  return axis === "x" ? 0 : axis === "y" ? 1 : 2;
+}
+
+/** Returns the integer slice that the given depth coordinate falls into.
+ *  Each slice spans 3 units (cube + 2 pipe slots) starting at a multiple of 3. */
+export function depthToSlice(depth: number): number {
+  return Math.floor(depth / 3) * 3;
+}
+
 /**
  * ZXCube types from TQEC. Each string character gives the basis
  * (X or Z) for the face pair on that TQEC axis: [X-axis, Y-axis, Z-axis].
@@ -165,19 +186,24 @@ function nearestMult3(v: number): number {
   return Math.round(v / 3) * 3;
 }
 
+/**
+ * Snap two raw in-plane coordinates to a valid TQEC pair: either both at block
+ * positions (multiples of 3) or one at a pipe slot (≡ 1 mod 3) for pipes.
+ */
+export function snapInPlane(rawA: number, rawB: number, forPipe: boolean): { a: number; b: number } {
+  if (!forPipe) return { a: nearestMult3(rawA), b: nearestMult3(rawB) };
+  const ba = nearestMult3(rawA), bb = nearestMult3(rawB);
+  const pa = nearest3kPipeCoord(rawA), pb = nearest3kPipeCoord(rawB);
+  const d1 = Math.abs(rawA - pa) + Math.abs(rawB - bb);
+  const d2 = Math.abs(rawA - ba) + Math.abs(rawB - pb);
+  if (d1 <= d2) return { a: pa, b: bb };
+  return { a: ba, b: pb };
+}
+
 /** Snap raw TQEC X/Y coordinates (on ground plane z=0) to nearest valid position. */
 export function snapGroundPos(rawX: number, rawY: number, forPipe: boolean): Position3D {
-  if (!forPipe) {
-    return { x: nearestMult3(rawX), y: nearestMult3(rawY), z: 0 };
-  }
-  // For pipe on ground: z=0 ≡ 0 (mod 3), need exactly one of x,y in a non-zero pipe remainder class
-  const bx = nearestMult3(rawX), by = nearestMult3(rawY);
-  const px = nearest3kPipeCoord(rawX), py = nearest3kPipeCoord(rawY);
-  // Candidate: X-pipe at (px, by) or Y-pipe at (bx, py)
-  const d1 = Math.abs(rawX - px) + Math.abs(rawY - by);
-  const d2 = Math.abs(rawX - bx) + Math.abs(rawY - py);
-  if (d1 <= d2) return { x: px, y: by, z: 0 };
-  return { x: bx, y: py, z: 0 };
+  const { a, b } = snapInPlane(rawX, rawY, forPipe);
+  return { x: a, y: b, z: 0 };
 }
 
 // ---------------------------------------------------------------------------

--- a/piper_draw/gui/src/utils/isoFoldOut.ts
+++ b/piper_draw/gui/src/utils/isoFoldOut.ts
@@ -1,0 +1,49 @@
+import * as THREE from "three";
+import { X_COLOR, Z_COLOR } from "../types";
+import type { IsoAxis } from "../types";
+
+export const FOLD_ANGLE = Math.PI / 6;
+
+export type ThreeAxis = 0 | 1 | 2;
+
+// Three.js axis index → corresponding TQEC axis. Three (X, Y, Z) ↔ TQEC (X, Z, Y).
+const TQEC_AXIS_FOR_THREE = [0, 2, 1] as const;
+
+/** Three.js axis facing the camera in each iso view (the cube's "top" face from the user's perspective). */
+export function isoTopThreeAxis(axis: IsoAxis): ThreeAxis {
+  if (axis === "x") return 0;
+  if (axis === "z") return 1;
+  return 2;
+}
+
+export function colorForCubeFaceThreeAxis(blockType: string, threeAxis: ThreeAxis): THREE.Color {
+  const ch = blockType[TQEC_AXIS_FOR_THREE[threeAxis]];
+  return ch === "X" ? X_COLOR : Z_COLOR;
+}
+
+/** Rotate the unit plane (originally XY with +Z normal) so its normal becomes sign·basis(axis). */
+export function faceOrientationEuler(axis: ThreeAxis, sign: 1 | -1): [number, number, number] {
+  if (axis === 0) return [0, sign === 1 ? Math.PI / 2 : -Math.PI / 2, 0];
+  if (axis === 1) return [sign === 1 ? -Math.PI / 2 : Math.PI / 2, 0, 0];
+  return sign === 1 ? [0, 0, 0] : [0, Math.PI, 0];
+}
+
+/**
+ * Outward fold rotation around the edge a side face shares with the top face.
+ * Rotation axis = sideNormal × topNormal (always one of the basis axes), angle = `angle`.
+ */
+export function foldRotationEuler(
+  sideAxis: ThreeAxis,
+  sideSign: 1 | -1,
+  topAxis: ThreeAxis,
+  angle: number,
+): [number, number, number] {
+  const side = [0, 0, 0]; side[sideAxis] = sideSign;
+  const top = [0, 0, 0]; top[topAxis] = 1;
+  const cross: [number, number, number] = [
+    side[1] * top[2] - side[2] * top[1],
+    side[2] * top[0] - side[0] * top[2],
+    side[0] * top[1] - side[1] * top[0],
+  ];
+  return [cross[0] * angle, cross[1] * angle, cross[2] * angle];
+}

--- a/piper_draw/gui/src/utils/isoView.ts
+++ b/piper_draw/gui/src/utils/isoView.ts
@@ -1,0 +1,91 @@
+import * as THREE from "three";
+import type { IsoAxis, Position3D, ViewMode } from "../types";
+import { axisIndex } from "../types";
+
+const ISO_DISTANCE = 1000;
+export const ISO_INITIAL_ZOOM = 30;
+
+type IsoMode = Extract<ViewMode, { kind: "iso" }>;
+
+/** Three.js position of orbit target for an iso view at the active slice. */
+export function isoTargetThree(viewMode: IsoMode): THREE.Vector3 {
+  const t: [number, number, number] = [0, 0, 0];
+  t[axisIndex(viewMode.axis)] = viewMode.slice;
+  return new THREE.Vector3(t[0], t[2], -t[1]);
+}
+
+/** Three.js camera position for an iso view (target + offset along depth axis). */
+export function isoCameraThree(viewMode: IsoMode): THREE.Vector3 {
+  return isoTargetThree(viewMode).add(isoCameraOffset(viewMode.axis));
+}
+
+function isoCameraOffset(axis: IsoAxis): THREE.Vector3 {
+  if (axis === "x") return new THREE.Vector3(ISO_DISTANCE, 0, 0);
+  if (axis === "y") return new THREE.Vector3(0, 0, ISO_DISTANCE);
+  return new THREE.Vector3(0, ISO_DISTANCE, 0);
+}
+
+/** Camera up vector for an iso axis (Z stays vertical except when Z is the depth axis). */
+export function isoUpThree(axis: IsoAxis): THREE.Vector3 {
+  if (axis === "z") return new THREE.Vector3(0, 0, -1);
+  return new THREE.Vector3(0, 1, 0);
+}
+
+/** Three.js plane perpendicular to the depth axis at the active slice. */
+export function isoPickPlane(viewMode: IsoMode): THREE.Plane {
+  if (viewMode.axis === "x") return new THREE.Plane(new THREE.Vector3(1, 0, 0), -viewMode.slice);
+  if (viewMode.axis === "y") return new THREE.Plane(new THREE.Vector3(0, 0, -1), -viewMode.slice);
+  return new THREE.Plane(new THREE.Vector3(0, 1, 0), -viewMode.slice);
+}
+
+/** Mesh transform for the slice grid plane: rotation matches the plane normal. */
+export function isoGridMeshTransform(axis: IsoAxis): {
+  rotation: [number, number, number];
+} {
+  // planeGeometry is in XY local plane (normal = +Z local). We rotate so local +Z aligns with the world plane normal.
+  if (axis === "x") return { rotation: [0, Math.PI / 2, 0] };       // local +Z → world +X
+  if (axis === "y") return { rotation: [0, 0, 0] };                  // local +Z → world +Z (matches y depth: plane normal = -Three Z; flip to +Z is fine for double-sided)
+  return { rotation: [-Math.PI / 2, 0, 0] };                         // local +Z → world +Y (floor-like)
+}
+
+/**
+ * Whether a TQEC position is part of the active slab (for dimming off-slab geometry).
+ * Range is [slice-2, slice+3): cubes/in-plane pipes at depth=slice are in; depth-axis pipes
+ * at depth=slice-2 (extending back to previous slab) and slice+1 (extending forward) are also
+ * considered in, since they connect to the active-slab cube. Cubes in adjacent slabs (slice-3,
+ * slice+3) and pipes further out (slice-5, slice+4) fall outside.
+ */
+export function posInActiveSlice(viewMode: ViewMode, pos: Position3D): boolean {
+  if (viewMode.kind !== "iso") return true;
+  const depth = viewMode.axis === "x" ? pos.x : viewMode.axis === "y" ? pos.y : pos.z;
+  return depth >= viewMode.slice - 2 && depth < viewMode.slice + 3;
+}
+
+/** Snap a Three.js point on the active iso plane to a valid TQEC position. */
+export function snapIsoPos(
+  viewMode: IsoMode,
+  planePoint: THREE.Vector3,
+  forPipe: boolean,
+  snapInPlane: (a: number, b: number, forPipe: boolean) => { a: number; b: number },
+): Position3D {
+  let rawA: number, rawB: number;
+  let axisAIdx: 0 | 1 | 2, axisBIdx: 0 | 1 | 2;
+
+  if (viewMode.axis === "x") {
+    axisAIdx = 1; rawA = -planePoint.z;   // TQEC Y = -Three Z
+    axisBIdx = 2; rawB = planePoint.y;    // TQEC Z =  Three Y
+  } else if (viewMode.axis === "y") {
+    axisAIdx = 0; rawA = planePoint.x;    // TQEC X =  Three X
+    axisBIdx = 2; rawB = planePoint.y;    // TQEC Z =  Three Y
+  } else {
+    axisAIdx = 0; rawA = planePoint.x;    // TQEC X =  Three X
+    axisBIdx = 1; rawB = -planePoint.z;   // TQEC Y = -Three Z
+  }
+
+  const { a, b } = snapInPlane(rawA, rawB, forPipe);
+  const out: [number, number, number] = [0, 0, 0];
+  out[axisIndex(viewMode.axis)] = viewMode.slice;
+  out[axisAIdx] = a;
+  out[axisBIdx] = b;
+  return { x: out[0], y: out[1], z: out[2] };
+}

--- a/piper_draw/gui/src/utils/isoView.ts
+++ b/piper_draw/gui/src/utils/isoView.ts
@@ -1,5 +1,5 @@
 import * as THREE from "three";
-import type { IsoAxis, Position3D, ViewMode } from "../types";
+import type { BuildDirection, IsoAxis, Position3D, ViewMode } from "../types";
 import { axisIndex } from "../types";
 
 const ISO_DISTANCE = 1000;
@@ -59,6 +59,56 @@ export function posInActiveSlice(viewMode: ViewMode, pos: Position3D): boolean {
   if (viewMode.kind !== "iso") return true;
   const depth = viewMode.axis === "x" ? pos.x : viewMode.axis === "y" ? pos.y : pos.z;
   return depth >= viewMode.slice - 2 && depth < viewMode.slice + 3;
+}
+
+/**
+ * Build-mode key → TQEC build direction in iso mode.
+ *   W/S      → vertical in-plane axis (screen up/down)
+ *   A/D      → horizontal in-plane axis (screen left/right)
+ *   ArrowUp/ArrowDown → depth axis (out of / into screen, toward camera = up)
+ *
+ * Camera in iso mode is locked to a fixed orientation per axis (no rotation),
+ * so the mapping doesn't need an azimuth — it's a static table per IsoAxis.
+ */
+export function isoBuildDirection(
+  key: "w" | "a" | "s" | "d" | "arrowup" | "arrowdown",
+  axis: IsoAxis,
+): BuildDirection {
+  // [horizontal+ , vertical+ , depth-out] in TQEC-axis units, where depth-out
+  // points from the slice toward the camera (out of the screen).
+  // Iso X: camera at +X, up = +Three Y = +TQEC Z, screen-right = +TQEC Y.
+  // Iso Y: camera at -TQEC Y (Three +Z), up = +TQEC Z, screen-right = +TQEC X.
+  // Iso Z: camera at +TQEC Z (Three +Y), up = +TQEC Y, screen-right = +TQEC X.
+  const table: Record<IsoAxis, [BuildDirection, BuildDirection, BuildDirection]> = {
+    x: [
+      { tqecAxis: 1, sign:  1 }, // right = +Y
+      { tqecAxis: 2, sign:  1 }, // up    = +Z
+      { tqecAxis: 0, sign:  1 }, // out   = +X
+    ],
+    y: [
+      { tqecAxis: 0, sign:  1 }, // right = +X
+      { tqecAxis: 2, sign:  1 }, // up    = +Z
+      { tqecAxis: 1, sign: -1 }, // out   = -Y (camera is at -Y)
+    ],
+    z: [
+      { tqecAxis: 0, sign:  1 }, // right = +X
+      { tqecAxis: 1, sign:  1 }, // up    = +Y
+      { tqecAxis: 2, sign:  1 }, // out   = +Z
+    ],
+  };
+  const [right, up, out] = table[axis];
+  const flip = (d: BuildDirection): BuildDirection => ({
+    tqecAxis: d.tqecAxis,
+    sign: (d.sign * -1) as 1 | -1,
+  });
+  switch (key) {
+    case "d": return right;
+    case "a": return flip(right);
+    case "w": return up;
+    case "s": return flip(up);
+    case "arrowup": return out;
+    case "arrowdown": return flip(out);
+  }
 }
 
 /** Snap a Three.js point on the active iso plane to a valid TQEC position. */


### PR DESCRIPTION
## Summary
- Adds orthographic Iso X/Y/Z views: axis-locked camera, slice-based placement, off-slice geometry dimmed for context. 3D / Iso ▾ replace the old X/Y/Z camera-snap buttons in the toolbar.
- Cube ghost preview and toolbar icons in iso mode splay the 4 side faces outward (fold-out) so a cube's type stays readable end-on; placed cubes get the same fold-out via a new \`FoldOutCubeOverlay\` so placement feels continuous.
- Depth-axis pipe ghosts draw a dimmed full-length wire outline so the user can see direction + extent past the visible cap.
- Build-mode keys in iso mode are screen-relative: W/S = vertical, A/D = horizontal, Arrow Up/Down = depth (toward/away from camera).
- Misc fixes: build cursor now renders above placed blocks (depthTest off + renderOrder); polygonOffset on placed-block faces so cube-pipe boundary edges aren't z-fought away in ortho.

## Test plan
- [ ] Toolbar: 3D and Iso ▾ buttons work; Iso button label updates to "Iso X/Y/Z" and is highlighted when active.
- [ ] In each iso view, place blocks via grid clicks and via clicking on existing block faces; off-slice geometry is dimmed.
- [ ] \`[\` / \`]\` step the slice; grid + camera + placement follow.
- [ ] Build mode in iso: WASD moves in-plane, Arrow Up/Down moves along depth axis (slice steps automatically).
- [ ] Cube ghosts and placed cubes show the splayed type-colored sides in iso views.
- [ ] Depth-axis pipe ghost shows extruded wire outline; placement via face-click on a cube works.
- [ ] Switching back to 3D restores free-orbit perspective.