### PR TITLE
feat: flip X/Z colors on selection (#97)

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -302,6 +302,7 @@ function SelectModeHints() {
     ["Shift+Click", "Add/remove"],
     [`${modKey}A`, "Select all"],
     ["Delete", "Delete selected"],
+    ["F", "Flip colors"],
     ["Esc", "Clear selection"],
   ];
 
@@ -536,6 +537,11 @@ export default function App() {
         if ((key === "[" || key === "]") && store.viewMode.kind === "iso") {
           e.preventDefault();
           store.stepSlice(key === "]" ? 3 : -3);
+          return;
+        }
+        if (key === "f" && store.mode === "select" && store.selectedKeys.size > 0) {
+          e.preventDefault();
+          store.flipSelected();
           return;
         }
         return;

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -123,6 +123,7 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
     return count;
   });
   const deleteSelected = useBlockStore((s) => s.deleteSelected);
+  const flipSelected = useBlockStore((s) => s.flipSelected);
 
   const buildCursor = useBlockStore((s) => s.buildCursor);
   const moveBuildCursor = useBlockStore((s) => s.moveBuildCursor);
@@ -365,6 +366,15 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
             style={{ ...btnStyle(false), borderColor: "#dc3545", color: "#dc3545" }}
           >
             Delete {selectedCount}
+          </button>
+        )}
+        {selectedCount > 0 && (
+          <button
+            onClick={flipSelected}
+            title="Swap X↔Z colors on all selected blocks"
+            style={{ ...btnStyle(false), borderColor: "#4a9eff", color: "#4a9eff" }}
+          >
+            Flip {selectedCount}
           </button>
         )}
         <button

--- a/piper_draw/gui/src/stores/blockStore.test.ts
+++ b/piper_draw/gui/src/stores/blockStore.test.ts
@@ -15,6 +15,8 @@ function reset() {
     hoveredBlockType: null,
     hoveredInvalid: false,
     selectedKeys: new Set(),
+    undeterminedCubes: new Map(),
+    freeBuild: false,
   });
 }
 
@@ -297,6 +299,88 @@ describe("blockStore", () => {
       // selectedKeys still has "0,0,0" but block was removed
       useBlockStore.getState().deleteSelected();
       expect(useBlockStore.getState().blocks.size).toBe(0);
+    });
+  });
+
+  describe("flipSelected", () => {
+    it("swaps X↔Z on a selected cube", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      useBlockStore.getState().flipSelected();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXX");
+    });
+
+    it("flips a connected cube+pipe+cube chain", () => {
+      // XZZ cubes with a Z-open pipe between them (variant XZ at Z-axis = XZO)
+      // matches the cubes' X=X, Y=Z on the closed axes.
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "XZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 1 });
+      useBlockStore.setState({ pipeVariant: null, cubeType: "XZZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 3 });
+      expect(useBlockStore.getState().blocks.size).toBe(3);
+      useBlockStore.getState().selectAll();
+      useBlockStore.getState().flipSelected();
+      const b = useBlockStore.getState().blocks;
+      expect(b.get("0,0,0")?.type).toBe("ZXX");
+      expect(b.get("0,0,1")?.type).toBe("ZXO");
+      expect(b.get("0,0,3")?.type).toBe("ZXX");
+    });
+
+    it("leaves Y blocks unchanged", () => {
+      useBlockStore.setState({ cubeType: "Y" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      useBlockStore.getState().flipSelected();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("Y");
+    });
+
+    it("is a no-op when nothing is selected", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      const histBefore = useBlockStore.getState().history.length;
+      useBlockStore.getState().flipSelected();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
+      expect(useBlockStore.getState().history.length).toBe(histBefore);
+    });
+
+    it("rejects when flipping would conflict with a non-selected adjacent pipe", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "XZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 1 });
+      expect(useBlockStore.getState().blocks.size).toBe(2);
+      // Select only the cube — flipping it would mismatch the adjacent pipe.
+      useBlockStore.getState().selectBlock({ x: 0, y: 0, z: 0 }, false);
+      useBlockStore.getState().flipSelected();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
+      expect(useBlockStore.getState().blocks.get("0,0,1")?.type).toBe("XZO");
+    });
+
+    it("allows flipping across a selection boundary when freeBuild is on", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "XZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 1 });
+      useBlockStore.setState({ freeBuild: true });
+      useBlockStore.getState().selectBlock({ x: 0, y: 0, z: 0 }, false);
+      useBlockStore.getState().flipSelected();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXX");
+    });
+
+    it("can be undone and redone", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      useBlockStore.getState().flipSelected();
+      useBlockStore.getState().undo();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
+      useBlockStore.getState().redo();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXX");
+    });
+
+    it("is idempotent under double flip", () => {
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      useBlockStore.getState().flipSelected();
+      useBlockStore.getState().flipSelected();
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
     });
   });
 

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -28,6 +28,7 @@ import {
   VARIANT_AXIS_MAP,
   toggleHadamard,
   swapPipeVariant,
+  flipBlockType,
 } from "../types";
 
 export type Mode = "place" | "delete" | "select" | "build";
