### PR TITLE
fix: advertise Option+Drag for camera rotate in drag+drop mode

### DIFF
--- a/piper_draw/gui/src/components/EditModeHints.tsx
+++ b/piper_draw/gui/src/components/EditModeHints.tsx
@@ -62,7 +62,11 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
     hints.push(
       ["Click", placeLabel],
       ["Drag", dragRotates ? "Rotate" : "Pan"],
-      ...(isIso ? [] : [["Shift+Drag", dragRotates ? "Pan" : "Rotate"] as const]),
+      ...(isIso
+        ? []
+        : dragRotates
+          ? [["Shift+Drag", "Pan"] as const]
+          : [[`${altKey}Drag`, "Rotate"] as const]),
       ["Scroll", "Zoom"],
       [`Hold ${bindingToLabel(b.holdToDelete)}`, "Click-to-delete"],
       [bindingToLabel(b.clearSelection), "Disarm (→ pointer)"],


### PR DESCRIPTION
## Summary
- Drag+drop hint bar was advertising `Shift+Drag → Rotate` while pointer mode already showed `⌥ Option+Drag → Orbit` for the same camera gesture — issue #151.
- `Alt+Drag` was already mapped to camera rotate in `NavControlsModifier.tsx` for both modes, so this is a hint copy fix only. Rotate navStyle is unchanged (plain drag rotates, Shift+Drag pans).

## Test plan
- [ ] Enter drag+drop mode with pan navStyle, arm a block/pipe/port tool, confirm hint reads `⌥ Option+Drag → Rotate` (non-iso camera).
- [ ] Hold Option and drag on the canvas → camera orbits.
- [ ] Switch to pointer/select mode, confirm hint still reads `⌥ Option+Drag → Orbit`.
- [ ] Switch navStyle to "rotate" → hint reads `Drag → Rotate`, `Shift+Drag → Pan`.
- [ ] Iso camera view hides the modifier hint entirely.

Closes #151

🧙 Built with [WOZCODE](https://wozcode.com)