### PR TITLE
fix: pointer tool usability across modes and iso camera

### DIFF
--- a/piper_draw/gui/src/components/NavControlsModifier.tsx
+++ b/piper_draw/gui/src/components/NavControlsModifier.tsx
@@ -11,6 +11,7 @@ export function NavControlsModifier({
 }) {
   const mode = useBlockStore((s) => s.mode);
   const armedTool = useBlockStore((s) => s.armedTool);
+  const viewMode = useBlockStore((s) => s.viewMode);
   const navStyle = useKeybindStore((s) => s.navStyle);
 
   useEffect(() => {
@@ -61,7 +62,7 @@ export function NavControlsModifier({
       window.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", onBlur);
     };
-  }, [mode, armedTool, navStyle, controlsRef]);
+  }, [mode, armedTool, viewMode, navStyle, controlsRef]);
 
   return null;
 }

--- a/piper_draw/gui/src/components/SelectModePointer.tsx
+++ b/piper_draw/gui/src/components/SelectModePointer.tsx
@@ -234,13 +234,20 @@ export function SelectModePointer({
         hitBlockKey: hitKey,
         shiftAtDown: e.shiftKey,
       };
+      // Lock out OrbitControls for the duration of the gesture. Without this,
+      // Shift-swapping of OrbitControls' LEFT button (ROTATE↔PAN) lets the camera
+      // pan out from under the pointer before we commit to marquee/selection.
+      if (controlsRef.current) {
+        controlsRef.current.enableRotate = false;
+        controlsRef.current.enablePan = false;
+      }
       try {
         target.setPointerCapture(e.pointerId);
       } catch {
         // Some browsers reject capture during certain input phases
       }
     },
-    [isSelectActive, threeStateRef],
+    [isSelectActive, threeStateRef, controlsRef],
   );
 
   const onPointerMove = useCallback(

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -554,7 +554,7 @@ export function Toolbar({
             title="Select and move blocks"
             style={blockBtnStyle(mode === "edit" && armedTool === "pointer")}
           >
-            Pointer
+            Select
             <div style={previewWrapStyle}>
               <PointerIcon />
             </div>

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -547,9 +547,12 @@ export function Toolbar({
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
           <button
             key="pointer"
-            onClick={() => setArmedTool("pointer")}
+            onClick={() => {
+              if (mode === "build") setMode("edit");
+              setArmedTool("pointer");
+            }}
             title="Select and move blocks"
-            style={blockBtnStyle(armedTool === "pointer")}
+            style={blockBtnStyle(mode === "edit" && armedTool === "pointer")}
           >
             Pointer
             <div style={previewWrapStyle}>


### PR DESCRIPTION
## Summary
- Pointer button in the toolbar now switches to Drag / Drop mode when clicked from Keyboard Build, and only highlights when the pointer tool is actually active.
- In Iso camera mode with the Pointer tool active, left-drag no longer pans the camera — `NavControlsModifier` re-applies its LEFT-button override when `viewMode` changes so the freshly-mounted iso OrbitControls picks it up.
- Shift + drag in select mode no longer pans the camera: `enableRotate` / `enablePan` are now disabled on `pointerdown` instead of on the drag-threshold transition, closing the window where OrbitControls' built-in Shift ROTATE↔PAN swap could move the camera.

## Test plan
- [ ] In Keyboard Build mode, click the Pointer button → mode switches to Drag / Drop and Pointer is armed.
- [ ] In Iso view with Pointer armed, left-drag selects/marquees and does not pan the camera.
- [ ] In Persp view with Pointer armed, Shift + left-drag does not pan the camera.

🤖 Generated with [Claude Code](https://claude.com/claude-code)