### PR TITLE
Responsive hint bar + help button alignment

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -640,8 +640,8 @@ export default function App() {
         title="About piper-draw"
         style={{
           position: "fixed",
-          bottom: 16,
-          left: 16,
+          bottom: 20,
+          left: 20,
           zIndex: 1,
           width: 32,
           height: 32,

--- a/piper_draw/gui/src/components/HintBar.tsx
+++ b/piper_draw/gui/src/components/HintBar.tsx
@@ -1,4 +1,11 @@
-import type { ReactNode } from "react";
+import { useRef, type ReactNode } from "react";
+import { useViewportFitScale } from "../hooks/useViewportFitScale";
+
+// Reserve horizontal space on both sides so the centered hint bar stays
+// clear of the "?" help button at bottom-left (left: 20, width: 32 ⇒ right
+// edge at 52). Margin is symmetric because the bar is centered; 64 px per
+// side = 52 for the button + 12 px gap.
+const HINT_BAR_VIEWPORT_MARGIN_PX = 128;
 
 export function HintBar({
   hints,
@@ -7,28 +14,32 @@ export function HintBar({
   hints: ReadonlyArray<readonly [string, string]>;
   trailing?: ReactNode;
 }) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  const scale = useViewportFitScale(ref, HINT_BAR_VIEWPORT_MARGIN_PX);
   return (
     <div
+      ref={ref}
       style={{
         position: "fixed",
-        bottom: 60,
+        bottom: 20,
         left: "50%",
-        transform: "translateX(-50%)",
+        transform: `translateX(-50%) scale(${scale})`,
+        transformOrigin: "bottom center",
         zIndex: 1,
         display: "flex",
         gap: "6px",
         alignItems: "center",
         background: "rgba(0,0,0,0.7)",
         color: "#fff",
-        padding: "6px 14px",
+        height: 32,
+        boxSizing: "border-box",
+        padding: "0 14px",
         borderRadius: "8px",
         fontSize: "12px",
         fontFamily: "sans-serif",
         pointerEvents: "none",
         boxShadow: "0 2px 8px rgba(0,0,0,0.2)",
         whiteSpace: "nowrap",
-        maxWidth: "calc(100vw - 32px)",
-        overflowX: "auto",
       }}
     >
       {hints.map(([key, action], i) => (

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -8,49 +8,12 @@ import { triggerDaeImport } from "../utils/daeImport";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
 import { usePreviewImages } from "./PreviewRenderer";
 import { FpsDisplay } from "./FpsCounter";
+import { useViewportFitScale } from "../hooks/useViewportFitScale";
 import type { ViewMode } from "../types";
 
-// ---------------------------------------------------------------------------
-// Responsive sizing
-// ---------------------------------------------------------------------------
-
-// Horizontal margin (px) kept between the toolbar and the viewport edges
-// when the toolbar is scaled down to fit a narrow window.
-const TOOLBAR_VIEWPORT_MARGIN_PX = 20;
-
-// Returns a CSS scale factor that keeps the toolbar at its natural size when
-// it fits in the viewport, and shrinks it just enough to fit when it doesn't.
-function useToolbarScale(toolbarRef: React.RefObject<HTMLDivElement | null>): number {
-  const [scale, setScale] = useState(1);
-  useEffect(() => {
-    let frame = 0;
-    const recompute = () => {
-      if (frame) return;
-      frame = requestAnimationFrame(() => {
-        frame = 0;
-        const node = toolbarRef.current;
-        if (!node) return;
-        // offsetWidth is the layout (untransformed) width — independent of
-        // the scale we apply, so this measurement is stable across renders.
-        const natural = node.offsetWidth;
-        if (natural === 0) return;
-        const available = window.innerWidth - TOOLBAR_VIEWPORT_MARGIN_PX;
-        setScale(Math.min(1, available / natural));
-      });
-    };
-    const node = toolbarRef.current;
-    const ro = node ? new ResizeObserver(recompute) : null;
-    if (node && ro) ro.observe(node);
-    window.addEventListener("resize", recompute);
-    recompute();
-    return () => {
-      ro?.disconnect();
-      window.removeEventListener("resize", recompute);
-      if (frame) cancelAnimationFrame(frame);
-    };
-  }, [toolbarRef]);
-  return scale;
-}
+// Horizontal margin (px) kept between fixed overlays (toolbar, hint bar) and
+// the viewport edges when they scale down to fit a narrow window.
+const VIEWPORT_FIT_MARGIN_PX = 20;
 
 // ---------------------------------------------------------------------------
 // Styles
@@ -101,7 +64,7 @@ const blockBtnStyle = (active: boolean, disabled?: boolean) => ({
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function Toolbar({ onResetCamera, controlsRef, toolbarRef, fpsRef }: { onResetCamera: () => void; controlsRef: React.RefObject<any>; toolbarRef: React.RefObject<HTMLDivElement | null>; fpsRef: React.RefObject<HTMLSpanElement | null> }) {
-  const scale = useToolbarScale(toolbarRef);
+  const scale = useViewportFitScale(toolbarRef, VIEWPORT_FIT_MARGIN_PX);
   const mode = useBlockStore((s) => s.mode);
   const setMode = useBlockStore((s) => s.setMode);
   const cubeType = useBlockStore((s) => s.cubeType);

--- a/piper_draw/gui/src/hooks/useViewportFitScale.ts
+++ b/piper_draw/gui/src/hooks/useViewportFitScale.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+
+// Returns a CSS scale factor that keeps an element at its natural size when
+// it fits within the viewport (minus `marginPx` on each side), and shrinks it
+// just enough to fit when it doesn't.
+export function useViewportFitScale(
+  ref: React.RefObject<HTMLElement | null>,
+  marginPx: number,
+): number {
+  const [scale, setScale] = useState(1);
+  useEffect(() => {
+    let frame = 0;
+    const recompute = () => {
+      if (frame) return;
+      frame = requestAnimationFrame(() => {
+        frame = 0;
+        const node = ref.current;
+        if (!node) return;
+        // offsetWidth is the layout (untransformed) width — independent of
+        // the scale we apply, so this measurement is stable across renders.
+        const natural = node.offsetWidth;
+        if (natural === 0) return;
+        const available = window.innerWidth - marginPx;
+        setScale(Math.min(1, available / natural));
+      });
+    };
+    const node = ref.current;
+    const ro = node ? new ResizeObserver(recompute) : null;
+    if (node && ro) ro.observe(node);
+    window.addEventListener("resize", recompute);
+    recompute();
+    return () => {
+      ro?.disconnect();
+      window.removeEventListener("resize", recompute);
+      if (frame) cancelAnimationFrame(frame);
+    };
+  }, [ref, marginPx]);
+  return scale;
+}


### PR DESCRIPTION
## Summary
- Extract a shared `useViewportFitScale` hook so the hint bar scales with window width the same way the toolbar already does.
- Reposition the hint bar to `bottom: 20` with a fixed `height: 32`, reserving symmetric horizontal margin so the centered bar stays clear of the bottom-left help button.
- Move the `?` help button from `(16, 16)` to `(20, 20)` so its bottom margin lines up with the hint bar.

## Test plan
- [ ] Verify hint bar shrinks proportionally when window is narrowed (no overflow, no text clipping).
- [ ] Verify hint bar and help button have matching ~20 px bottom margins and do not overlap at any viewport width.
- [ ] Verify toolbar still scales as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)