### PR TITLE
feat: locate button on flows panel ports

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -20,6 +20,7 @@ import { OrientationGizmo } from "./components/OrientationGizmo";
 import { Toolbar } from "./components/Toolbar";
 import { ValidationToast } from "./components/ValidationToast";
 import { InvalidBlockHighlights } from "./components/InvalidBlockHighlights";
+import { LocatePulseHighlight } from "./components/LocatePulseHighlight";
 import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
 import { SelectModePointer, type ThreeState } from "./components/SelectModePointer";
@@ -812,7 +813,7 @@ export default function App() {
         ?
       </button>
       {helpOpen && <HelpPanel onClose={() => setHelpOpen(false)} />}
-      <FlowsPanel />
+      <FlowsPanel controlsRef={controlsRef} />
       <EditModeHints onCustomize={() => setKeybindEditorMode("edit")} />
       <BuildModeHints onCustomize={() => setKeybindEditorMode("build")} />
       {keybindEditorMode && (
@@ -829,6 +830,7 @@ export default function App() {
         <BlockInstances />
         {!photoRequest && <FoldOutCubeOverlay />}
         {!photoRequest && <InvalidBlockHighlights />}
+        {!photoRequest && <LocatePulseHighlight />}
         {!photoRequest && <SelectionHighlights />}
         {!photoRequest && <DragGhost />}
         {!photoRequest && <BuildCursor />}

--- a/piper_draw/gui/src/components/FlowsPanel.tsx
+++ b/piper_draw/gui/src/components/FlowsPanel.tsx
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
+import { useLocateStore } from "../stores/locateStore";
 import { computeFlows, type FlowsResult } from "../utils/flows";
-import { getAllPortPositions, posKey, type Position3D } from "../types";
+import { getAllPortPositions, posKey, tqecToThree, type Position3D } from "../types";
 import { isInSpanGF2, pauliToSymplectic } from "../utils/stabilizerSpan";
+import { animateCamera } from "../utils/cameraAnim";
 
 type Pauli = "I" | "X" | "Y" | "Z";
 const PAULI_CYCLE: Pauli[] = ["I", "X", "Y", "Z"];
@@ -87,6 +90,19 @@ function PortLabelInput({
   );
 }
 
+function LocateIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 16 16" aria-hidden="true">
+      <circle cx="8" cy="8" r="5" fill="none" stroke="currentColor" strokeWidth="1.2" />
+      <circle cx="8" cy="8" r="1" fill="currentColor" />
+      <line x1="8" y1="1" x2="8" y2="3.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="8" y1="12.5" x2="8" y2="15" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="1" y1="8" x2="3.5" y2="8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="12.5" y1="8" x2="15" y2="8" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
 function PauliCell({ pauli }: { pauli: string }) {
   const color = PAULI_COLOR[pauli] ?? "#ccc";
   const isI = pauli === "I";
@@ -145,7 +161,12 @@ function EditablePauliCell({
   );
 }
 
-export function FlowsPanel() {
+export function FlowsPanel({
+  controlsRef,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  controlsRef: React.RefObject<any>;
+}) {
   const open = useBlockStore((s) => s.flowsPanelOpen);
   const blocks = useBlockStore((s) => s.blocks);
   const portMeta = useBlockStore((s) => s.portMeta);
@@ -187,6 +208,22 @@ export function FlowsPanel() {
     setQueries([]);
     setLoading(false);
   }, [ensurePortLabels]);
+
+  const handleLocate = useCallback(
+    (pos: Position3D) => {
+      const controls = controlsRef.current;
+      if (controls) {
+        const [tx, ty, tz] = tqecToThree(pos, "XZZ");
+        const camera = controls.object as THREE.PerspectiveCamera;
+        const endTarget = new THREE.Vector3(tx, ty, tz);
+        const offset = new THREE.Vector3().subVectors(camera.position, controls.target);
+        const endPos = endTarget.clone().add(offset);
+        animateCamera(controls, endTarget, endPos, { duration: 400 });
+      }
+      useLocateStore.getState().setPulse(posKey(pos));
+    },
+    [controlsRef],
+  );
 
   const generatorSpan = useMemo(() => {
     if (!result || !result.ok) return null;
@@ -313,6 +350,25 @@ export function FlowsPanel() {
                 marginBottom: 4,
               }}
             >
+              <button
+                type="button"
+                onClick={() => handleLocate(pos)}
+                aria-label="Locate port"
+                title="Locate port"
+                style={{
+                  background: "none",
+                  border: "none",
+                  padding: 2,
+                  cursor: "pointer",
+                  color: "#666",
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  flexShrink: 0,
+                }}
+              >
+                <LocateIcon />
+              </button>
               <PortLabelInput
                 pos={pos}
                 label={meta?.label ?? ""}

--- a/piper_draw/gui/src/components/FlowsPanel.tsx
+++ b/piper_draw/gui/src/components/FlowsPanel.tsx
@@ -383,10 +383,10 @@ export function FlowsPanel({
                 <option value="out">out</option>
               </select>
               <span
-                title={`(${pos.x}, ${pos.y}, ${pos.z})`}
+                title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
                 style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
               >
-                {pos.x},{pos.y},{pos.z}
+                {pos.x / 3},{pos.y / 3},{pos.z / 3}
               </span>
             </div>
           ))}

--- a/piper_draw/gui/src/components/LocatePulseHighlight.tsx
+++ b/piper_draw/gui/src/components/LocatePulseHighlight.tsx
@@ -1,0 +1,82 @@
+import * as THREE from "three";
+import { useLocateStore } from "../stores/locateStore";
+import { useBlockStore } from "../stores/blockStore";
+import { usePulseScale } from "../hooks/usePulseScale";
+import { tqecToThree, blockThreeSize, yBlockZOffset } from "../types";
+import type { BlockType } from "../types";
+
+const PULSE_COLOR = 0xffa500;
+
+const fillMaterial = new THREE.MeshBasicMaterial({
+  color: PULSE_COLOR,
+  transparent: true,
+  opacity: 0.5,
+  depthWrite: false,
+  side: THREE.DoubleSide,
+});
+
+const outlineMaterial = new THREE.LineBasicMaterial({
+  color: PULSE_COLOR,
+  linewidth: 2,
+});
+
+const boxCache = new Map<BlockType, THREE.BoxGeometry>();
+const edgesCache = new Map<BlockType, THREE.EdgesGeometry>();
+
+function getPulseGeo(blockType: BlockType) {
+  let box = boxCache.get(blockType);
+  if (!box) {
+    const [sx, sy, sz] = blockThreeSize(blockType);
+    box = new THREE.BoxGeometry(sx * 1.15, sy * 1.15, sz * 1.15);
+    boxCache.set(blockType, box);
+  }
+  let edges = edgesCache.get(blockType);
+  if (!edges) {
+    edges = new THREE.EdgesGeometry(box);
+    edgesCache.set(blockType, edges);
+  }
+  return { box, edges };
+}
+
+const noRaycast = () => {};
+
+function PulsingLocateBlock({
+  position,
+  blockType,
+}: {
+  position: [number, number, number];
+  blockType: BlockType;
+}) {
+  const groupRef = usePulseScale();
+  const { box, edges } = getPulseGeo(blockType);
+  return (
+    <group ref={groupRef} position={position}>
+      <mesh geometry={box} material={fillMaterial} raycast={noRaycast} />
+      <lineSegments geometry={edges} material={outlineMaterial} raycast={noRaycast} />
+    </group>
+  );
+}
+
+function parseKey(key: string): { x: number; y: number; z: number } | null {
+  const parts = key.split(",").map(Number);
+  if (parts.length !== 3 || parts.some(isNaN)) return null;
+  return { x: parts[0], y: parts[1], z: parts[2] };
+}
+
+export function LocatePulseHighlight() {
+  const pulseKey = useLocateStore((s) => s.pulseKey);
+  const blocks = useBlockStore((s) => s.blocks);
+
+  if (!pulseKey) return null;
+  const block = blocks.get(pulseKey);
+  if (block) {
+    const zo = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+    const [tx, ty, tz] = tqecToThree(block.pos, block.type, zo);
+    return <PulsingLocateBlock position={[tx, ty, tz]} blockType={block.type} />;
+  }
+
+  const pos = parseKey(pulseKey);
+  if (!pos) return null;
+  const [tx, ty, tz] = tqecToThree(pos, "XZZ");
+  return <PulsingLocateBlock position={[tx, ty, tz]} blockType="XZZ" />;
+}

--- a/piper_draw/gui/src/stores/locateStore.ts
+++ b/piper_draw/gui/src/stores/locateStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+import { PULSE_SPEED } from "../hooks/usePulseScale";
+
+const PULSE_DURATION_MS = ((2 * 2 * Math.PI) / PULSE_SPEED) * 1000;
+
+interface LocateStore {
+  pulseKey: string | null;
+  setPulse: (key: string) => void;
+  clear: () => void;
+}
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+export const useLocateStore = create<LocateStore>((set) => ({
+  pulseKey: null,
+  setPulse: (key) => {
+    if (timer) clearTimeout(timer);
+    set({ pulseKey: key });
+    timer = setTimeout(() => {
+      set({ pulseKey: null });
+      timer = null;
+    }, PULSE_DURATION_MS);
+  },
+  clear: () => {
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    set({ pulseKey: null });
+  },
+}));


### PR DESCRIPTION
## Summary
- Adds a crosshair icon next to every detected port in the stabilizer flows panel. Clicking it pans the camera to the port and pulses an orange highlight on the port cell for two sine periods.
- Introduces a small Zustand store (`locateStore`) with a module-scope auto-clear timer so the pulse self-expires, and a `<LocatePulseHighlight />` renderer that mirrors the `InvalidBlockHighlights` pattern.
- Mirrors the UX of clicking an error in the verify toast, so identifying which pipe a port entry refers to is now a one-click operation in dense diagrams.

## Test plan
- [ ] Open the flows panel on a diagram with ≥2 open ports and click the locate icon — camera animates and orange pulse appears at the port for ~4.2s.
- [ ] Click a different port mid-pulse — prior pulse clears, new one restarts fresh.
- [ ] Close the flows panel during a pulse — pulse still auto-clears.
- [ ] Delete the owning pipe mid-pulse — no console error.
- [ ] `npm run test`, `npm run lint`, `tsc -b` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)