### PR TITLE
docs: mark tqec-backed toolbar actions and tidy toolbar columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This package contains a test that verifies the exported `.dae` file is correctly
 
 The **Verify (tqec)** button sends the current diagram to a FastAPI backend that builds a [`tqec.BlockGraph`](https://github.com/tqec/tqec) and reports per-cube validation errors.
 
+The **Flows (tqec)** button opens a side panel that computes stabilizer flows (correlation surfaces) for the current diagram, also via the [tqec](https://github.com/tqec/tqec) package.
+
 ## Getting started
 
 ### Prerequisites
@@ -41,6 +43,7 @@ The **Verify (tqec)** button sends the current diagram to a FastAPI backend that
 - Assemble stack elements with drag-and-drop.
 - Export the design via the Collada export button to generate a `.dae` file.
 - Click **Verify (tqec)** to run server-side validation via the [tqec](https://github.com/tqec/tqec) package; any errors are shown inline on the offending cubes.
+- Click **Flows (tqec)** to compute and inspect stabilizer flows (correlation surfaces) for the current diagram via the [tqec](https://github.com/tqec/tqec) package.
 - Run the provided validation test to check `.dae` compatibility.
 - Use the **Templates** button in the toolbar to load a bundled example diagram (CNOT, CZ, move + rotation, three CNOTs, Steane encoding) and edit it as a starting point.
 

--- a/piper_draw/gui/src/components/FlowsPanel.tsx
+++ b/piper_draw/gui/src/components/FlowsPanel.tsx
@@ -260,7 +260,18 @@ export function FlowsPanel() {
           justifyContent: "space-between",
         }}
       >
-        <span style={{ fontWeight: 600, fontSize: 13 }}>Stabilizer flows</span>
+        <span style={{ fontWeight: 600, fontSize: 13 }}>
+          Stabilizer flows (
+          <a
+            href="https://github.com/tqec/tqec"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "#4a9eff", textDecoration: "underline" }}
+          >
+            tqec
+          </a>
+          )
+        </span>
         <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
           <button
             onClick={() => setHelpOpen((v) => !v)}

--- a/piper_draw/gui/src/components/HelpPanel.tsx
+++ b/piper_draw/gui/src/components/HelpPanel.tsx
@@ -102,7 +102,8 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
         <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Tips</h4>
         <ul style={{ margin: 0, paddingLeft: 18 }}>
           <li>Use <b>Undo</b>/<b>Redo</b> or Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z.</li>
-          <li><b>Verify</b> checks that the diagram is a valid TQEC structure.</li>
+          <li><b>Verify (tqec)</b> checks that the diagram is a valid TQEC structure via the <a href="https://github.com/tqec/tqec" target="_blank" rel="noreferrer">tqec</a> package.</li>
+          <li><b>Flows (tqec)</b> computes stabilizer flows (correlation surfaces) for the diagram via the <a href="https://github.com/tqec/tqec" target="_blank" rel="noreferrer">tqec</a> package.</li>
           <li><b>Import</b>/<b>Export</b> round-trip through Collada (.dae) files.</li>
           <li>Use the X / Y / Z view buttons or drag to rotate the camera.</li>
         </ul>

--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -484,7 +484,7 @@ export function Toolbar({
         </button>
       </div>
 
-      {/* History + Verify */}
+      {/* History + Flows */}
       <div style={{ display: "flex", flexDirection: "column", gap: "4px", justifyContent: "center" }}>
         <button
           onClick={undo}
@@ -500,6 +500,33 @@ export function Toolbar({
         >
           Redo
         </button>
+        <button
+          onClick={() => useBlockStore.getState().toggleFlowsPanel()}
+          title="Show stabilizer flows for the current diagram (computed by the tqec package)"
+          style={{
+            ...btnStyle(flowsPanelOpen),
+            borderColor: flowsPanelOpen ? "#4a9eff" : "#ccc",
+            background: flowsPanelOpen ? "#e8f0fe" : "#fff",
+          }}
+        >
+          Flows (tqec)
+        </button>
+      </div>
+
+      {/* Settings + File menu + Verify */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px", justifyContent: "center" }}>
+        <SettingsMenu
+          freeBuild={freeBuild}
+          toggleFreeBuild={toggleFreeBuild}
+          onOpenKeybindEditor={onOpenKeybindEditor}
+        />
+        <FileMenu
+          loadBlocks={loadBlocks}
+          insertBlocks={insertBlocks}
+          clearAll={clearAll}
+          onResetCamera={onResetCamera}
+          blocksEmpty={blocksEmpty}
+        />
         <button
           onClick={runValidation}
           disabled={blocksEmpty || validationStatus === "loading"}
@@ -521,33 +548,6 @@ export function Toolbar({
         >
           {validationStatus === "loading" ? "Verifying..." : "Verify (tqec)"}
         </button>
-        <button
-          onClick={() => useBlockStore.getState().toggleFlowsPanel()}
-          title="Show stabilizer flows for the current diagram"
-          style={{
-            ...btnStyle(flowsPanelOpen),
-            borderColor: flowsPanelOpen ? "#4a9eff" : "#ccc",
-            background: flowsPanelOpen ? "#e8f0fe" : "#fff",
-          }}
-        >
-          Flows
-        </button>
-      </div>
-
-      {/* File menu + Settings */}
-      <div style={{ display: "flex", flexDirection: "column", gap: "4px", justifyContent: "center" }}>
-        <FileMenu
-          loadBlocks={loadBlocks}
-          insertBlocks={insertBlocks}
-          clearAll={clearAll}
-          onResetCamera={onResetCamera}
-          blocksEmpty={blocksEmpty}
-        />
-        <SettingsMenu
-          freeBuild={freeBuild}
-          toggleFreeBuild={toggleFreeBuild}
-          onOpenKeybindEditor={onOpenKeybindEditor}
-        />
       </div>
 
       {/* Separator */}


### PR DESCRIPTION
## Summary
- Relabel the Flows button as **Flows (tqec)** to match **Verify (tqec)**, and surface the tqec package in the Flows panel header and Help panel tips as clickable links to https://github.com/tqec/tqec.
- Mention **Flows (tqec)** in the README alongside the existing **Verify (tqec)** description.
- Reorganise the toolbar columns: Undo / Redo / Flows, then Settings / File / Verify.

## Test plan
- [ ] Open the app, confirm the toolbar shows the new column order and the Flows button reads "Flows (tqec)".
- [ ] Click Flows and confirm the panel header reads "Stabilizer flows (tqec)" with "tqec" linking to the tqec GitHub repo.
- [ ] Open the Help panel and confirm the Verify / Flows tips link to the tqec repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)