### PR TITLE
feat: extend colored axes to infinity, remove X/Y/Z labels

### DIFF
--- a/piper_draw/gui/src/components/AxisLabels.tsx
+++ b/piper_draw/gui/src/components/AxisLabels.tsx
@@ -1,35 +1,19 @@
-import { Html, Line } from "@react-three/drei";
+import { Line } from "@react-three/drei";
 
-const AXIS_LENGTH = 20;
+const AXIS_LENGTH = 10000;
 const ORIGIN: [number, number, number] = [0, 0, 0];
 
-const axes: { label: string; color: string; end: [number, number, number] }[] = [
-  { label: "X", color: "#ff7f7f", end: [AXIS_LENGTH, 0, 0] },
-  { label: "Y", color: "#44cc44", end: [0, 0, -AXIS_LENGTH] },
-  { label: "Z", color: "#7396ff", end: [0, AXIS_LENGTH, 0] },
+const axes: { key: string; color: string; end: [number, number, number] }[] = [
+  { key: "X", color: "#ff7f7f", end: [AXIS_LENGTH, 0, 0] },
+  { key: "Y", color: "#44cc44", end: [0, 0, -AXIS_LENGTH] },
+  { key: "Z", color: "#7396ff", end: [0, AXIS_LENGTH, 0] },
 ];
 
 export function AxisLabels() {
   return (
     <group>
-      {axes.map(({ label, color, end }) => (
-        <group key={label}>
-          <Line points={[ORIGIN, end]} color={color} lineWidth={2} />
-          <Html
-            position={end}
-            center
-            style={{
-              color,
-              fontSize: "14px",
-              fontWeight: "bold",
-              fontFamily: "sans-serif",
-              pointerEvents: "none",
-              userSelect: "none",
-            }}
-          >
-            {label}
-          </Html>
-        </group>
+      {axes.map(({ key, color, end }) => (
+        <Line key={key} points={[ORIGIN, end]} color={color} lineWidth={2} />
       ))}
     </group>
   );


### PR DESCRIPTION
## Summary
- Removes the X/Y/Z HTML labels from the reference axes
- Extends the three colored positive axis lines to a length of 10000 (within the camera's 100000 far plane) so they read as infinite

## Test plan
- [ ] Open the 3D view and confirm the red/green/blue positive axes extend far past the scene with no X/Y/Z labels visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)