@@ -86,7 +87,9 @@ type UndoCommand =
       oldPlacedType: CubeType | "Y" | null; newPlacedType: CubeType | "Y";
       oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }>;
       oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo }
-  | { kind: "replace"; key: string; oldBlock: Block; newBlock: Block };
+  | { kind: "replace"; key: string; oldBlock: Block; newBlock: Block }
+  | { kind: "bulk-replace"; entries: Array<{ key: string; oldBlock: Block; newBlock: Block }>;
+      undeterminedChanges: Array<{ key: string; oldInfo?: UndeterminedCubeInfo; newInfo?: UndeterminedCubeInfo }> };
 
 interface BlockStore {
   blocks: Map<string, Block>;
@@ -129,6 +132,7 @@ interface BlockStore {
   selectBlock: (pos: Position3D, additive: boolean) => void;
   clearSelection: () => void;
   deleteSelected: () => void;
+  flipSelected: () => void;
   selectAll: () => void;
   selectBlocks: (keys: string[], additive: boolean) => void;
 
@@ -640,6 +644,27 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         };
       }
 
+      if (cmd.kind === "bulk-replace") {
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        for (const e of cmd.entries) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, e.key, e.newBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, e.key, e.oldBlock));
+        }
+        const newUndetermined = new Map(state.undeterminedCubes);
+        for (const u of cmd.undeterminedChanges) {
+          if (u.oldInfo) newUndetermined.set(u.key, { ...u.oldInfo, options: [...u.oldInfo.options] });
+          else newUndetermined.delete(u.key);
+        }
+        return {
+          blocks,
+          hiddenFaces,
+          history: newHistory,
+          future: [cmd, ...state.future].slice(0, MAX_HISTORY),
+          hoveredGridPos: null,
+          undeterminedCubes: newUndetermined,
+        };
+      }
+
       // cmd.kind === "clear" — restore saved state, rebuild spatial index
       const newIndex = buildSpatialIndex(cmd.savedBlocks);
       return {
@@ -839,6 +864,27 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         };
       }
 
