### PR TITLE
Keyboard build: camera-follow and axis-locked WASD toggles (#71)

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -24,6 +24,7 @@ import { MarqueeSelect, type ThreeState } from "./components/MarqueeSelect";
 import { NavControlsModifier } from "./components/NavControlsModifier";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
 import { BuildModeHints } from "./components/BuildModeHints";
+import { BuildModeToggles } from "./components/BuildModeToggles";
 import { KeybindEditor } from "./components/KeybindEditor";
 import { HelpPanel } from "./components/HelpPanel";
 import { useBlockStore } from "./stores/blockStore";
@@ -324,7 +325,8 @@ export default function App() {
               if (!controls) return;
               const azimuth = controls.getAzimuthalAngle();
               const dirKey = actionToWasdKey(action);
-              const direction = wasdToBuildDirection(dirKey, azimuth);
+              const { axisAbsoluteWasd } = useKeybindStore.getState();
+              const direction = wasdToBuildDirection(dirKey, azimuth, axisAbsoluteWasd);
               store.buildMove(direction);
               return;
             }
@@ -478,6 +480,7 @@ export default function App() {
       </div>
       <SelectModeHints />
       <BuildModeHints onCustomize={() => setKeybindEditorOpen(true)} />
+      <BuildModeToggles />
       {keybindEditorOpen && <KeybindEditor onClose={() => setKeybindEditorOpen(false)} />}
       <PlacementWarning toolbarRef={toolbarRef} />
       <Canvas

--- a/piper_draw/gui/src/components/BuildModeHints.tsx
+++ b/piper_draw/gui/src/components/BuildModeHints.tsx
@@ -4,15 +4,17 @@ import { useKeybindStore } from "../stores/keybindStore";
 export function BuildModeHints({ onCustomize }: { onCustomize: () => void }) {
   const mode = useBlockStore((s) => s.mode);
   const bindings = useKeybindStore((s) => s.bindings);
+  const axisAbsoluteWasd = useKeybindStore((s) => s.axisAbsoluteWasd);
   if (mode !== "build") return null;
 
+  const moveLabel = axisAbsoluteWasd ? "Move ±X / ±Y" : "Move XY";
   const hints = [
     ["Drag", "Pan"],
     ["Shift+Drag", "Rotate"],
     ["Scroll", "Zoom"],
     [
       `${bindings.moveForward.displayLabel}/${bindings.moveLeft.displayLabel}/${bindings.moveBack.displayLabel}/${bindings.moveRight.displayLabel}`,
-      "Move XY",
+      moveLabel,
     ],
     [`${bindings.moveUp.displayLabel}/${bindings.moveDown.displayLabel}`, "Move Z"],
     [bindings.undo.displayLabel, "Undo step"],

--- a/piper_draw/gui/src/components/BuildModeToggles.tsx
+++ b/piper_draw/gui/src/components/BuildModeToggles.tsx
@@ -1,0 +1,64 @@
+import { useBlockStore } from "../stores/blockStore";
+import { useKeybindStore } from "../stores/keybindStore";
+
+export function BuildModeToggles() {
+  const mode = useBlockStore((s) => s.mode);
+  const cameraFollowsBuild = useKeybindStore((s) => s.cameraFollowsBuild);
+  const toggleCameraFollowsBuild = useKeybindStore((s) => s.toggleCameraFollowsBuild);
+  const axisAbsoluteWasd = useKeybindStore((s) => s.axisAbsoluteWasd);
+  const toggleAxisAbsoluteWasd = useKeybindStore((s) => s.toggleAxisAbsoluteWasd);
+
+  if (mode !== "build") return null;
+
+  return (
+    <div
+      onPointerDown={(e) => e.stopPropagation()}
+      style={{
+        position: "fixed",
+        top: 120,
+        left: 16,
+        zIndex: 1,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+        background: "rgba(255,255,255,0.9)",
+        padding: "8px 10px",
+        borderRadius: 8,
+        border: "1px solid #ddd",
+        boxShadow: "0 1px 4px rgba(0,0,0,0.1)",
+        fontFamily: "sans-serif",
+      }}
+    >
+      <button
+        onClick={toggleCameraFollowsBuild}
+        title="When off, the camera stays put while you build with the keyboard"
+        style={toggleBtnStyle(cameraFollowsBuild)}
+      >
+        Camera Follow {cameraFollowsBuild ? "ON" : "OFF"}
+      </button>
+      <button
+        onClick={toggleAxisAbsoluteWasd}
+        title="When on, W/S = ±X and A/D = ±Y regardless of camera angle"
+        style={toggleBtnStyle(axisAbsoluteWasd)}
+      >
+        Axis-Locked WASD {axisAbsoluteWasd ? "ON" : "OFF"}
+      </button>
+    </div>
+  );
+}
+
+function toggleBtnStyle(active: boolean): React.CSSProperties {
+  return {
+    padding: "4px 10px",
+    fontSize: 11,
+    fontFamily: "sans-serif",
+    cursor: "pointer",
+    border: active ? "2px solid #4a9eff" : "2px solid #ccc",
+    borderRadius: 4,
+    background: active ? "#e8f0fe" : "#fff",
+    color: active ? "#1a5ec8" : "#333",
+    fontWeight: "normal",
+    textAlign: "left",
+    whiteSpace: "nowrap",
+  };
+}

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { useKeybindStore } from "./keybindStore";
 import type {
   Position3D, Block, BlockType, CubeType, PipeVariant, PipeType, SpatialIndex, FaceMask,
   BuildDirection, UndeterminedCubeInfo,
@@ -962,6 +963,17 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     const destKey = posKey(destPos);
     const srcKey = posKey(cursor);
 
+    // Camera-follow toggle: when off, skip updating cameraSnapTarget and
+    // lastBuildAxis so the CameraBuildSnap component never animates.
+    const cameraFollowsBuild = useKeybindStore.getState().cameraFollowsBuild;
+    const snapUpdate: { cameraSnapTarget?: { azimuth: number | null; targetPos: Position3D }; lastBuildAxis?: number } =
+      cameraFollowsBuild
+        ? {
+            cameraSnapTarget: { azimuth: cameraAzimuthForDirection(direction), targetPos: destPos },
+            lastBuildAxis: direction.tqecAxis,
+          }
+        : {};
+
     const reject = (reason?: string) => {
       if (reason) set({ hoveredInvalidReason: reason });
       return false;
@@ -973,11 +985,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     if (existingPipe) {
       const existingDest = state.blocks.get(destKey);
       if (existingDest && !isPipeType(existingDest.type)) {
-        const azimuth = cameraAzimuthForDirection(direction);
         set({
           buildCursor: destPos,
-          cameraSnapTarget: { azimuth, targetPos: destPos },
-          lastBuildAxis: direction.tqecAxis,
+          ...snapUpdate,
           hoveredInvalidReason: null,
         });
         return true;
@@ -1009,15 +1019,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             cube: { key: destKey, block: destBlock },
             destUndetermined,
           };
-          const azimuth = cameraAzimuthForDirection(direction);
           return {
             blocks,
             hiddenFaces,
             buildCursor: destPos,
             buildHistory: [...s.buildHistory, step],
             undeterminedCubes: newUndetermined,
-            cameraSnapTarget: { azimuth, targetPos: destPos },
-            lastBuildAxis: direction.tqecAxis,
+            ...snapUpdate,
             history: [...s.history, { kind: "build-step" as const, step }].slice(-MAX_HISTORY),
             future: [],
             hoveredInvalidReason: null,
@@ -1299,16 +1307,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         destDetermination,
       };
 
-      const azimuth = cameraAzimuthForDirection(direction);
-
       return {
         blocks,
         hiddenFaces,
         buildCursor: destPos,
         buildHistory: [...s.buildHistory, step],
         undeterminedCubes: newUndetermined,
-        cameraSnapTarget: { azimuth, targetPos: destPos },
-        lastBuildAxis: direction.tqecAxis,
+        ...snapUpdate,
         history: [...s.history, { kind: "build-step" as const, step }].slice(-MAX_HISTORY),
         future: [],
         hoveredInvalidReason: null,

--- a/piper_draw/gui/src/stores/keybindStore.ts
+++ b/piper_draw/gui/src/stores/keybindStore.ts
@@ -101,14 +101,20 @@ export function actionToWasdKey(
 
 interface KeybindState {
   bindings: Record<BuildAction, KeyBinding>;
+  cameraFollowsBuild: boolean;
+  axisAbsoluteWasd: boolean;
   setBinding: (action: BuildAction, key: string) => void;
   resetToDefaults: () => void;
+  toggleCameraFollowsBuild: () => void;
+  toggleAxisAbsoluteWasd: () => void;
 }
 
 export const useKeybindStore = create<KeybindState>()(
   persist(
     (set) => ({
       bindings: { ...DEFAULT_BINDINGS },
+      cameraFollowsBuild: false,
+      axisAbsoluteWasd: false,
 
       setBinding: (action, key) =>
         set((state) => {
@@ -126,6 +132,11 @@ export const useKeybindStore = create<KeybindState>()(
         }),
 
       resetToDefaults: () => set({ bindings: { ...DEFAULT_BINDINGS } }),
+
+      toggleCameraFollowsBuild: () =>
+        set((s) => ({ cameraFollowsBuild: !s.cameraFollowsBuild })),
+      toggleAxisAbsoluteWasd: () =>
+        set((s) => ({ axisAbsoluteWasd: !s.axisAbsoluteWasd })),
     }),
     {
       name: "piper-draw-keybinds",
@@ -138,7 +149,8 @@ export const useKeybindStore = create<KeybindState>()(
         // Only restore persisted bindings for actions that still exist,
         // ensuring new/renamed actions always get their defaults.
         const p = persisted as Partial<KeybindState>;
-        const merged = { ...(current as KeybindState).bindings };
+        const cur = current as KeybindState;
+        const merged = { ...cur.bindings };
         if (p.bindings) {
           for (const action of BUILD_ACTIONS) {
             if (action in p.bindings) {
@@ -146,7 +158,14 @@ export const useKeybindStore = create<KeybindState>()(
             }
           }
         }
-        return { ...(current as KeybindState), bindings: merged };
+        return {
+          ...cur,
+          bindings: merged,
+          cameraFollowsBuild:
+            typeof p.cameraFollowsBuild === "boolean" ? p.cameraFollowsBuild : cur.cameraFollowsBuild,
+          axisAbsoluteWasd:
+            typeof p.axisAbsoluteWasd === "boolean" ? p.axisAbsoluteWasd : cur.axisAbsoluteWasd,
+        };
       },
     },
   ),

--- a/piper_draw/gui/src/types/index.test.ts
+++ b/piper_draw/gui/src/types/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict } from "./index";
+import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, wasdToBuildDirection } from "./index";
 import type { PipeType, CubeType } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
@@ -321,6 +321,28 @@ describe("hasYCubePipeAxisConflict", () => {
   it("does not affect regular cube placement", () => {
     const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" as BlockType }]);
     expect(hasYCubePipeAxisConflict("XZZ" as BlockType, { x: 0, y: 0, z: 0 }, blocks)).toBe(false);
+  });
+});
+
+describe("wasdToBuildDirection", () => {
+  it("axis-absolute: W/S map to TQEC X axis, A/D to TQEC Y axis", () => {
+    // Camera azimuth should be ignored in axis-absolute mode.
+    expect(wasdToBuildDirection("w", 1.3, true)).toEqual({ tqecAxis: 0, sign: 1 });
+    expect(wasdToBuildDirection("s", -2.7, true)).toEqual({ tqecAxis: 0, sign: -1 });
+    expect(wasdToBuildDirection("a", 0.5, true)).toEqual({ tqecAxis: 1, sign: 1 });
+    expect(wasdToBuildDirection("d", 3.14, true)).toEqual({ tqecAxis: 1, sign: -1 });
+  });
+
+  it("axis-absolute: arrow keys still map to vertical (Z) axis", () => {
+    expect(wasdToBuildDirection("arrowup", 0, true)).toEqual({ tqecAxis: 2, sign: 1 });
+    expect(wasdToBuildDirection("arrowdown", 0, true)).toEqual({ tqecAxis: 2, sign: -1 });
+  });
+
+  it("camera-relative (default): forward depends on camera azimuth quadrant", () => {
+    // Azimuth 0 → camera on +Z, W = build +Y
+    expect(wasdToBuildDirection("w", 0)).toEqual({ tqecAxis: 1, sign: 1 });
+    // Azimuth π/2 → W = build -X
+    expect(wasdToBuildDirection("w", Math.PI / 2)).toEqual({ tqecAxis: 0, sign: -1 });
   });
 });
 

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -1050,9 +1050,20 @@ export function determineCubeOptions(
 export function wasdToBuildDirection(
   key: "w" | "a" | "s" | "d" | "arrowup" | "arrowdown",
   cameraAzimuth: number,
+  axisAbsolute: boolean = false,
 ): BuildDirection {
   if (key === "arrowup") return { tqecAxis: 2, sign: 1 };
   if (key === "arrowdown") return { tqecAxis: 2, sign: -1 };
+
+  // Axis-absolute mode: WASD maps to fixed world axes regardless of camera.
+  if (axisAbsolute) {
+    switch (key) {
+      case "w": return { tqecAxis: 0, sign: 1 };
+      case "s": return { tqecAxis: 0, sign: -1 };
+      case "a": return { tqecAxis: 1, sign: 1 };
+      case "d": return { tqecAxis: 1, sign: -1 };
+    }
+  }
 
   // Snap to nearest 90° quadrant: 0, 1, 2, 3
   const q = ((Math.round(cameraAzimuth / (Math.PI / 2)) % 4) + 4) % 4;


### PR DESCRIPTION
## Summary
- Adds two independent toggles to build mode (left-side floating panel): **Camera Follow** (camera follows cursor and rotates on axis changes, as before) and **Axis-Locked WASD** (W/S → ±X, A/D → ±Y, ignoring camera orientation). Up/Down arrows remain vertical in both modes.
- Both toggles default to OFF and persist across sessions via the existing keybind store.
- Closes #71.

## Test plan
- [ ] In build mode, verify the two toggles appear on the left and disappear outside build mode.
- [ ] Cycle through all four on/off combinations and confirm WASD + camera behavior matches expectations.
- [ ] Reload the page and confirm toggle state persists.
- [ ] Confirm ↑/↓ always moves the cursor vertically, regardless of toggles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)