### PR TITLE
Disclaimer: membership check requires single-component diagram (#145)

### DIFF
--- a/piper_draw/gui/src/components/FlowsPanel.tsx
+++ b/piper_draw/gui/src/components/FlowsPanel.tsx
@@ -465,6 +465,21 @@ export function FlowsPanel() {
                   + Add query
                 </button>
               </div>
+              <div
+                style={{
+                  background: "#fff3cd",
+                  color: "#856404",
+                  border: "1px solid #ffeeba",
+                  borderRadius: 4,
+                  padding: "6px 8px",
+                  fontSize: 12,
+                  marginBottom: 6,
+                }}
+              >
+                ⚠ Membership checks are only reliable for pipe diagrams with a
+                single connected component. Results may be incorrect for
+                disconnected diagrams.
+              </div>
               {queries.length === 0 && (
                 <div style={{ color: "#888" }}>
                   Add a query row to check whether a Pauli flow lies in the span.


### PR DESCRIPTION
## Summary
- Adds a yellow warning banner inside the FlowsPanel "Check membership" section noting that span-membership results are only reliable when the pipe diagram has a single connected component.
- Addresses #145. Pure UI copy addition — no math, backend, or component-detection changes.

## Test plan
- [x] `npx tsc -b` clean
- [x] `npm run test` — 249/249 passing
- [ ] Visual check: open FlowsPanel, click Compute on a simple diagram, confirm the banner appears above the query rows with the yellow palette matching `ValidationToast`'s warning style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)