### PR TITLE
feat: replace selected block via toolbar click; tighten Y greyout

### DIFF
--- a/piper_draw/gui/src/components/Toolbar.tsx
+++ b/piper_draw/gui/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useBlockStore, type BuildStep } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { useKeybindStore, type Mode as KeybindMode, type NavStyle } from "../stores/keybindStore";
-import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
+import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
@@ -110,6 +110,7 @@ export function Toolbar({
   const setPaletteDragging = useBlockStore((s) => s.setPaletteDragging);
   const cycleBlock = useBlockStore((s) => s.cycleBlock);
   const cyclePipe = useBlockStore((s) => s.cyclePipe);
+  const cycleSelectedType = useBlockStore((s) => s.cycleSelectedType);
   const historyLen = useBlockStore((s) => s.history.length);
   const futureLen = useBlockStore((s) => s.future.length);
   const undo = useBlockStore((s) => s.undo);
@@ -174,7 +175,6 @@ export function Toolbar({
     const cursor = s.buildCursor;
     const coords: [number, number, number] = [cursor.x, cursor.y, cursor.z];
     let pipeCount = 0;
-    let yValid = true;
     for (let axis = 0; axis < 3; axis++) {
       for (const offset of [1, -2]) {
         const nc: [number, number, number] = [coords[0], coords[1], coords[2]];
@@ -182,10 +182,7 @@ export function Toolbar({
         const n = s.blocks.get(posKey({ x: nc[0], y: nc[1], z: nc[2] }));
         if (n && isPipeType(n.type)) {
           const openAxis = n.type.replace("H", "").indexOf("O");
-          if (openAxis === axis) {
-            pipeCount++;
-            if (openAxis !== 2) yValid = false;
-          }
+          if (openAxis === axis) pipeCount++;
         }
       }
     }
@@ -196,7 +193,8 @@ export function Toolbar({
           const result = determineCubeOptions(cursor, s.blocks);
           return result.determined ? [result.type] : [...result.options];
         })();
-    if (yValid) opts.push("Y");
+    // Y is a leaf: only valid with at most one attached (Z-open) pipe.
+    if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", cursor, s.blocks)) opts.push("Y");
     return opts.join(",");
   });
   const buildValidTypes = buildValidTypesStr != null ? new Set(buildValidTypesStr.split(",").filter(Boolean)) : null;
@@ -228,7 +226,6 @@ export function Toolbar({
     }
     const coords: [number, number, number] = [pos.x, pos.y, pos.z];
     let pipeCount = 0;
-    let yValid = true;
     for (let axis = 0; axis < 3; axis++) {
       for (const offset of [1, -2]) {
         const nc: [number, number, number] = [coords[0], coords[1], coords[2]];
@@ -236,16 +233,14 @@ export function Toolbar({
         const n = s.blocks.get(posKey({ x: nc[0], y: nc[1], z: nc[2] }));
         if (n && isPipeType(n.type)) {
           const openAxis = n.type.replace("H", "").indexOf("O");
-          if (openAxis === axis) {
-            pipeCount++;
-            if (openAxis !== 2) yValid = false;
-          }
+          if (openAxis === axis) pipeCount++;
         }
       }
     }
     const result = determineCubeOptions(pos, s.blocks);
     const opts: string[] = result.determined ? [result.type] : [...result.options];
-    if (yValid) opts.push("Y");
+    // Y is a leaf: only valid with at most one attached (Z-open) pipe.
+    if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", pos, s.blocks)) opts.push("Y");
     return `${currentType};${pipeCount < 2 ? "1" : "0"};${opts.join(",")}`;
   });
   const selectedCubeSlotInfo = (() => {
@@ -605,6 +600,10 @@ export function Toolbar({
             key="port"
             onPointerDown={() => {
               if (mode !== "edit") return;
+              // With a single block/port selected, defer to onClick (which
+              // replaces the selection in place); calling setPlacePort here
+              // would clear the selection before the click is handled.
+              if (selectedCubeSlotInfo != null) return;
               setPlacePort(true);
               setPaletteDragging(true);
             }}
@@ -613,6 +612,12 @@ export function Toolbar({
                 // In Keyboard Build mode, clicking Port converts the cursor cube back to a port
                 // (only valid when pipeCount < 2; cycleBlock validates and no-ops otherwise).
                 cycleBlock(null);
+                return;
+              }
+              // Single block/port selected → replace it in place rather than
+              // dropping the selection and arming the placement tool.
+              if (selectedCubeSlotInfo != null && selectedCubeSlotInfo.portAllowed) {
+                cycleSelectedType(1, { kind: "port" });
                 return;
               }
               setPlacePort(true);
@@ -634,12 +639,17 @@ export function Toolbar({
               key={ct}
               onPointerDown={() => {
                 if (mode !== "edit") return;
+                if (selectedCubeSlotInfo != null) return;
                 setCubeType(ct as BlockType);
                 setPaletteDragging(true);
               }}
               onClick={() => {
                 if (mode === "build") {
                   cycleBlock(ct);
+                  return;
+                }
+                if (selectedCubeSlotInfo != null && selectedCubeSlotInfo.validTypes.has(ct)) {
+                  cycleSelectedType(1, { kind: "cube", type: ct });
                   return;
                 }
                 setCubeType(ct as BlockType);
@@ -666,12 +676,17 @@ export function Toolbar({
           <button
             onPointerDown={() => {
               if (mode !== "edit") return;
+              if (selectedCubeSlotInfo != null) return;
               setCubeType("Y");
               setPaletteDragging(true);
             }}
             onClick={() => {
               if (mode === "build") {
                 cycleBlock("Y");
+                return;
+              }
+              if (selectedCubeSlotInfo != null && selectedCubeSlotInfo.validTypes.has("Y")) {
+                cycleSelectedType(1, { kind: "cube", type: "Y" });
                 return;
               }
               setCubeType("Y");
@@ -705,12 +720,17 @@ export function Toolbar({
               key={v}
               onPointerDown={() => {
                 if (mode !== "edit") return;
+                if (selectedPipeInfo != null) return;
                 setPipeVariant(v);
                 setPaletteDragging(true);
               }}
               onClick={() => {
                 if (mode === "build") {
                   cyclePipe(v);
+                  return;
+                }
+                if (selectedPipeInfo != null && selectedPipeInfo.validVariants.has(v)) {
+                  cycleSelectedType(1, { kind: "pipe", variant: v });
                   return;
                 }
                 setPipeVariant(v);

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -207,8 +207,16 @@ interface BlockStore {
    * cycle the selected item through the toolbar options that remain valid at its
    * position. Selection is preserved (the selected-indicator follows the new type).
    * No-op if selection is empty, multi-select, or the only valid option is current.
+   * If `target` is provided, jump directly to that option instead of cycling
+   * (used by toolbar-button clicks). `dir` is ignored when `target` is provided.
    */
-  cycleSelectedType: (dir: -1 | 1) => void;
+  cycleSelectedType: (
+    dir: -1 | 1,
+    target?:
+      | { kind: "port" }
+      | { kind: "cube"; type: CubeType | "Y" }
+      | { kind: "pipe"; variant: PipeVariant },
+  ) => void;
   setPaletteDragging: (on: boolean) => void;
   convertBlockToPort: (pos: Position3D) => void;
   clearPortWarning: () => void;
@@ -575,7 +583,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     else if (target.kind === "cube") s.setCubeType(target.cubeType);
     else s.setPipeVariant(target.variant);
   },
-  cycleSelectedType: (dir) => {
+  cycleSelectedType: (dir, target) => {
     const state = get();
     if (state.mode !== "edit" || state.armedTool !== "pointer") return;
 
@@ -621,10 +629,16 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           }
           if (cycle.length <= 1) return s;
 
-          const curIdx = cycle.indexOf(currentVariant);
-          if (curIdx === -1) return s;
-          const nextIdx = (((curIdx + dir) % cycle.length) + cycle.length) % cycle.length;
-          const nextVariant = cycle[nextIdx];
+          let nextVariant: PipeVariant;
+          if (target !== undefined) {
+            if (target.kind !== "pipe" || !cycle.includes(target.variant)) return s;
+            nextVariant = target.variant;
+          } else {
+            const curIdx = cycle.indexOf(currentVariant);
+            if (curIdx === -1) return s;
+            const nextIdx = (((curIdx + dir) % cycle.length) + cycle.length) % cycle.length;
+            nextVariant = cycle[nextIdx];
+          }
           if (nextVariant === currentVariant) return s;
 
           const newType = VARIANT_AXIS_MAP[nextVariant][openAxis];
@@ -678,7 +692,6 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
       const coords: [number, number, number] = [pos.x, pos.y, pos.z];
       let pipeCount = 0;
-      let yValid = true;
       for (let axis = 0; axis < 3; axis++) {
         for (const offset of [1, -2]) {
           const nc: [number, number, number] = [coords[0], coords[1], coords[2]];
@@ -686,16 +699,14 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const n = s.blocks.get(posKey({ x: nc[0], y: nc[1], z: nc[2] }));
           if (n && isPipeType(n.type)) {
             const openAxis = n.type.replace("H", "").indexOf("O");
-            if (openAxis === axis) {
-              pipeCount++;
-              if (openAxis !== 2) yValid = false;
-            }
+            if (openAxis === axis) pipeCount++;
           }
         }
       }
       const result = determineCubeOptions(pos, s.blocks);
       const cubeOpts = new Set<CubeType | "Y">(result.determined ? [result.type] : result.options);
-      if (yValid) cubeOpts.add("Y");
+      // Y is a leaf: only valid with at most one attached (Z-open) pipe.
+      if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", pos, s.blocks)) cubeOpts.add("Y");
       const portAllowed = pipeCount < 2;
 
       type Opt = { kind: "port" } | { kind: "cube"; type: CubeType | "Y" };
@@ -707,19 +718,32 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       if (cubeOpts.has("Y") || currentKind === "Y") cycle.push({ kind: "cube", type: "Y" });
       if (cycle.length <= 1) return s;
 
-      const curIdx = cycle.findIndex((o) =>
-        currentKind === "PORT" ? o.kind === "port" : (o.kind === "cube" && o.type === currentKind)
-      );
-      if (curIdx === -1) return s;
-      const nextIdx = (((curIdx + dir) % cycle.length) + cycle.length) % cycle.length;
-      const target = cycle[nextIdx];
+      let nextOpt: Opt;
+      if (target !== undefined) {
+        if (target.kind === "pipe") return s;
+        const found = cycle.find((o) =>
+          target.kind === "port" ? o.kind === "port" : (o.kind === "cube" && o.type === target.type),
+        );
+        if (!found) return s;
+        nextOpt = found;
+      } else {
+        const curIdx = cycle.findIndex((o) =>
+          currentKind === "PORT" ? o.kind === "port" : (o.kind === "cube" && o.type === currentKind)
+        );
+        if (curIdx === -1) return s;
+        const nextIdx = (((curIdx + dir) % cycle.length) + cycle.length) % cycle.length;
+        nextOpt = cycle[nextIdx];
+      }
+      // No-op if target equals current (toolbar click on the already-placed type).
+      if (nextOpt.kind === "port" && currentKind === "PORT") return s;
+      if (nextOpt.kind === "cube" && nextOpt.type === currentKind) return s;
 
       let { blocks, hiddenFaces } = { blocks: s.blocks, hiddenFaces: s.hiddenFaces };
       const oldPortMarker = s.portPositions.has(key);
       let newBlock: Block | null;
       let newPortMarker: boolean;
 
-      if (target.kind === "port") {
+      if (nextOpt.kind === "port") {
         if (existingBlock) {
           ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, key, existingBlock));
         }
@@ -731,7 +755,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (existingBlock) {
           ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, key, existingBlock));
         }
-        newBlock = { pos, type: target.type };
+        newBlock = { pos, type: nextOpt.type };
         ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, key, newBlock));
         // Placing a cube clears any explicit port marker at this position
         // (mirrors addBlock's behaviour when a cube lands on a user-placed port).
@@ -2692,9 +2716,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       const cursorKey = posKey(cursor);
       const coords: [number, number, number] = [cursor.x, cursor.y, cursor.z];
 
-      // Count adjacent pipes and check if Y is valid (only Z-open pipes)
+      // Count adjacent pipes (Y validity uses hasYCubePipeAxisConflict below).
       let pipeCount = 0;
-      let yValid = true;
       for (let axis = 0; axis < 3; axis++) {
         for (const pipeOffset of [1, -2]) {
           const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
@@ -2702,10 +2725,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const n = state.blocks.get(posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] }));
           if (n && isPipeType(n.type)) {
             const openAxis = n.type.replace("H", "").indexOf("O");
-            if (openAxis === axis) {
-              pipeCount++;
-              if (openAxis !== 2) yValid = false;
-            }
+            if (openAxis === axis) pipeCount++;
           }
         }
       }
@@ -2721,7 +2741,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
               const result = determineCubeOptions(cursor, state.blocks);
               return result.determined ? [result.type] : result.options;
             })();
-        if (yValid) cubeOptions.push("Y");
+        // Y is a leaf: only valid with at most one attached (Z-open) pipe.
+        if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", cursor, state.blocks)) cubeOptions.push("Y");
       }
       if (cubeOptions.length === 0) return state;
 


### PR DESCRIPTION
## Summary
- In Drag/Drop mode with a single Port/cube/Y/pipe selected, clicking a toolbar block button now replaces the selection in place (via an extended `cycleSelectedType(dir, target?)`) instead of clearing the selection and arming the placement tool.
- Toolbar Y greying now uses `hasYCubePipeAxisConflict` (the canonical placement check) plus a leaf-rule guard (`pipeCount <= 1`) so Y is correctly greyed at junctions in edit mode, matching build mode.
- The same Y leaf-rule + axis check is applied in `cycleSelectedType` and `cycleBlock`, keeping toolbar greying, R-cycling, and arrow-key cycling consistent.

## Test plan
- [x] `npm test` (256 passed)
- [x] `tsc -b` clean
- [ ] In Drag/Drop mode, select a single block and click a different cube/Y/Port in the toolbar — selection should be replaced in place
- [ ] Select a position with two Z-open pipes attached — Y button should be greyed
- [ ] R-cycling on a single selection still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)