### PR TITLE
fix: clarify build-direction warnings

### DIFF
--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1389,7 +1389,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         } else {
           // Displayed type can't pipe here. Only fall back when remaining options agree.
           const pipeSet = new Set(validForDir.map(opt => inferPipeType(opt, direction.tqecAxis)));
-          if (pipeSet.size > 1) return reject("Ambiguous pipe type — cycle with R first");
+          if (pipeSet.size > 1) return reject("Ambiguous pipe type — cycle with C first");
           srcType = validForDir[0];
         }
         sourceDetermination = {
@@ -1412,7 +1412,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const bestScore = charMatchCount(ranked[0], srcType);
           const bestTied = ranked.filter(ct => charMatchCount(ct, srcType) === bestScore);
           const pipeSet = new Set(bestTied.map(ct => inferPipeType(ct, direction.tqecAxis)));
-          if (pipeSet.size > 1) return reject("Ambiguous pipe type — cycle with R first");
+          if (pipeSet.size > 1) return reject("Cube colors don't match — cannot build in this direction");
           sourceRetype = { key: srcKey, prevType: srcType };
           srcType = ranked[0];
         }


### PR DESCRIPTION
## Summary
- The "Ambiguous pipe type — cycle with R first" message fired in two places in `blockStore.ts` where it was misleading.
- In the retype branch for a **determined** source cube whose color doesn't support the build axis, the real cause is a color mismatch, not ambiguity — now shows "Cube colors don't match — cannot build in this direction" (consistent with the sibling branch).
- In the **undetermined** source branch, "cycle with R" pointed at `cyclePipe`, but the user needs `cycleBlock` — now says "cycle with C first".

## Test plan
- [ ] Place a lone `XZZ` cube, try to build in X — expect "Cube colors don't match…".
- [ ] Undetermined cube whose displayed option can't pipe in direction, other options disagree — expect "…cycle with C first".

🤖 Generated with [Claude Code](https://claude.com/claude-code)