+      if (cmd.kind === "bulk-replace") {
+        let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
+        for (const e of cmd.entries) {
+          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, e.key, e.oldBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, e.key, e.newBlock));
+        }
+        const newUndetermined = new Map(state.undeterminedCubes);
+        for (const u of cmd.undeterminedChanges) {
+          if (u.newInfo) newUndetermined.set(u.key, { ...u.newInfo, options: [...u.newInfo.options] });
+          else newUndetermined.delete(u.key);
+        }
+        return {
+          blocks,
+          hiddenFaces,
+          history: [...state.history, cmd],
+          future: newFuture,
+          hoveredGridPos: null,
+          undeterminedCubes: newUndetermined,
+        };
+      }
+
       // cmd.kind === "clear" — save current state, then clear
       const savedCmd: UndoCommand = {
         kind: "clear",
@@ -961,6 +1007,71 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         selectedKeys: new Set<string>(),
         hoveredGridPos: null,
         undeterminedCubes: newUndetermined,
+      };
+    }),
+
+  flipSelected: () =>
+    set((state) => {
+      if (state.selectedKeys.size === 0) return state;
+
+      const entries: Array<{ key: string; oldBlock: Block; newBlock: Block }> = [];
+      for (const key of state.selectedKeys) {
+        const block = state.blocks.get(key);
+        if (!block) continue;
+        const newType = flipBlockType(block.type);
+        if (newType === block.type) continue;
+        entries.push({ key, oldBlock: block, newBlock: { pos: block.pos, type: newType } });
+      }
+      if (entries.length === 0) return state;
+
+      // Simulated post-flip map for color-conflict checks against non-selected neighbors.
+      const proposed = new Map(state.blocks);
+      for (const e of entries) proposed.set(e.key, e.newBlock);
+
+      if (!state.freeBuild) {
+        for (const e of entries) {
+          const { pos, type } = e.newBlock;
+          if (isPipeType(type)) {
+            if (hasPipeColorConflict(type, pos, proposed)) {
+              return { hoveredInvalidReason: "Flip blocked: selection boundary mismatches adjacent colors" };
+            }
+          } else if (type !== "Y") {
+            if (hasCubeColorConflict(type as CubeType, pos, proposed)) {
+              return { hoveredInvalidReason: "Flip blocked: selection boundary mismatches adjacent colors" };
+            }
+          }
+          if (hasYCubePipeAxisConflict(type, pos, proposed)) {
+            return { ...state, hoveredInvalidReason: "Flip blocked: selection boundary mismatches adjacent colors" };
+          }
+        }
+      }
+
+      let blocks = state.blocks;
+      let hiddenFaces = state.hiddenFaces;
+      for (const e of entries) {
+        ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, e.key, e.oldBlock));
+        ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, e.key, e.newBlock));
+      }
+
+      const newUndetermined = new Map(state.undeterminedCubes);
+      const undeterminedChanges: Array<{ key: string; oldInfo?: UndeterminedCubeInfo; newInfo?: UndeterminedCubeInfo }> = [];
+      for (const e of entries) {
+        const key = e.key;
+        const oldInfo = state.undeterminedCubes.get(key);
+        if (oldInfo) {
+          newUndetermined.delete(key);
+          undeterminedChanges.push({ key, oldInfo, newInfo: undefined });
+        }
+      }
+
+      const cmd: UndoCommand = { kind: "bulk-replace", entries, undeterminedChanges };
+      return {
+        blocks,
+        hiddenFaces,
+        history: [...state.history, cmd].slice(-MAX_HISTORY),
+        future: [],
+        undeterminedCubes: newUndetermined,
+        hoveredInvalidReason: null,
       };
     }),
 

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1028,20 +1028,21 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       const proposed = new Map(state.blocks);
       for (const e of entries) proposed.set(e.key, e.newBlock);
 
+      const flipBlocked = "Flip blocked: selection boundary mismatches adjacent colors";
       if (!state.freeBuild) {
         for (const e of entries) {
           const { pos, type } = e.newBlock;
           if (isPipeType(type)) {
             if (hasPipeColorConflict(type, pos, proposed)) {
-              return { hoveredInvalidReason: "Flip blocked: selection boundary mismatches adjacent colors" };
+              return { hoveredInvalidReason: flipBlocked };
             }
           } else if (type !== "Y") {
             if (hasCubeColorConflict(type as CubeType, pos, proposed)) {
-              return { hoveredInvalidReason: "Flip blocked: selection boundary mismatches adjacent colors" };
+              return { hoveredInvalidReason: flipBlocked };
             }
           }
           if (hasYCubePipeAxisConflict(type, pos, proposed)) {
-            return { ...state, hoveredInvalidReason: "Flip blocked: selection boundary mismatches adjacent colors" };
+            return { hoveredInvalidReason: flipBlocked };
           }
         }
       }

