### PR TITLE
Add Photo button: export current 3D view as PNG (#102)

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -32,6 +32,7 @@ import { useKeybindStore, buildActionForKey, actionToWasdKey } from "./stores/ke
 import { wasdToBuildDirection, tqecToThree, type Block } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
+import { downloadPng } from "./utils/photoExport";
 
 const GRID_SNAP = 3;
 
@@ -247,6 +248,41 @@ function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> })
   return null;
 }
 
+/**
+ * Captures the WebGL canvas as a PNG when `photoRequest` is set.
+ * Waits two animation frames so React's commit (which hides grid/overlays)
+ * and R3F's subsequent render both complete before reading pixels.
+ */
+function ScreenshotCapture() {
+  const photoRequest = useBlockStore((s) => s.photoRequest);
+  const clearPhotoRequest = useBlockStore((s) => s.clearPhotoRequest);
+  const { gl } = useThree();
+
+  useEffect(() => {
+    if (!photoRequest) return;
+    let raf1 = 0;
+    let raf2 = 0;
+    let cancelled = false;
+    raf1 = requestAnimationFrame(() => {
+      raf2 = requestAnimationFrame(() => {
+        if (cancelled) return;
+        downloadPng(gl.domElement).catch((err) => {
+          console.error("Photo export failed:", err);
+        }).finally(() => {
+          clearPhotoRequest();
+        });
+      });
+    });
+    return () => {
+      cancelled = true;
+      cancelAnimationFrame(raf1);
+      cancelAnimationFrame(raf2);
+    };
+  }, [photoRequest, gl, clearPhotoRequest]);
+
+  return null;
+}
+
 /** Exposes Three.js camera + viewport size to HTML components via a shared ref. Must be inside <Canvas>. */
 function ThreeStateBridge({ stateRef }: { stateRef: React.MutableRefObject<ThreeState | null> }) {
   const { camera, size } = useThree();
@@ -301,6 +337,7 @@ export default function App() {
   const [keybindEditorOpen, setKeybindEditorOpen] = useState(false);
   const [helpOpen, setHelpOpen] = useState(false);
   const threeStateRef = useRef<ThreeState | null>(null);
+  const photoRequest = useBlockStore((s) => s.photoRequest);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -485,26 +522,29 @@ export default function App() {
       <PlacementWarning toolbarRef={toolbarRef} />
       <Canvas
         camera={{ position: [14, 14, -14], fov: 35, near: 0.1, far: 100000 }}
-        gl={{ logarithmicDepthBuffer: true, toneMapping: THREE.ACESFilmicToneMapping }}
+        gl={{ logarithmicDepthBuffer: true, toneMapping: THREE.ACESFilmicToneMapping, preserveDrawingBuffer: true }}
         onContextMenu={(e) => e.preventDefault()}
       >
         <color attach="background" args={["#CBDFC6"]} />
         <ambientLight intensity={1.4} />
         <directionalLight position={[10, 10, 10]} intensity={1.0} />
         <BlockInstances />
-        <InvalidBlockHighlights />
-        <SelectionHighlights />
-        <BuildCursor />
-        <OpenPipeGhosts />
+        {!photoRequest && <InvalidBlockHighlights />}
+        {!photoRequest && <SelectionHighlights />}
+        {!photoRequest && <BuildCursor />}
+        {!photoRequest && <OpenPipeGhosts />}
         <CameraBuildSnap controlsRef={controlsRef} />
         <GridPlane />
-        <GhostBlock />
+        {!photoRequest && <GhostBlock />}
         <AxisLabels />
         <FpsSampler targetRef={fpsRef} />
-        <CheckerboardGrid />
-        <GizmoHelper alignment="bottom-right" margin={[80, 80]}>
-          <OrientationGizmo />
-        </GizmoHelper>
+        {!photoRequest && <CheckerboardGrid />}
+        {!photoRequest && (
+          <GizmoHelper alignment="bottom-right" margin={[80, 80]}>
+            <OrientationGizmo />
+          </GizmoHelper>
+        )}
+        <ScreenshotCapture />
         <ThreeStateBridge stateRef={threeStateRef} />
         <OrbitControls
           ref={controlsRef}

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -386,6 +386,14 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
         >
           Export
         </button>
+        <button
+          onClick={() => useBlockStore.getState().requestPhoto()}
+          disabled={blocksEmpty}
+          title="Save current view as PNG"
+          style={{ ...btnStyle(false), opacity: blocksEmpty ? 0.4 : 1, cursor: blocksEmpty ? "default" : "pointer" }}
+        >
+          Photo
+        </button>
         <TemplatePicker onLoad={loadBlocks} />
       </div>
 

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -143,6 +143,11 @@ interface BlockStore {
   // Free build (disables color-matching validation)
   freeBuild: boolean;
   toggleFreeBuild: () => void;
+
+  // Photo export — transient flag consumed by ScreenshotCapture inside <Canvas>.
+  photoRequest: boolean;
+  requestPhoto: () => void;
+  clearPhotoRequest: () => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -238,6 +243,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
   freeBuild: false,
   toggleFreeBuild: () => set((s) => ({ freeBuild: !s.freeBuild })),
+
+  photoRequest: false,
+  requestPhoto: () => set({ photoRequest: true }),
+  clearPhotoRequest: () => set({ photoRequest: false }),
 
   setMode: (mode) => {
     const prev = get();

--- a/piper_draw/gui/src/utils/photoExport.ts
+++ b/piper_draw/gui/src/utils/photoExport.ts
@@ -1,0 +1,38 @@
+/**
+ * Save a canvas as a PNG, prompting the user for save location and name.
+ * Uses the File System Access API (showSaveFilePicker) when available,
+ * with a fallback to a traditional download for unsupported browsers.
+ */
+export async function downloadPng(canvas: HTMLCanvasElement, filename = "pipe-diagram.png"): Promise<void> {
+  const blob = await new Promise<Blob | null>((resolve) => canvas.toBlob(resolve, "image/png"));
+  if (!blob) throw new Error("Failed to encode canvas as PNG");
+
+  const w = window as Window & { showSaveFilePicker?: (opts: unknown) => Promise<FileSystemFileHandle> };
+  if (typeof w.showSaveFilePicker === "function") {
+    try {
+      const handle = await w.showSaveFilePicker({
+        suggestedName: filename,
+        types: [
+          {
+            description: "PNG image",
+            accept: { "image/png": [".png"] },
+          },
+        ],
+      });
+      const writable = await handle.createWritable();
+      await writable.write(blob);
+      await writable.close();
+      return;
+    } catch (err: unknown) {
+      if (err instanceof DOMException && err.name === "AbortError") return;
+      throw err;
+    }
+  }
+
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Summary
- New Photo button in the toolbar saves the current 3D view as a PNG via `showSaveFilePicker` (with `a.download` fallback).
- During capture, hides the checkerboard grid, orientation gizmo, selection highlights, build cursor, and ghost previews so the image contains only the pipe diagram and X/Y/Z axis.
- Implemented as a transient `photoRequest` store flag consumed by a new `ScreenshotCapture` component inside `<Canvas>`; canvas uses `preserveDrawingBuffer: true` plus a double-rAF to capture a clean frame.

Closes #102.

## Test plan
- [ ] `cd piper_draw/gui && npm run dev`, place some blocks, rotate/zoom to a desired angle
- [ ] Click **Photo** → save dialog appears → save the PNG
- [ ] Open the PNG: diagram + X/Y/Z axis present, no grid, no orientation gizmo, no highlights/cursors/ghosts
- [ ] After saving, UI returns to normal (grid, gizmo, highlights reappear)
- [ ] Photo button is disabled when the diagram is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)