### PR TITLE
fix: keep iso camera locked after drag in edit mode

### DIFF
--- a/piper_draw/gui/src/components/SelectModePointer.tsx
+++ b/piper_draw/gui/src/components/SelectModePointer.tsx
@@ -120,6 +120,11 @@ export function SelectModePointer({
 
   const [marqueeRect, setMarqueeRect] = useState<{ x: number; y: number; w: number; h: number } | null>(null);
 
+  // Iso mode locks the camera to a 2D plane — rotation must stay disabled after a drag ends.
+  const restoreRotate = useCallback(() => {
+    return useBlockStore.getState().viewMode.kind === "persp";
+  }, []);
+
   const cancelDrag = useCallback(() => {
     const state = dragRef.current;
     if (!state) return;
@@ -132,7 +137,7 @@ export function SelectModePointer({
       useBlockStore.getState().setDragState({ isDragging: false, delta: null, valid: true });
     }
     if (controlsRef.current) {
-      controlsRef.current.enableRotate = true;
+      controlsRef.current.enableRotate = restoreRotate();
       controlsRef.current.enablePan = true;
     }
     dragRef.current = null;
@@ -141,7 +146,7 @@ export function SelectModePointer({
       cancelAnimationFrame(rafRef.current);
       rafRef.current = null;
     }
-  }, [controlsRef]);
+  }, [controlsRef, restoreRotate]);
 
   const updateDragFromLatest = useCallback(() => {
     rafRef.current = null;
@@ -338,7 +343,7 @@ export function SelectModePointer({
         // already released
       }
       if (controlsRef.current) {
-        controlsRef.current.enableRotate = true;
+        controlsRef.current.enableRotate = restoreRotate();
         controlsRef.current.enablePan = true;
       }
 
@@ -387,7 +392,7 @@ export function SelectModePointer({
         useBlockStore.getState().moveSelection(commitDelta);
       }
     },
-    [controlsRef, threeStateRef],
+    [controlsRef, threeStateRef, restoreRotate],
   );
 
   const onKeyDown = useCallback(


### PR DESCRIPTION
## Summary
- In iso mode, `SelectModePointer` was unconditionally setting `controls.enableRotate = true` after every drag/cancel, overriding `IsoViewport`'s `enableRotate={false}` prop. With the default `navStyle=pan`, Shift+drag then swapped to ROTATE and tilted the camera off the locked 2D plane.
- Fixed by restoring `enableRotate` from `viewMode.kind` (`"persp"` → true, `"iso"` → false) in both `cancelDrag` and `onPointerUp`.

## Test plan
- [ ] Iso mode + edit mode: marquee-drag on empty area, release, then Shift+drag — camera should stay locked to the 2D plane (X axis must remain hidden / collinear with view direction).
- [ ] Iso mode + edit mode: drag a selected block, release, then Shift+drag — camera still locked.
- [ ] Perspective mode + edit mode: Shift+drag after a selection drag still rotates as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)