### PR TITLE
feat: arithmetic expressions in build-cursor coordinate inputs

### DIFF
--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -7,6 +7,7 @@ import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } 
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
+import { evalCoordExpr } from "../utils/parseCoordExpr";
 import { usePreviewImages } from "./PreviewRenderer";
 import { FpsDisplay } from "./FpsCounter";
 import { useViewportFitScale } from "../hooks/useViewportFitScale";
@@ -849,14 +850,9 @@ function PositionEditor({ pos, onCommit }: { pos: Position3D; onCommit: (p: Posi
   const valueOf = (k: "x" | "y" | "z") => draft[k] ?? String(pos[k] / 3);
 
   const commit = () => {
-    const parse = (s: string): number | null => {
-      if (s.trim() === "") return null;
-      const n = Number(s);
-      return Number.isInteger(n) ? n : null;
-    };
-    const nx = draft.x !== undefined ? parse(draft.x) : pos.x / 3;
-    const ny = draft.y !== undefined ? parse(draft.y) : pos.y / 3;
-    const nz = draft.z !== undefined ? parse(draft.z) : pos.z / 3;
+    const nx = draft.x !== undefined ? evalCoordExpr(draft.x) : pos.x / 3;
+    const ny = draft.y !== undefined ? evalCoordExpr(draft.y) : pos.y / 3;
+    const nz = draft.z !== undefined ? evalCoordExpr(draft.z) : pos.z / 3;
     if (nx === null || ny === null || nz === null) {
       setDraft({});
       return;
@@ -887,8 +883,8 @@ function PositionEditor({ pos, onCommit }: { pos: Position3D; onCommit: (p: Posi
     <label key={k} style={{ display: "flex", alignItems: "center", gap: 4 }}>
       {k.toUpperCase()}:
       <input
-        type="number"
-        step={1}
+        type="text"
+        inputMode="numeric"
         value={valueOf(k)}
         onChange={(e) => setDraft((d) => ({ ...d, [k]: e.target.value }))}
         onKeyDown={onKeyDown}

--- a/piper_draw/gui/src/utils/parseCoordExpr.test.ts
+++ b/piper_draw/gui/src/utils/parseCoordExpr.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { evalCoordExpr } from "./parseCoordExpr";
+
+describe("evalCoordExpr", () => {
+  it("accepts plain integers", () => {
+    expect(evalCoordExpr("5")).toBe(5);
+    expect(evalCoordExpr("-3")).toBe(-3);
+    expect(evalCoordExpr("  7  ")).toBe(7);
+    expect(evalCoordExpr("0")).toBe(0);
+  });
+
+  it("evaluates basic arithmetic", () => {
+    expect(evalCoordExpr("3+2")).toBe(5);
+    expect(evalCoordExpr("4*5-1")).toBe(19);
+    expect(evalCoordExpr("(2+3)*2")).toBe(10);
+    expect(evalCoordExpr("10/2")).toBe(5);
+    expect(evalCoordExpr("10 - 2 - 3")).toBe(5);
+  });
+
+  it("handles unary minus and parentheses", () => {
+    expect(evalCoordExpr("-(2+3)")).toBe(-5);
+    expect(evalCoordExpr("2*-3")).toBe(-6);
+    expect(evalCoordExpr("--4")).toBe(4);
+    expect(evalCoordExpr("+5")).toBe(5);
+  });
+
+  it("rounds non-integer division results", () => {
+    expect(evalCoordExpr("5/2")).toBe(3);
+    expect(evalCoordExpr("7/2")).toBe(4);
+    expect(evalCoordExpr("-5/2")).toBe(-2);
+    expect(evalCoordExpr("10/3")).toBe(3);
+    expect(evalCoordExpr("10/4")).toBe(3);
+  });
+
+  it("does not pre-round intermediate floats", () => {
+    expect(evalCoordExpr("1+5/2+5/2")).toBe(6);
+  });
+
+  it("rejects division by zero", () => {
+    expect(evalCoordExpr("1/0")).toBeNull();
+    expect(evalCoordExpr("5/(2-2)")).toBeNull();
+  });
+
+  it("rejects malformed input", () => {
+    expect(evalCoordExpr("")).toBeNull();
+    expect(evalCoordExpr("   ")).toBeNull();
+    expect(evalCoordExpr("3+")).toBeNull();
+    expect(evalCoordExpr("abc")).toBeNull();
+    expect(evalCoordExpr("(1+2")).toBeNull();
+    expect(evalCoordExpr("1++2")).toBe(3);
+    expect(evalCoordExpr("1 2")).toBeNull();
+    expect(evalCoordExpr("*5")).toBeNull();
+  });
+});

--- a/piper_draw/gui/src/utils/parseCoordExpr.ts
+++ b/piper_draw/gui/src/utils/parseCoordExpr.ts
@@ -1,0 +1,92 @@
+// Tiny arithmetic evaluator for coordinate input fields (Keyboard Build mode).
+// Accepts number literals, `+ - * /`, unary `-`, and parentheses. Returns the
+// final value rounded to an integer via Math.round, or `null` if the input is
+// empty, malformed, divides by zero, or produces a non-finite result.
+
+export function evalCoordExpr(src: string): number | null {
+  const s = src.trim();
+  if (s === "") return null;
+
+  let i = 0;
+
+  const skipWs = () => {
+    while (i < s.length && (s[i] === " " || s[i] === "\t")) i++;
+  };
+
+  const parseNumber = (): number | null => {
+    skipWs();
+    const start = i;
+    while (i < s.length && /[0-9]/.test(s[i])) i++;
+    if (i < s.length && s[i] === ".") {
+      i++;
+      while (i < s.length && /[0-9]/.test(s[i])) i++;
+    }
+    if (i === start) return null;
+    const n = Number(s.slice(start, i));
+    return Number.isFinite(n) ? n : null;
+  };
+
+  const parseFactor = (): number | null => {
+    skipWs();
+    if (i >= s.length) return null;
+    if (s[i] === "-") {
+      i++;
+      const v = parseFactor();
+      return v === null ? null : -v;
+    }
+    if (s[i] === "+") {
+      i++;
+      return parseFactor();
+    }
+    if (s[i] === "(") {
+      i++;
+      const v = parseExpr();
+      skipWs();
+      if (v === null || i >= s.length || s[i] !== ")") return null;
+      i++;
+      return v;
+    }
+    return parseNumber();
+  };
+
+  const parseTerm = (): number | null => {
+    let v = parseFactor();
+    if (v === null) return null;
+    while (true) {
+      skipWs();
+      const op = s[i];
+      if (op !== "*" && op !== "/") break;
+      i++;
+      const rhs = parseFactor();
+      if (rhs === null) return null;
+      if (op === "/") {
+        if (rhs === 0) return null;
+        v = v / rhs;
+      } else {
+        v = v * rhs;
+      }
+    }
+    return v;
+  };
+
+  const parseExpr = (): number | null => {
+    let v = parseTerm();
+    if (v === null) return null;
+    while (true) {
+      skipWs();
+      const op = s[i];
+      if (op !== "+" && op !== "-") break;
+      i++;
+      const rhs = parseTerm();
+      if (rhs === null) return null;
+      v = op === "+" ? v + rhs : v - rhs;
+    }
+    return v;
+  };
+
+  const result = parseExpr();
+  skipWs();
+  if (result === null || i !== s.length) return null;
+  if (!Number.isFinite(result)) return null;
+  return Math.round(result);
+}


### PR DESCRIPTION
## Summary
- Keyboard Build mode's X/Y/Z coordinate inputs now accept arithmetic expressions (e.g. `3+2`, `(10-3)*2`, `10/2`), evaluated on Enter / blur.
- Non-integer division rounds to the nearest integer via `Math.round`; empty, malformed, or div-by-zero inputs revert to the current value (same UX as before).
- Parser lives in a new `utils/parseCoordExpr.ts` (recursive-descent, no `eval`) with unit tests.

## Test plan
- [x] `npm test` — 256 tests pass, including 7 new `parseCoordExpr` cases (arithmetic, rounding, intermediate-float preservation, div-by-zero, malformed input).
- [x] `tsc -b` clean.
- [x] `npm run lint` — 0 errors (2 pre-existing warnings unchanged).
- [ ] Manual browser smoke: enter Keyboard Build mode, type expressions in each axis input, verify cursor jumps correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)