### PR TITLE
fix: keep origin as a port when building from an empty slot

### DIFF
--- a/piper_draw/gui/src/stores/blockStore.test.ts
+++ b/piper_draw/gui/src/stores/blockStore.test.ts
@@ -854,4 +854,42 @@ describe("blockStore", () => {
       expect(st.cubeType).toBe("XZZ");
     });
   });
+
+  describe("buildMove from an empty origin", () => {
+    it("leaves the origin slot empty (no cube placed at the start position)", () => {
+      useBlockStore.setState({
+        mode: "build",
+        buildCursor: { x: 0, y: 0, z: 0 },
+        buildHistory: [],
+      });
+      const ok = useBlockStore.getState().buildMove({ tqecAxis: 0, sign: 1 });
+      expect(ok).toBe(true);
+      const s = useBlockStore.getState();
+      // Pipe placed between origin and dest; neither endpoint holds a cube.
+      expect(s.blocks.has("1,0,0")).toBe(true);
+      expect(s.blocks.has("0,0,0")).toBe(false);
+      expect(s.blocks.has("3,0,0")).toBe(false);
+      // Cursor advances to the destination slot.
+      expect(s.buildCursor).toEqual({ x: 3, y: 0, z: 0 });
+    });
+
+    it("promotes the origin port to a cube once a second pipe attaches", () => {
+      useBlockStore.setState({
+        mode: "build",
+        buildCursor: { x: 0, y: 0, z: 0 },
+        buildHistory: [],
+      });
+      // First step: +X. Origin stays a port.
+      useBlockStore.getState().buildMove({ tqecAxis: 0, sign: 1 });
+      expect(useBlockStore.getState().blocks.has("0,0,0")).toBe(false);
+
+      // Move cursor back to the origin port and build along +Y — now the
+      // origin has two attached pipes and should auto-promote to a cube.
+      useBlockStore.setState({ buildCursor: { x: 0, y: 0, z: 0 } });
+      useBlockStore.getState().buildMove({ tqecAxis: 1, sign: 1 });
+      const origin = useBlockStore.getState().blocks.get("0,0,0");
+      expect(origin).toBeDefined();
+      expect(origin!.type).not.toMatch(/O/); // cube, not pipe
+    });
+  });
 });

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -1952,14 +1952,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     set((s) => {
       let { blocks, hiddenFaces } = { blocks: s.blocks, hiddenFaces: s.hiddenFaces };
       const newUndetermined = new Map(s.undeterminedCubes);
-      let originCubeEntry: BuildStep["originCube"];
 
-      // Place origin cube on empty canvas (always determined — no ghost)
-      if (isEmptyOrigin) {
-        const originBlock: Block = { pos: cursor, type: srcType };
-        ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, srcKey, originBlock));
-        originCubeEntry = { key: srcKey, block: originBlock };
-      }
+      // Intentionally do NOT place a cube at an empty origin. The slot stays a
+      // port (explicit or implicit at the pipe endpoint). syncPortsAndPromote
+      // below will promote it to a canonical cube only if the new pipe pushes
+      // its attachment count to ≥2.
 
       if (!state.freeBuild) {
         // Apply source determination (commit undetermined source to chosen type)
@@ -1983,17 +1980,6 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       // Place pipe
       const pipeBlock: Block = { pos: pipePos, type: pipeType };
       ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pipeKey, pipeBlock));
-
-      // Check if origin cube should be undetermined (placed before the pipe was known)
-      let originUndetermined: UndeterminedCubeInfo | undefined;
-      if (isEmptyOrigin && !state.freeBuild) {
-        const originOptions = determineCubeOptions(cursor, blocks);
-        if (!originOptions.determined && originOptions.options.length > 1) {
-          const idx = Math.max(0, originOptions.options.indexOf(srcType));
-          originUndetermined = { options: [...originOptions.options], currentIndex: idx };
-          newUndetermined.set(srcKey, originUndetermined);
-        }
-      }
 
       // Apply dest type change if existing cube needs re-typing
       if (destTypeChange) {
@@ -2043,10 +2029,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         destCursorPos: destPos,
         pipe: { key: pipeKey, block: pipeBlock },
         cube: cubeAdded,
-        originCube: originCubeEntry,
         sourceDetermination,
         sourceRetype,
-        originUndetermined,
         destUndetermined,
         destTypeChange,
         destDetermination,


### PR DESCRIPTION
## Summary
In build mode, starting a build from an empty slot was reintroducing an old bug where the origin position was stamped with a determined cube. Now the origin stays a port; `syncPortsAndPromote` still promotes it to a canonical cube once a second pipe attaches. Regression picked up after the First-class PORT blocks change (#120).

## Test plan
- [x] `npm run test` (207 pass; 2 new regression tests cover origin-stays-empty and two-builds-promote-to-cube)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: in build mode, select an empty slot, build in a direction — origin stays a port

🤖 Generated with [Claude Code](https://claude.com/claude-code)