### PR TITLE
refactor: rename modes to "Drag / Drop" and "Keyboard Build"

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -613,7 +613,7 @@ export default function App() {
     };
   }, []);
 
-  // Hold-to-delete modifier (default X): while held in edit mode, clicks
+  // Hold-to-delete modifier (default X): while held in Drag / Drop mode, clicks
   // delete the hovered block regardless of the currently armed tool. The
   // BlockInstances/GhostBlock components read store.xHeld to switch to a
   // red-preview cursor.

--- a/piper_draw/gui/src/components/BlockInstances.tsx
+++ b/piper_draw/gui/src/components/BlockInstances.tsx
@@ -306,13 +306,13 @@ function TypedInstances({
     if (e.instanceId == null || e.instanceId >= b.length) return;
     const store = useBlockStore.getState();
     if (store.isDraggingSelection) return;
-    // X-held single-click delete (edit mode only) short-circuits everything.
+    // X-held single-click delete (Drag / Drop mode only) short-circuits everything.
     if (store.xHeld && store.mode === "edit") {
       store.removeBlock(b[e.instanceId].pos);
       return;
     }
     if (store.mode === "build") {
-      // In build mode, clicking a cube moves the cursor there
+      // In Keyboard Build mode, clicking a cube moves the cursor there
       const clicked = b[e.instanceId];
       if (!isPipeType(clicked.type)) {
         store.moveBuildCursor(clicked.pos);

--- a/piper_draw/gui/src/components/GhostBlock.tsx
+++ b/piper_draw/gui/src/components/GhostBlock.tsx
@@ -224,7 +224,7 @@ export function GhostBlock() {
   const armedTool = useBlockStore((s) => s.armedTool);
   const xHeld = useBlockStore((s) => s.xHeld);
   if (!hasHover || mode === "build") return null;
-  // In edit mode, only show a ghost when a placement tool is armed (or X-held
+  // In Drag / Drop mode, only show a ghost when a placement tool is armed (or X-held
   // delete preview). Pointer mode has no ghost — hover just highlights.
   if (mode === "edit" && !xHeld && armedTool === "pointer") return null;
   return <GhostBlockInner />;

--- a/piper_draw/gui/src/components/GridPlane.tsx
+++ b/piper_draw/gui/src/components/GridPlane.tsx
@@ -152,7 +152,7 @@ export function GridPlane() {
         onClick={(e: ThreeEvent<MouseEvent>) => {
           e.stopPropagation();
           if (e.delta > 2) return;
-          // Build mode places cubes; always snap to block positions (forPipe=false).
+          // Keyboard Build mode places cubes; always snap to block positions (forPipe=false).
           const pos = snapForViewMode(viewMode, e.point, false);
           // For build we ignore the slice constraint on Z if needed; honor depth from snap.
           // But ensure depth axis lands on a block coord.

--- a/piper_draw/gui/src/components/HelpPanel.tsx
+++ b/piper_draw/gui/src/components/HelpPanel.tsx
@@ -90,7 +90,7 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
           <li><b>Place</b> — pick a block or pipe, then click a grid cell to add it.</li>
           <li><b>Select</b> — click or drag to select blocks; Shift-click to add/remove.</li>
           <li><b>Delete</b> — click a block to remove it.</li>
-          <li><b>Build</b> — move a cursor with the keyboard to extend from the last block.</li>
+          <li><b>Keyboard Build</b> — move a cursor with the keyboard to extend from the last block.</li>
         </ul>
 
         <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Tips</h4>

--- a/piper_draw/gui/src/components/KeybindEditor.tsx
+++ b/piper_draw/gui/src/components/KeybindEditor.tsx
@@ -10,8 +10,8 @@ import {
 } from "../stores/keybindStore";
 
 const MODE_TAB_LABELS: Record<Mode, string> = {
-  edit: "Edit",
-  build: "Build",
+  edit: "Drag / Drop",
+  build: "Keyboard Build",
 };
 
 export function KeybindEditor({

--- a/piper_draw/gui/src/components/OpenPipeGhosts.tsx
+++ b/piper_draw/gui/src/components/OpenPipeGhosts.tsx
@@ -237,7 +237,7 @@ function PortSelectionHighlight({ threePos }: { threePos: [number, number, numbe
 }
 
 /**
- * Non-interactive ghost cube (for delete/build modes).
+ * Non-interactive ghost cube (for delete tool / Keyboard Build mode).
  */
 function StaticGhost({ threePos }: { threePos: [number, number, number] }) {
   return (
@@ -260,7 +260,7 @@ function StaticGhost({ threePos }: { threePos: [number, number, number] }) {
  * Renders white semi-transparent ghost cubes ("ports") at open pipe endpoints.
  * - Place mode: hovering shows placement preview; clicking places the block.
  * - Select mode: clicking adds the port to `selectedPortPositions` (shift-click = additive).
- * - Delete/build mode: static ghost, no interaction.
+ * - Delete tool / Keyboard Build mode: static ghost, no interaction.
  */
 export function OpenPipeGhosts() {
   const blocks = useBlockStore((s) => s.blocks);
@@ -275,7 +275,7 @@ export function OpenPipeGhosts() {
     const result: Array<{ key: string; pos: Position3D; threePos: [number, number, number] }> = [];
 
     // Ghost cubes at open pipe endpoints (positions with no block).
-    // In build mode, skip the cursor position — BuildCursor renders it with a pulse.
+    // In Keyboard Build mode, skip the cursor position — BuildCursor renders it with a pulse.
     const cursorKey = buildCursor ? posKey(buildCursor) : null;
     for (const pos of getAllPortPositions(blocks, portPositions)) {
       const key = posKey(pos);

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -120,14 +120,14 @@ export function Toolbar({
     return block.type;
   });
   // True when the build cursor is sitting on a port (no cube at that position).
-  // Lets the toolbar highlight the Port button as "currently selected" while in build mode.
+  // Lets the toolbar highlight the Port button as "currently selected" while in Keyboard Build mode.
   const buildCursorOnPort = useBlockStore((s) => {
     if (s.mode !== "build" || !s.buildCursor) return false;
     return !s.blocks.has(posKey(s.buildCursor));
   });
   // True when the cursor position has ≥2 attached pipes — i.e. it can't be
   // converted back to a port without first removing a pipe. Used to dim the
-  // Port button in build mode so users don't click it expecting a no-op.
+  // Port button in Keyboard Build mode so users don't click it expecting a no-op.
   const buildCursorPortAllowed = useBlockStore((s) => {
     if (s.mode !== "build" || !s.buildCursor) return true;
     const coords: [number, number, number] = [s.buildCursor.x, s.buildCursor.y, s.buildCursor.z];
@@ -179,7 +179,7 @@ export function Toolbar({
   });
   const buildValidTypes = buildValidTypesStr != null ? new Set(buildValidTypesStr.split(",").filter(Boolean)) : null;
 
-  // When exactly one cube-slot thing is selected in edit mode (a single port OR a
+  // When exactly one cube-slot thing is selected in Drag / Drop mode (a single port OR a
   // single cube/Y block), compute info used to grey out and highlight toolbar
   // entries: the currently placed type, whether port-conversion is still legal,
   // and which cube types remain valid replacements at that position.
@@ -236,7 +236,7 @@ export function Toolbar({
     };
   })();
 
-  // When exactly one pipe is selected in edit mode, compute (a) its current
+  // When exactly one pipe is selected in Drag / Drop mode, compute (a) its current
   // toolbar variant (for highlighting) and (b) which other variants would still
   // be valid at that position — i.e. swapping to that variant keeps every
   // committed neighbour cube within its valid CUBE_TYPES set. Mirrors the
@@ -539,23 +539,31 @@ export function Toolbar({
       {/* Separator */}
       <div style={{ width: 1, background: "#ddd" }} />
 
-      {/* Blocks group (Pointer + Port + ZXCubes + Y) */}
+      {/* Tool group (Pointer) */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+        <span style={groupLabelStyle}>Tool</span>
+        <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
+          <button
+            key="pointer"
+            onClick={() => setArmedTool("pointer")}
+            title="Select and move blocks"
+            style={blockBtnStyle(armedTool === "pointer")}
+          >
+            Pointer
+            <div style={previewWrapStyle}>
+              <PointerIcon />
+            </div>
+          </button>
+        </div>
+      </div>
+
+      {/* Separator */}
+      <div style={{ width: 1, background: "#ddd" }} />
+
+      {/* Blocks group (Port + ZXCubes + Y) */}
       <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
         <span style={groupLabelStyle}>Blocks</span>
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
-          {mode === "edit" && (
-            <button
-              key="pointer"
-              onClick={() => setArmedTool("pointer")}
-              title="Select and move blocks"
-              style={blockBtnStyle(armedTool === "pointer")}
-            >
-              Pointer
-              <div style={previewWrapStyle}>
-                <PointerIcon />
-              </div>
-            </button>
-          )}
           <button
             key="port"
             onPointerDown={() => {
@@ -565,7 +573,7 @@ export function Toolbar({
             }}
             onClick={() => {
               if (mode === "build") {
-                // In build mode, clicking Port converts the cursor cube back to a port
+                // In Keyboard Build mode, clicking Port converts the cursor cube back to a port
                 // (only valid when pipeCount < 2; cycleBlock validates and no-ops otherwise).
                 cycleBlock(null);
                 return;
@@ -885,7 +893,7 @@ function PositionEditor({ pos, onCommit }: { pos: Position3D; onCommit: (p: Posi
 }
 
 // ---------------------------------------------------------------------------
-// Mode segmented control — Edit | Build pill
+// Mode segmented control — Drag / Drop | Keyboard Build pill
 // ---------------------------------------------------------------------------
 
 function ModeSegmented({
@@ -911,6 +919,7 @@ function ModeSegmented({
     <div
       style={{
         display: "inline-flex",
+        flexDirection: "column",
         border: "2px solid #4a9eff",
         borderRadius: 6,
         overflow: "hidden",
@@ -919,10 +928,10 @@ function ModeSegmented({
       }}
     >
       <button onClick={() => setMode("edit")} style={segStyle(mode === "edit")}>
-        Edit
+        Drag / Drop
       </button>
       <button onClick={() => setMode("build")} style={segStyle(mode === "build")}>
-        Build
+        Keyboard Build
       </button>
     </div>
   );
@@ -1257,7 +1266,7 @@ function SettingsMenu({
           <div style={{ height: 1, background: "#eee" }} />
 
           <div>
-            <div style={{ fontWeight: 600, color: "#555", marginBottom: 4 }}>Build mode</div>
+            <div style={{ fontWeight: 600, color: "#555", marginBottom: 4 }}>Keyboard Build</div>
             <label style={{ display: "flex", alignItems: "center", gap: 6, cursor: "pointer", padding: "2px 0" }}>
               <input type="checkbox" checked={cameraFollowsBuild} onChange={toggleCameraFollowsBuild} />
               <span title="When off, the camera stays put while you build with the keyboard">

--- a/piper_draw/gui/src/stores/blockStore.test.ts
+++ b/piper_draw/gui/src/stores/blockStore.test.ts
@@ -846,7 +846,7 @@ describe("blockStore", () => {
       expect(st.pipeVariant).toBe("XZH");
     });
 
-    it("does nothing in build mode", () => {
+    it("does nothing in Keyboard Build mode", () => {
       useBlockStore.setState({ mode: "build", armedTool: "cube", cubeType: "XZZ", pipeVariant: null });
       useBlockStore.getState().cycleArmedType(1);
       const st = useBlockStore.getState();

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -115,7 +115,7 @@ interface BlockStore {
   future: UndoCommand[];
   mode: Mode;
   /**
-   * The currently armed tool in edit mode. "pointer" behaves like the old
+   * The currently armed tool in Drag / Drop mode. "pointer" behaves like the old
    * select mode (click selects, drag moves/marquees). A type tool ("cube" /
    * "pipe" / "port") behaves like the old place mode and uses the matching
    * `cubeType` / `pipeVariant` / port intent.
@@ -124,7 +124,7 @@ interface BlockStore {
   /**
    * True while the delete-modifier key (default X) is held. Short-circuits
    * hover/click handling to preview and perform single-click deletion in
-   * edit mode, regardless of the currently armed tool.
+   * Drag / Drop mode, regardless of the currently armed tool.
    */
   xHeld: boolean;
   cubeType: BlockType;
@@ -161,7 +161,7 @@ interface BlockStore {
   dragDelta: Position3D | null;
   dragValid: boolean;
 
-  // Build mode state
+  // Keyboard Build mode state
   buildCursor: Position3D | null;
   buildHistory: BuildStep[];
   undeterminedCubes: Map<string, UndeterminedCubeInfo>;
@@ -176,7 +176,7 @@ interface BlockStore {
   setCubeType: (cubeType: BlockType) => void;
   setPipeVariant: (variant: PipeVariant) => void;
   setPlacePort: (on: boolean) => void;
-  /** Cycle the armed placeable by ±1 within PLACEABLE_ORDER (edit mode only). */
+  /** Cycle the armed placeable by ±1 within PLACEABLE_ORDER (Drag / Drop mode only). */
   cycleArmedType: (dir: -1 | 1) => void;
   setPaletteDragging: (on: boolean) => void;
   convertBlockToPort: (pos: Position3D) => void;
@@ -204,7 +204,7 @@ interface BlockStore {
   setDragState: (s: { isDragging: boolean; delta: Position3D | null; valid: boolean }) => void;
   moveSelection: (delta: Position3D) => boolean;
 
-  // Build mode actions
+  // Keyboard Build mode actions
   buildMove: (direction: BuildDirection) => boolean;
   undoBuildStep: () => void;
   cycleBlock: (target?: CubeType | "Y" | null) => void;
@@ -389,7 +389,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   dragDelta: null,
   dragValid: true,
 
-  // Build mode state
+  // Keyboard Build mode state
   buildCursor: null,
   buildHistory: [],
   undeterminedCubes: new Map(),
@@ -424,7 +424,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   setMode: (mode) => {
     const prev = get();
 
-    // Leaving build mode: keep undetermined cubes as-is (only committed when building away)
+    // Leaving Keyboard Build mode: keep undetermined cubes as-is (only committed when building away)
     if (prev.mode === "build" && mode !== "build") {
       set({
         mode,
@@ -443,7 +443,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       return;
     }
 
-    // Entering build mode: place cursor on last-placed cube or origin
+    // Entering Keyboard Build mode: place cursor on last-placed cube or origin
     if (mode === "build") {
       let cursorPos: Position3D = { x: 0, y: 0, z: 0 };
 
@@ -1726,7 +1726,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   },
 
   // ---------------------------------------------------------------------------
-  // Build mode actions
+  // Keyboard Build mode actions
   // ---------------------------------------------------------------------------
 
   buildMove: (direction) => {
@@ -2249,7 +2249,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
       let placeType: CubeType | "Y" | null;
       if (target !== undefined) {
-        // Explicit target (e.g. toolbar click in build mode) must be a valid option.
+        // Explicit target (e.g. toolbar click in Keyboard Build mode) must be a valid option.
         if (!cycle.includes(target)) return state;
         placeType = target;
       } else {

--- a/piper_draw/gui/src/types/index.ts
+++ b/piper_draw/gui/src/types/index.ts
@@ -67,7 +67,7 @@ export const PIPE_VARIANTS: PipeVariant[] = ["ZX", "XZ", "ZXH", "XZH"];
 /**
  * Toolbar-order list of placeable items (Port + 6 cubes + Y + 4 pipes).
  * Pointer is excluded — it's a tool, not an object. Used by ArrowLeft/Right
- * cycling in edit mode.
+ * cycling in Drag / Drop mode.
  */
 export type Placeable =
   | { kind: "port" }
@@ -1021,7 +1021,7 @@ export function hasYCubePipeAxisConflict(
  *   (0, 0, ±1) → TQEC Y ∓ srcSizeY / dstSizeY
  */
 // ---------------------------------------------------------------------------
-// Build mode types & logic
+// Keyboard Build mode types & logic
 // ---------------------------------------------------------------------------
 
 export type BuildDirection = { tqecAxis: 0 | 1 | 2; sign: 1 | -1 };


### PR DESCRIPTION
## Summary
- Renames the Edit/Build mode toggle to "Drag / Drop" / "Keyboard Build" and stacks the toggle vertically.
- Lifts the Pointer button out of the Blocks row into its own "Tool" group, separated by the same divider used between groups, and shows it in both modes so selection can extend cleanly into Keyboard Build later.
- Updates the Settings panel section header, keybind-editor tab labels, help-panel description, and all relevant code comments to match the new naming (free-build references and internal `mode === "edit" | "build"` keys are unchanged).

## Test plan
- [ ] Toggle between Drag / Drop and Keyboard Build via the vertical pill — labels render correctly and active highlight switches.
- [ ] Pointer button is visible in both modes and sits in its own group separated by a vertical divider.
- [ ] Open Settings → "Keyboard Build" section header reads correctly.
- [ ] Open the keybind editor → tabs read "Drag / Drop" and "Keyboard Build".
- [ ] Help panel mode list shows "Keyboard Build".

🤖 Generated with [Claude Code](https://claude.com/claude-code)