### PR TITLE
fix: allow port placement off the ground plane in iso mode

### DIFF
--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -74,7 +74,7 @@ export function GridPlane() {
     // PortPlacementGhost (OpenPipeGhosts.tsx) reads hoveredGridPos and renders a
     // ghost cube at empty slots.
     if (store.armedTool === "port") {
-      const pos = snapGroundPos(e.point.x, -e.point.z, false);
+      const pos = snapForViewMode(viewMode, e.point, false);
       const key = posKey(pos);
       if (store.blocks.has(key) || store.portPositions.has(key)) {
         setHoveredGridPos(null);
@@ -126,7 +126,7 @@ export function GridPlane() {
     }
     // Port tool: place an explicit port marker at the snapped cube position.
     if (store.armedTool === "port") {
-      const pos = snapGroundPos(e.point.x, -e.point.z, false);
+      const pos = snapForViewMode(viewMode, e.point, false);
       store.addPortAt(pos);
       return;
     }


### PR DESCRIPTION
## Summary
- In iso mode, the port tool's hover and click handlers used `snapGroundPos`, which always returns `z = 0`, so ports could only be placed on the ground plane.
- Switched both handlers in `GridPlane.tsx` to `snapForViewMode`, which delegates to `snapIsoPos` in iso mode — matching how cubes and pipes already snap to the active slice plane.

## Test plan
- [ ] In iso mode (X, Y, and Z slices), arm the port tool and confirm ports can be placed at slice coordinates other than the ground plane.
- [ ] Confirm perspective mode port placement still behaves as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)