### PR TITLE
Zoom toward cursor in perspective and iso views (#106)

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -228,6 +228,7 @@ function ViewportCamera({ controlsRef }: { controlsRef: React.RefObject<any> }) 
           ref={controlsRef}
           makeDefault
           enableRotate
+          zoomToCursor
           maxDistance={50000}
           screenSpacePanning={false}
           mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN }}
@@ -278,6 +279,7 @@ function IsoViewport({
         ref={controlsRef}
         makeDefault
         enableRotate={false}
+        zoomToCursor
         maxZoom={500}
         minZoom={2}
         screenSpacePanning={false}


### PR DESCRIPTION
## Summary
- Enables three.js OrbitControls `zoomToCursor` on both the perspective and iso/ortho viewports so mouse-wheel zoom anchors at the cursor (Google-Earth style) instead of dollying toward the orbit target.
- Fixes #106.

## Test plan
- [ ] Perspective: hover a block in a corner, scroll in/out — point stays under cursor; rotate/pan unchanged.
- [ ] Iso: hover a point on a slice, scroll in/out — point stays under cursor; min/max zoom clamp still works; switching slice/axis re-centers cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)