--- a/piper_draw/gui/src/types/index.test.ts
+++ b/piper_draw/gui/src/types/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, wasdToBuildDirection } from "./index";
+import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, wasdToBuildDirection, flipBlockType, CUBE_TYPES, PIPE_TYPES } from "./index";
 import type { PipeType, CubeType } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
@@ -360,5 +360,37 @@ describe("createBlockGeometry", () => {
     const hidden = createBlockGeometry("OZX", FACE_POS_Z);
 
     expect((full.getIndex()?.count ?? 0) - (hidden.getIndex()?.count ?? 0)).toBe(6);
+  });
+});
+
+describe("flipBlockType", () => {
+  it("swaps X↔Z in cube types", () => {
+    expect(flipBlockType("XZZ")).toBe("ZXX");
+    expect(flipBlockType("ZXZ")).toBe("XZX");
+    expect(flipBlockType("XXZ")).toBe("ZZX");
+  });
+
+  it("swaps closed-axis characters on pipes (preserving O and H)", () => {
+    expect(flipBlockType("OXZ")).toBe("OZX");
+    expect(flipBlockType("XOZH")).toBe("ZOXH");
+    expect(flipBlockType("ZXOH")).toBe("XZOH");
+  });
+
+  it("leaves Y unchanged", () => {
+    expect(flipBlockType("Y")).toBe("Y");
+  });
+
+  it("maps every cube and pipe type to another valid type", () => {
+    for (const ct of CUBE_TYPES) {
+      expect(CUBE_TYPES).toContain(flipBlockType(ct));
+    }
+    for (const pt of PIPE_TYPES) {
+      expect(PIPE_TYPES).toContain(flipBlockType(pt));
+    }
+  });
+
+  it("is an involution", () => {
+    for (const ct of CUBE_TYPES) expect(flipBlockType(flipBlockType(ct))).toBe(ct);
+    for (const pt of PIPE_TYPES) expect(flipBlockType(flipBlockType(pt))).toBe(pt);
   });
 });

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -998,6 +998,21 @@ export function swapPipeVariant(pipeBase: string): string {
 }
 
 /**
+ * Flip basis colors on any BlockType by globally swapping X↔Z.
+ * Cubes: "XZZ" → "ZXX", pipes: "OXZ" → "OZX", "XZOH" → "ZXOH". Y is returned unchanged.
+ */
+export function flipBlockType(type: BlockType): BlockType {
+  if (type === "Y") return type;
+  let out = "";
+  for (const ch of type) {
+    if (ch === "X") out += "Z";
+    else if (ch === "Z") out += "X";
+    else out += ch;
+  }
+  return out as BlockType;
+}
+
+/**
  * Infer the non-Hadamard PipeType to place from a source cube along the given axis.
  * The pipe's closed-axis characters come from the source cube's type characters.
  * Returns null if the closed-axis characters are both the same (e.g. "OZZ"),


### PR DESCRIPTION
## Summary
- Adds a "Flip" action in select mode that swaps X↔Z basis on every selected cube/pipe. Y blocks stay unchanged; Hadamard pipes keep their `H` suffix.
- Wired to a toolbar button (shown next to Delete when ≥1 block is selected) and the `F` hotkey (hint added to the select-mode hints panel).
- Undo/redo via a new `bulk-replace` command; respects existing color-adjacency validation and is a no-op in a way that refuses to flip when the boundary to non-selected neighbors would mismatch (skipped when `freeBuild` is on).

Closes #97.

## Test plan
- [x] Unit: `flipBlockType` helper (X↔Z cubes, pipes with H preserved, Y unchanged, involution) — 5 tests
- [x] Unit: `flipSelected` store action (single, connected chain, Y no-op, empty selection, boundary rejection, freeBuild override, undo/redo, double-flip idempotence) — 8 tests
- [x] `npm test` passes (146/146)
- [x] `npx tsc -b` clean
- [x] Manual: place blocks, select, click Flip / press F, colors swap; undo restores; boundary conflict rejected

🤖 Generated with [Claude Code](https://claude.com/claude-code)