### PR TITLE
feat: arrow-key cycling and drag-from-palette in edit mode

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -567,10 +567,50 @@ export default function App() {
             store.flipSelected();
           }
           return;
+        case "cyclePrev":
+          e.preventDefault();
+          store.cycleArmedType(-1);
+          return;
+        case "cycleNext":
+          e.preventDefault();
+          store.cycleArmedType(1);
+          return;
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  // Drag-from-palette: on toolbar button pointerdown, paletteDragging is set
+  // true. The cursor-over-canvas pointermove already updates hoveredGridPos
+  // (via GridPlane). On pointerup, place at that position if valid — using
+  // the same dispatch as GridPlane.handleClick (addPortAt vs addBlock).
+  // Also clear the flag on cancel/blur so a hijacked gesture (e.g. native
+  // drag, alt-tab) can't leave the next click stuck placing blocks.
+  useEffect(() => {
+    const onUp = () => {
+      const s = useBlockStore.getState();
+      if (!s.paletteDragging) return;
+      s.setPaletteDragging(false);
+      const pos = s.hoveredGridPos;
+      if (!pos || s.hoveredInvalid) return;
+      if (s.armedTool === "port") s.addPortAt(pos);
+      else if (s.armedTool === "cube" || s.armedTool === "pipe") s.addBlock(pos);
+    };
+    const onCancel = () => {
+      const s = useBlockStore.getState();
+      if (s.paletteDragging) s.setPaletteDragging(false);
+    };
+    window.addEventListener("pointerup", onUp);
+    window.addEventListener("pointercancel", onCancel);
+    window.addEventListener("dragend", onCancel);
+    window.addEventListener("blur", onCancel);
+    return () => {
+      window.removeEventListener("pointerup", onUp);
+      window.removeEventListener("pointercancel", onCancel);
+      window.removeEventListener("dragend", onCancel);
+      window.removeEventListener("blur", onCancel);
+    };
   }, []);
 
   // Hold-to-delete modifier (default X): while held in edit mode, clicks

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -87,6 +87,7 @@ export function Toolbar({
   const setCubeType = useBlockStore((s) => s.setCubeType);
   const setPipeVariant = useBlockStore((s) => s.setPipeVariant);
   const setPlacePort = useBlockStore((s) => s.setPlacePort);
+  const setPaletteDragging = useBlockStore((s) => s.setPaletteDragging);
   const cycleBlock = useBlockStore((s) => s.cycleBlock);
   const cyclePipe = useBlockStore((s) => s.cyclePipe);
   const historyLen = useBlockStore((s) => s.history.length);
@@ -325,7 +326,12 @@ export function Toolbar({
   const previewImg = (key: string) => {
     const src = previewImages.get(key);
     return src ? (
-      <img src={src} alt={key} style={{ display: "block", width: "100%", height: "100%", objectFit: "contain" }} />
+      <img
+        src={src}
+        alt={key}
+        draggable={false}
+        style={{ display: "block", width: "100%", height: "100%", objectFit: "contain" }}
+      />
     ) : null;
   };
 
@@ -479,6 +485,11 @@ export function Toolbar({
           )}
           <button
             key="port"
+            onPointerDown={() => {
+              if (mode !== "edit") return;
+              setPlacePort(true);
+              setPaletteDragging(true);
+            }}
             onClick={() => {
               if (mode === "build") {
                 // In build mode, clicking Port converts the cursor cube back to a port
@@ -501,6 +512,11 @@ export function Toolbar({
           {CUBE_TYPES.map((ct) => (
             <button
               key={ct}
+              onPointerDown={() => {
+                if (mode !== "edit") return;
+                setCubeType(ct as BlockType);
+                setPaletteDragging(true);
+              }}
               onClick={() => {
                 if (mode === "build") {
                   cycleBlock(ct);
@@ -524,6 +540,11 @@ export function Toolbar({
             </button>
           ))}
           <button
+            onPointerDown={() => {
+              if (mode !== "edit") return;
+              setCubeType("Y");
+              setPaletteDragging(true);
+            }}
             onClick={() => {
               if (mode === "build") {
                 cycleBlock("Y");
@@ -555,6 +576,11 @@ export function Toolbar({
           {PIPE_VARIANTS.map((v) => (
             <button
               key={v}
+              onPointerDown={() => {
+                if (mode !== "edit") return;
+                setPipeVariant(v);
+                setPaletteDragging(true);
+              }}
               onClick={() => {
                 if (mode === "build") {
                   cyclePipe(v);

--- a/piper_draw/gui/src/stores/blockStore.test.ts
+++ b/piper_draw/gui/src/stores/blockStore.test.ts
@@ -789,4 +789,69 @@ describe("blockStore", () => {
       expect(useBlockStore.getState().selectedKeys.has("0,0,3")).toBe(true);
     });
   });
+
+  describe("cycleArmedType", () => {
+    it("walks the full PLACEABLE_ORDER (Port → cubes → Y → pipes → wrap)", () => {
+      const s = useBlockStore.getState();
+      // Start at Port
+      s.setPlacePort(true);
+      expect(useBlockStore.getState().armedTool).toBe("port");
+
+      // Right through all 6 cubes
+      const cubes = ["XZZ", "ZXZ", "ZXX", "XXZ", "ZZX", "XZX"];
+      for (const ct of cubes) {
+        useBlockStore.getState().cycleArmedType(1);
+        const st = useBlockStore.getState();
+        expect(st.armedTool).toBe("cube");
+        expect(st.cubeType).toBe(ct);
+      }
+
+      // → Y
+      useBlockStore.getState().cycleArmedType(1);
+      let st = useBlockStore.getState();
+      expect(st.armedTool).toBe("cube");
+      expect(st.cubeType).toBe("Y");
+
+      // → 4 pipes
+      const pipes = ["ZX", "XZ", "ZXH", "XZH"] as const;
+      for (const v of pipes) {
+        useBlockStore.getState().cycleArmedType(1);
+        st = useBlockStore.getState();
+        expect(st.armedTool).toBe("pipe");
+        expect(st.pipeVariant).toBe(v);
+      }
+
+      // → wrap back to Port
+      useBlockStore.getState().cycleArmedType(1);
+      expect(useBlockStore.getState().armedTool).toBe("port");
+    });
+
+    it("ArrowLeft from Port wraps to last pipe (XZH)", () => {
+      useBlockStore.getState().setPlacePort(true);
+      useBlockStore.getState().cycleArmedType(-1);
+      const st = useBlockStore.getState();
+      expect(st.armedTool).toBe("pipe");
+      expect(st.pipeVariant).toBe("XZH");
+    });
+
+    it("from pointer, ArrowRight arms Port and ArrowLeft arms last pipe", () => {
+      useBlockStore.getState().setArmedTool("pointer");
+      useBlockStore.getState().cycleArmedType(1);
+      expect(useBlockStore.getState().armedTool).toBe("port");
+
+      useBlockStore.getState().setArmedTool("pointer");
+      useBlockStore.getState().cycleArmedType(-1);
+      const st = useBlockStore.getState();
+      expect(st.armedTool).toBe("pipe");
+      expect(st.pipeVariant).toBe("XZH");
+    });
+
+    it("does nothing in build mode", () => {
+      useBlockStore.setState({ mode: "build", armedTool: "cube", cubeType: "XZZ", pipeVariant: null });
+      useBlockStore.getState().cycleArmedType(1);
+      const st = useBlockStore.getState();
+      expect(st.armedTool).toBe("cube");
+      expect(st.cubeType).toBe("XZZ");
+    });
+  });
 });

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -34,6 +34,8 @@ import {
   swapPipeVariant,
   traversedPipeKey,
   flipBlockType,
+  PLACEABLE_ORDER,
+  currentPlaceableIndex,
 } from "../types";
 
 export type Mode = "edit" | "build";
@@ -128,6 +130,12 @@ interface BlockStore {
   cubeType: BlockType;
   pipeVariant: PipeVariant | null;
   /**
+   * True between pointerdown on a placeable toolbar button and the
+   * subsequent window-level pointerup. While true, the pointerup handler
+   * places a block at the current hoveredGridPos (drag-from-palette gesture).
+   */
+  paletteDragging: boolean;
+  /**
    * Transient warning message (e.g. "can't convert cube with ≥2 pipes").
    * Cleared automatically on any mode/tool change or after a few seconds.
    */
@@ -168,6 +176,9 @@ interface BlockStore {
   setCubeType: (cubeType: BlockType) => void;
   setPipeVariant: (variant: PipeVariant) => void;
   setPlacePort: (on: boolean) => void;
+  /** Cycle the armed placeable by ±1 within PLACEABLE_ORDER (edit mode only). */
+  cycleArmedType: (dir: -1 | 1) => void;
+  setPaletteDragging: (on: boolean) => void;
   convertBlockToPort: (pos: Position3D) => void;
   clearPortWarning: () => void;
   addPortAt: (pos: Position3D) => void;
@@ -363,6 +374,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   xHeld: false,
   cubeType: "XZZ",
   pipeVariant: null,
+  paletteDragging: false,
   portWarning: null,
   hoveredGridPos: null,
   hoveredBlockType: null,
@@ -493,12 +505,27 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     hoveredInvalid: false,
     hoveredInvalidReason: null,
     hoveredReplace: false,
+    ...(tool !== "pipe" ? { pipeVariant: null } : {}),
     ...(tool !== "pointer" ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>() } : {}),
   }),
   setXHeld: (held) => set({ xHeld: held, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),
-  setCubeType: (cubeType) => set({ cubeType, armedTool: "cube", portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>() }),
+  setCubeType: (cubeType) => set({ cubeType, armedTool: "cube", pipeVariant: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>() }),
   setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], armedTool: "pipe", portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>() }),
-  setPlacePort: (on) => set({ armedTool: on ? "port" : "pointer", portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, ...(on ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>() } : {}) }),
+  setPlacePort: (on) => set({ armedTool: on ? "port" : "pointer", pipeVariant: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, ...(on ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>() } : {}) }),
+  cycleArmedType: (dir) => {
+    const s = get();
+    if (s.mode !== "edit") return;
+    const cur = currentPlaceableIndex(s.armedTool, s.cubeType, s.pipeVariant);
+    const N = PLACEABLE_ORDER.length;
+    const next = cur === -1
+      ? (dir === 1 ? 0 : N - 1)
+      : (((cur + dir) % N) + N) % N;
+    const target = PLACEABLE_ORDER[next];
+    if (target.kind === "port") s.setPlacePort(true);
+    else if (target.kind === "cube") s.setCubeType(target.cubeType);
+    else s.setPipeVariant(target.variant);
+  },
+  setPaletteDragging: (on) => set((state) => (state.paletteDragging === on ? state : { paletteDragging: on })),
   clearPortWarning: () => set((state) => (state.portWarning == null ? state : { portWarning: null })),
   addPortAt: (pos) =>
     set((state) => {

--- a/piper_draw/gui/src/stores/keybindStore.ts
+++ b/piper_draw/gui/src/stores/keybindStore.ts
@@ -26,7 +26,9 @@ export type EditAction =
   | "undo"
   | "redo"
   | "stepForward"
-  | "stepBack";
+  | "stepBack"
+  | "cyclePrev"
+  | "cycleNext";
 
 export type ActionForMode = {
   build: BuildAction;
@@ -50,7 +52,7 @@ export const ACTIONS: { [M in Mode]: readonly ActionForMode[M][] } = {
   ],
   edit: [
     "selectAll", "deleteSelection", "clearSelection", "flipColors", "holdToDelete",
-    "undo", "redo", "stepForward", "stepBack",
+    "undo", "redo", "stepForward", "stepBack", "cyclePrev", "cycleNext",
   ],
 };
 
@@ -78,6 +80,8 @@ export const ACTION_LABELS: { [M in Mode]: Record<ActionForMode[M], string> } = 
     redo: "Redo",
     stepForward: "Step forward (iso)",
     stepBack: "Step back (iso)",
+    cyclePrev: "Previous block / pipe",
+    cycleNext: "Next block / pipe",
   },
 };
 
@@ -105,6 +109,8 @@ export const DEFAULT_BINDINGS: { [M in Mode]: Record<ActionForMode[M], KeyBindin
     redo: { key: "z", ctrl: true, shift: true },
     stepForward: { key: "arrowup" },
     stepBack: { key: "arrowdown" },
+    cyclePrev: { key: "arrowleft" },
+    cycleNext: { key: "arrowright" },
   },
 };
 

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -64,6 +64,41 @@ export const FACE_BIT_BY_INDEX: ReadonlyArray<number> = [
 export type PipeVariant = "ZX" | "XZ" | "ZXH" | "XZH";
 export const PIPE_VARIANTS: PipeVariant[] = ["ZX", "XZ", "ZXH", "XZH"];
 
+/**
+ * Toolbar-order list of placeable items (Port + 6 cubes + Y + 4 pipes).
+ * Pointer is excluded — it's a tool, not an object. Used by ArrowLeft/Right
+ * cycling in edit mode.
+ */
+export type Placeable =
+  | { kind: "port" }
+  | { kind: "cube"; cubeType: BlockType }
+  | { kind: "pipe"; variant: PipeVariant };
+
+export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
+  { kind: "port" },
+  ...CUBE_TYPES.map((t) => ({ kind: "cube" as const, cubeType: t as BlockType })),
+  { kind: "cube" as const, cubeType: "Y" as BlockType },
+  ...PIPE_VARIANTS.map((v) => ({ kind: "pipe" as const, variant: v })),
+];
+
+/**
+ * Index of the currently armed placeable in PLACEABLE_ORDER, or -1 if the
+ * pointer tool is armed (no placeable selected).
+ */
+export function currentPlaceableIndex(
+  armedTool: "pointer" | "cube" | "pipe" | "port",
+  cubeType: BlockType,
+  pipeVariant: PipeVariant | null,
+): number {
+  if (armedTool === "pointer") return -1;
+  if (armedTool === "port") return 0;
+  if (armedTool === "pipe") {
+    if (!pipeVariant) return -1;
+    return PLACEABLE_ORDER.findIndex((p) => p.kind === "pipe" && p.variant === pipeVariant);
+  }
+  return PLACEABLE_ORDER.findIndex((p) => p.kind === "cube" && p.cubeType === cubeType);
+}
+
 export interface Block {
   pos: Position3D;
   type: BlockType;


### PR DESCRIPTION
## Summary

- Adds ArrowLeft/ArrowRight keybinds in edit mode that cycle through the 12 placeable items (Port, 6 ZX cubes, Y, 4 pipe variants) in toolbar order, with wrap-around.
- Adds drag-from-palette: pointer-down on any placeable button arms it and sets a `paletteDragging` flag; releasing over a valid grid cell places the object at the hover position. Plain click-to-arm + click-to-place is preserved.
- Fixes a latent bug where switching from a pipe to a cube/port left `pipeVariant` set, so subsequent placements still resolved as pipes; `setCubeType`/`setPlacePort`/`setArmedTool` now clear `pipeVariant` when leaving the pipe tool.
- Disables HTML5 native image dragging on toolbar previews and adds window-level `pointercancel`/`dragend`/`blur` safety listeners so a stuck drag never locks the palette.

## Test plan

- [ ] Edit mode: click each toolbar button, place via canvas click, undo/redo — matches prior behavior.
- [ ] Press Right from Pointer → Port armed; keep pressing Right to walk through cubes, Y, pipes, then wrap to Port. Press Left from Port → wraps to last pipe.
- [ ] Focus a text input, press arrows → no cycling.
- [ ] PointerDown on XZZ / Y / Port / a pipe variant, drag to a valid cell, release → object placed; release over invalid cell or off-canvas → no placement, tool stays armed.
- [ ] Drag a pipe, then click a cube button, then place → cube is placed (not pipe).