### PR TITLE
Move FPS counter into toolbar below position indicator

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -15,7 +15,7 @@ import { BlockInstances } from "./components/BlockInstances";
 import { GridPlane } from "./components/GridPlane";
 import { GhostBlock } from "./components/GhostBlock";
 import { AxisLabels } from "./components/AxisLabels";
-import { FpsDisplay, FpsSampler } from "./components/FpsCounter";
+import { FpsSampler } from "./components/FpsCounter";
 import { OrientationGizmo } from "./components/OrientationGizmo";
 import { Toolbar } from "./components/Toolbar";
 import { ValidationToast } from "./components/ValidationToast";
@@ -630,6 +630,7 @@ export default function App() {
         }}
         controlsRef={controlsRef}
         toolbarRef={toolbarRef}
+        fpsRef={fpsRef}
       />
       <ValidationToast toolbarRef={toolbarRef} controlsRef={controlsRef} />
       <button
@@ -660,22 +661,6 @@ export default function App() {
         ?
       </button>
       {helpOpen && <HelpPanel onClose={() => setHelpOpen(false)} />}
-      <div
-        onPointerDown={(e) => e.stopPropagation()}
-        style={{
-          position: "fixed",
-          top: 10,
-          right: 16,
-          zIndex: 1,
-          background: "rgba(255,255,255,0.9)",
-          padding: "6px 12px",
-          borderRadius: "8px",
-          border: "1px solid #ddd",
-          boxShadow: "0 1px 4px rgba(0,0,0,0.1)",
-        }}
-      >
-        <FpsDisplay spanRef={fpsRef} />
-      </div>
       <SelectModeHints onCustomize={() => setKeybindEditorMode("select")} />
       <BuildModeHints onCustomize={() => setKeybindEditorMode("build")} />
       <PlaceModeHints onCustomize={() => setKeybindEditorMode("place")} />

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
 import { usePreviewImages } from "./PreviewRenderer";
+import { FpsDisplay } from "./FpsCounter";
 import type { ViewMode } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -99,7 +100,7 @@ const blockBtnStyle = (active: boolean, disabled?: boolean) => ({
 // ---------------------------------------------------------------------------
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCamera: () => void; controlsRef: React.RefObject<any>; toolbarRef: React.RefObject<HTMLDivElement | null> }) {
+export function Toolbar({ onResetCamera, controlsRef, toolbarRef, fpsRef }: { onResetCamera: () => void; controlsRef: React.RefObject<any>; toolbarRef: React.RefObject<HTMLDivElement | null>; fpsRef: React.RefObject<HTMLSpanElement | null> }) {
   const scale = useToolbarScale(toolbarRef);
   const mode = useBlockStore((s) => s.mode);
   const setMode = useBlockStore((s) => s.setMode);
@@ -655,30 +656,35 @@ export function Toolbar({ onResetCamera, controlsRef, toolbarRef }: { onResetCam
 
       {/* Position display */}
       <div style={{ width: 1, background: "#ddd" }} />
-      <div style={{ display: "flex", flexDirection: "column", justifyContent: "center", fontFamily: "monospace", fontSize: "12px", color: "#555", lineHeight: "1.6", minWidth: 90 }}>
-        <span style={groupLabelStyle}>Position</span>
-        {mode === "build" && buildCursor ? (
-          <PositionEditor pos={buildCursor} onCommit={moveBuildCursor} />
-        ) : (() => {
-          const pos: Position3D | null = hoveredGridPos;
-          const bt: BlockType | null = useBlockStore.getState().hoveredBlockType;
-          if (!pos) return <><span>X: —</span><span>Y: —</span><span>Z: —</span></>;
-          const isPipe = bt ? isPipeType(bt) : pipeAxisFromPos(pos) !== null;
-          if (isPipe) {
-            const axis = pipeAxisFromPos(pos);
-            const coords = [pos.x, pos.y, pos.z];
-            const labels = ["X", "Y", "Z"];
-            return labels.map((l, i) => {
-              if (i === axis) {
-                const c1 = (coords[i] - 1) / 3;
-                const c2 = (coords[i] + 2) / 3;
-                return <span key={i}>{l}: {c1} → {c2}</span>;
-              }
-              return <span key={i}>{l}: {coords[i] / 3}</span>;
-            });
-          }
-          return <><span>X: {pos.x / 3}</span><span>Y: {pos.y / 3}</span><span>Z: {pos.z / 3}</span></>;
-        })()}
+      <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", fontFamily: "monospace", fontSize: "12px", color: "#555", lineHeight: "1.6", minWidth: 90 }}>
+        <div style={{ display: "flex", flexDirection: "column" }}>
+          <span style={groupLabelStyle}>Position</span>
+          {mode === "build" && buildCursor ? (
+            <PositionEditor pos={buildCursor} onCommit={moveBuildCursor} />
+          ) : (() => {
+            const pos: Position3D | null = hoveredGridPos;
+            const bt: BlockType | null = useBlockStore.getState().hoveredBlockType;
+            if (!pos) return <><span>X: —</span><span>Y: —</span><span>Z: —</span></>;
+            const isPipe = bt ? isPipeType(bt) : pipeAxisFromPos(pos) !== null;
+            if (isPipe) {
+              const axis = pipeAxisFromPos(pos);
+              const coords = [pos.x, pos.y, pos.z];
+              const labels = ["X", "Y", "Z"];
+              return labels.map((l, i) => {
+                if (i === axis) {
+                  const c1 = (coords[i] - 1) / 3;
+                  const c2 = (coords[i] + 2) / 3;
+                  return <span key={i}>{l}: {c1} → {c2}</span>;
+                }
+                return <span key={i}>{l}: {coords[i] / 3}</span>;
+              });
+            }
+            return <><span>X: {pos.x / 3}</span><span>Y: {pos.y / 3}</span><span>Z: {pos.z / 3}</span></>;
+          })()}
+        </div>
+        <div style={{ textAlign: "center" }}>
+          <FpsDisplay spanRef={fpsRef} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed the floating top-right FPS badge and rendered the FPS counter as part of the toolbar's bottom-right column, directly below the X/Y/Z position readout.
- `Toolbar` now receives `fpsRef` and uses `justify-content: space-between` on the position column so FPS anchors to the bottom; `FpsSampler` remains inside the Canvas.

## Test plan
- [ ] Verify FPS shows at the bottom of the toolbar's Position section in select, place, and build modes
- [ ] Confirm no floating FPS badge remains in the top-right corner