### PR TITLE
feat: power-user keyboard shortcuts and unified key bindings panel

### DIFF
--- a/piper_draw/gui/src/App.tsx
+++ b/piper_draw/gui/src/App.tsx
@@ -32,7 +32,7 @@ import { PortLabels3D } from "./components/PortLabels3D";
 import { FoldOutCubeOverlay } from "./components/FoldOutCubeOverlay";
 import { BuildModeHints } from "./components/BuildModeHints";
 import { EditModeHints } from "./components/EditModeHints";
-import { KeybindEditor } from "./components/KeybindEditor";
+import { KeybindEditor, type KeybindEditorTab } from "./components/KeybindEditor";
 import { HelpPanel } from "./components/HelpPanel";
 import { useBlockStore } from "./stores/blockStore";
 import {
@@ -40,13 +40,13 @@ import {
   actionForKey,
   actionToWasdKey,
   type KeyBinding,
-  type Mode,
 } from "./stores/keybindStore";
 import { useValidationStore } from "./stores/validationStore";
-import { wasdToBuildDirection, tqecToThree, posKey, type Block, type ViewMode } from "./types";
+import { wasdToBuildDirection, tqecToThree, posKey, blockTqecSize, type Block, type ViewMode } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 import { downloadPng } from "./utils/photoExport";
+import { downloadDae } from "./utils/daeExport";
 import { isEditableTarget } from "./utils/editableFocus";
 import {
   ISO_INITIAL_ZOOM,
@@ -464,11 +464,13 @@ export default function App() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const controlsRef = useRef<any>(null);
   const toolbarRef = useRef<HTMLDivElement>(null);
-  const [keybindEditorMode, setKeybindEditorMode] = useState<Mode | null>(null);
+  const [keybindEditorMode, setKeybindEditorMode] = useState<KeybindEditorTab | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
   const threeStateRef = useRef<ThreeState | null>(null);
   const photoRequest = useBlockStore((s) => s.photoRequest);
   const flowsPanelOpen = useBlockStore((s) => s.flowsPanelOpen);
+  const showGrid = useBlockStore((s) => s.showGrid);
+  const showHints = useBlockStore((s) => s.showHints);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -480,6 +482,154 @@ export default function App() {
       const store = useBlockStore.getState();
       const bindings = useKeybindStore.getState().bindings;
       const mode = store.mode;
+
+      // Global shortcuts (work in both modes). Run before mode-specific bindings.
+      // Ctrl/Cmd-modified globals: copy, paste, export.
+      if (ctrl && !alt && !shift) {
+        switch (key) {
+          case "c":
+            if (store.selectedKeys.size > 0) {
+              e.preventDefault();
+              store.copySelection();
+              return;
+            }
+            break;
+          case "v":
+            if (store.clipboard && store.clipboard.size > 0) {
+              e.preventDefault();
+              store.paste();
+              return;
+            }
+            break;
+          case "s":
+            e.preventDefault();
+            void downloadDae(store.blocks);
+            return;
+        }
+      }
+
+      if (!ctrl && !alt) {
+        if (!shift) {
+          switch (key) {
+            case "tab":
+              e.preventDefault();
+              store.setMode(mode === "build" ? "edit" : "build");
+              return;
+            case "1": e.preventDefault(); store.setIsoView("x"); return;
+            case "2": e.preventDefault(); store.setIsoView("y"); return;
+            case "3": e.preventDefault(); store.setIsoView("z"); return;
+            case "4": {
+              e.preventDefault();
+              const controls = controlsRef.current;
+              const wasPersp = store.viewMode.kind === "persp";
+              store.setPerspView();
+              // When already in persp, switching is a no-op — re-center camera
+              // to match the fresh-camera behaviour of switching from iso.
+              if (wasPersp && controls?.target0 && controls?.position0) {
+                animateCamera(controls, controls.target0.clone(), controls.position0.clone());
+              }
+              return;
+            }
+            case "g": e.preventDefault(); store.toggleShowGrid(); return;
+            case "h": e.preventDefault(); store.toggleShowHints(); return;
+            case "t": {
+              e.preventDefault();
+              let minX = Infinity, minY = Infinity, minZ = Infinity;
+              let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
+              let count = 0;
+              for (const block of store.blocks.values()) {
+                const [sx, sy, sz] = blockTqecSize(block.type);
+                const { x, y, z } = block.pos;
+                if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+                if (x + sx > maxX) maxX = x + sx;
+                if (y + sy > maxY) maxY = y + sy;
+                if (z + sz > maxZ) maxZ = z + sz;
+                count++;
+              }
+              for (const k of store.portPositions) {
+                const [x, y, z] = k.split(",").map(Number);
+                if (x < minX) minX = x; if (y < minY) minY = y; if (z < minZ) minZ = z;
+                if (x + 1 > maxX) maxX = x + 1;
+                if (y + 1 > maxY) maxY = y + 1;
+                if (z + 1 > maxZ) maxZ = z + 1;
+                count++;
+              }
+              if (count === 0) return;
+              const threeCenter = new THREE.Vector3(
+                (minX + maxX) / 2,
+                (minZ + maxZ) / 2,
+                -(minY + maxY) / 2,
+              );
+              const dX = maxX - minX, dY = maxY - minY, dZ = maxZ - minZ;
+              const diameter = Math.sqrt(dX * dX + dY * dY + dZ * dZ);
+              const controls = controlsRef.current;
+              if (!controls) return;
+              if (store.viewMode.kind === "persp") {
+                const camera = controls.object as THREE.PerspectiveCamera;
+                const fovRad = (camera.fov * Math.PI) / 180;
+                const margin = 1.2;
+                const distance = Math.max(diameter / 2 / Math.tan(fovRad / 2) * margin, 2);
+                const dir = camera.position.clone().sub(controls.target);
+                if (dir.lengthSq() < 1e-6) dir.set(1, 1, -1);
+                dir.normalize();
+                animateCamera(
+                  controls,
+                  threeCenter,
+                  threeCenter.clone().add(dir.multiplyScalar(distance)),
+                );
+              } else {
+                // Iso: step slice to bbox center on depth axis, then pan target in-plane.
+                const axis = store.viewMode.axis;
+                const centerDepth = axis === "x"
+                  ? (minX + maxX) / 2
+                  : axis === "y"
+                  ? (minY + maxY) / 2
+                  : (minZ + maxZ) / 2;
+                const sliceDelta = Math.round(centerDepth) - store.viewMode.slice;
+                if (sliceDelta !== 0) store.stepSlice(sliceDelta);
+                // Let the IsoViewport effect reposition the ortho camera, then
+                // animate the in-plane pan.
+                requestAnimationFrame(() => {
+                  const c = controlsRef.current;
+                  if (!c) return;
+                  const camObj = c.object as THREE.Object3D;
+                  const offset = camObj.position.clone().sub(c.target);
+                  animateCamera(c, threeCenter, threeCenter.clone().add(offset));
+                });
+              }
+              return;
+            }
+            case ".": {
+              e.preventDefault();
+              const all = [
+                ...store.selectedKeys,
+                ...store.selectedPortPositions,
+              ];
+              if (all.length === 0) return;
+              let sx = 0, sy = 0, sz = 0;
+              for (const k of all) {
+                const [x, y, z] = k.split(",").map(Number);
+                sx += x; sy += y; sz += z;
+              }
+              const n = all.length;
+              const [tx, ty, tz] = tqecToThree({ x: sx / n, y: sy / n, z: sz / n });
+              const newTarget = new THREE.Vector3(tx, ty, tz);
+              const controls = controlsRef.current;
+              if (!controls) return;
+              const camera = controls.object as THREE.Object3D;
+              const offset = camera.position.clone().sub(controls.target);
+              animateCamera(controls, newTarget, newTarget.clone().add(offset));
+              return;
+            }
+          }
+        }
+        // ? requires shift (on US layouts); match the literal key.
+        if (e.key === "?") {
+          e.preventDefault();
+          setKeybindEditorMode("general");
+          return;
+        }
+      }
 
       if (mode === "build") {
         const action = actionForKey(bindings.build, key, ctrl, shift, alt);
@@ -814,8 +964,8 @@ export default function App() {
       </button>
       {helpOpen && <HelpPanel onClose={() => setHelpOpen(false)} />}
       <FlowsPanel controlsRef={controlsRef} />
-      <EditModeHints onCustomize={() => setKeybindEditorMode("edit")} />
-      <BuildModeHints onCustomize={() => setKeybindEditorMode("build")} />
+      {showHints && <EditModeHints onCustomize={() => setKeybindEditorMode("edit")} />}
+      {showHints && <BuildModeHints onCustomize={() => setKeybindEditorMode("build")} />}
       {keybindEditorMode && (
         <KeybindEditor initialMode={keybindEditorMode} onClose={() => setKeybindEditorMode(null)} />
       )}
@@ -841,7 +991,7 @@ export default function App() {
         {!photoRequest && <GhostBlock />}
         <AxisLabels />
         <FpsSampler targetRef={fpsRef} />
-        {!photoRequest && <CheckerboardGrid />}
+        {!photoRequest && showGrid && <CheckerboardGrid />}
         {!photoRequest && (
           <GizmoHelper alignment="bottom-right" margin={[80, 80]}>
             <OrientationGizmo />

--- a/piper_draw/gui/src/components/KeybindEditor.tsx
+++ b/piper_draw/gui/src/components/KeybindEditor.tsx
@@ -9,21 +9,44 @@ import {
   type Mode,
 } from "../stores/keybindStore";
 
-const MODE_TAB_LABELS: Record<Mode, string> = {
+export type KeybindEditorTab = Mode | "general";
+
+const TAB_LABELS: Record<KeybindEditorTab, string> = {
+  general: "General",
   edit: "Drag / Drop",
   build: "Keyboard Build",
 };
+
+const TAB_ORDER: readonly KeybindEditorTab[] = ["general", "edit", "build"];
+
+// General (mode-independent) shortcuts are hardcoded in App.tsx, not stored in
+// the keybindStore — so they're shown here read-only.
+const GENERAL_SHORTCUTS: ReadonlyArray<readonly [string, string]> = [
+  ["Tab", "Toggle Keyboard Build / Drag-Drop mode"],
+  ["1", "Iso X view"],
+  ["2", "Iso Y view"],
+  ["3", "Iso Z view"],
+  ["4", "3D view (re-centers camera)"],
+  ["G", "Toggle grid"],
+  ["H", "Toggle hint bar"],
+  [".", "Focus camera on selection"],
+  ["T", "Fit camera to total scene"],
+  ["Ctrl/Cmd+C", "Copy selection"],
+  ["Ctrl/Cmd+V", "Paste"],
+  ["Ctrl/Cmd+S", "Export .dae"],
+  ["?", "Show this shortcut list"],
+];
 
 export function KeybindEditor({
   initialMode,
   onClose,
 }: {
-  initialMode: Mode;
+  initialMode: KeybindEditorTab;
   onClose: () => void;
 }) {
-  const [mode, setMode] = useState<Mode>(initialMode);
+  const [tab, setTab] = useState<KeybindEditorTab>(initialMode);
   const [listening, setListening] = useState<AnyAction | null>(null);
-  const bindings = useKeybindStore((s) => s.bindings[mode]) as Record<AnyAction, KeyBinding>;
+  const bindings = useKeybindStore((s) => s.bindings);
   const setBinding = useKeybindStore((s) => s.setBinding);
   const resetMode = useKeybindStore((s) => s.resetMode);
 
@@ -38,13 +61,15 @@ export function KeybindEditor({
       if (e.ctrlKey || e.metaKey) binding.ctrl = true;
       if (e.shiftKey) binding.shift = true;
       if (e.altKey) binding.alt = true;
-      // Cast is safe because `listening` was selected from the same mode's action list.
-      setBinding(mode, listening as never, binding);
+      // Only edit/build tabs can be listening (the General tab doesn't bind).
+      if (tab === "edit" || tab === "build") {
+        setBinding(tab, listening as never, binding);
+      }
       setListening(null);
     };
     window.addEventListener("keydown", handler, true);
     return () => window.removeEventListener("keydown", handler, true);
-  }, [listening, setBinding, mode]);
+  }, [listening, setBinding, tab]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -65,14 +90,11 @@ export function KeybindEditor({
     [onClose],
   );
 
-  const switchMode = (next: Mode) => {
-    if (next === mode) return;
+  const switchTab = (next: KeybindEditorTab) => {
+    if (next === tab) return;
     setListening(null);
-    setMode(next);
+    setTab(next);
   };
-
-  const actions = ACTIONS[mode] as readonly AnyAction[];
-  const labels = ACTION_LABELS[mode] as Record<AnyAction, string>;
 
   return (
     <div
@@ -93,8 +115,10 @@ export function KeybindEditor({
           background: "#fff",
           borderRadius: "12px",
           padding: "20px 24px",
-          minWidth: 340,
-          maxWidth: 420,
+          minWidth: 360,
+          maxWidth: 460,
+          maxHeight: "80vh",
+          overflowY: "auto",
           boxShadow: "0 8px 32px rgba(0,0,0,0.2)",
         }}
       >
@@ -122,7 +146,6 @@ export function KeybindEditor({
           </button>
         </div>
 
-        {/* Mode tab switcher */}
         <div
           style={{
             display: "flex",
@@ -133,12 +156,12 @@ export function KeybindEditor({
             marginBottom: 12,
           }}
         >
-          {(["edit", "build"] as Mode[]).map((m) => {
-            const active = mode === m;
+          {TAB_ORDER.map((t) => {
+            const active = tab === t;
             return (
               <button
-                key={m}
-                onClick={() => switchMode(m)}
+                key={t}
+                onClick={() => switchTab(t)}
                 style={{
                   flex: 1,
                   padding: "4px 12px",
@@ -153,68 +176,142 @@ export function KeybindEditor({
                   boxShadow: active ? "0 1px 2px rgba(0,0,0,0.08)" : "none",
                 }}
               >
-                {MODE_TAB_LABELS[m]}
+                {TAB_LABELS[t]}
               </button>
             );
           })}
         </div>
 
-        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          {actions.map((action) => {
-            const binding = bindings[action];
-            const isListeningThis = listening === action;
-            return (
-              <div
-                key={action}
-                style={{
-                  display: "flex",
-                  justifyContent: "space-between",
-                  alignItems: "center",
-                  padding: "6px 8px",
-                  borderRadius: 6,
-                  background: isListeningThis ? "#e8f0fe" : "#f8f8f8",
-                }}
-              >
-                <span style={{ fontSize: 13, color: "#333" }}>{labels[action]}</span>
-                <button
-                  onClick={() => setListening(isListeningThis ? null : action)}
-                  style={{
-                    minWidth: 60,
-                    padding: "4px 10px",
-                    border: isListeningThis ? "2px solid #4285f4" : "1px solid #ccc",
-                    borderRadius: 4,
-                    background: "#fff",
-                    cursor: "pointer",
-                    fontSize: 13,
-                    fontFamily: "monospace",
-                    color: isListeningThis ? "#4285f4" : "#333",
-                    textAlign: "center",
-                  }}
-                >
-                  {isListeningThis ? "Press a key…" : bindingToLabel(binding)}
-                </button>
-              </div>
-            );
-          })}
-        </div>
-
-        <div style={{ marginTop: 14, textAlign: "right" }}>
-          <button
-            onClick={() => resetMode(mode)}
-            style={{
-              background: "none",
-              border: "1px solid #ccc",
-              borderRadius: 6,
-              padding: "5px 12px",
-              fontSize: 12,
-              cursor: "pointer",
-              color: "#555",
-            }}
-          >
-            Reset {MODE_TAB_LABELS[mode]} to defaults
-          </button>
-        </div>
+        {tab === "general" ? (
+          <GeneralList />
+        ) : (
+          <BindableList
+            mode={tab}
+            bindings={bindings[tab] as Record<AnyAction, KeyBinding>}
+            listening={listening}
+            setListening={setListening}
+            onReset={() => resetMode(tab)}
+          />
+        )}
       </div>
     </div>
+  );
+}
+
+function GeneralList() {
+  return (
+    <>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {GENERAL_SHORTCUTS.map(([key, action]) => (
+          <div
+            key={`${key}:${action}`}
+            style={{
+              display: "flex",
+              justifyContent: "space-between",
+              alignItems: "center",
+              padding: "6px 8px",
+              borderRadius: 6,
+              background: "#f8f8f8",
+            }}
+          >
+            <span style={{ fontSize: 13, color: "#333" }}>{action}</span>
+            <span
+              style={{
+                minWidth: 60,
+                padding: "4px 10px",
+                border: "1px solid #ddd",
+                borderRadius: 4,
+                background: "#fafafa",
+                fontSize: 13,
+                fontFamily: "monospace",
+                color: "#666",
+                textAlign: "center",
+              }}
+            >
+              {key}
+            </span>
+          </div>
+        ))}
+      </div>
+      <p style={{ margin: "12px 2px 0", fontSize: 11, color: "#888" }}>
+        General shortcuts are fixed and not rebindable.
+      </p>
+    </>
+  );
+}
+
+function BindableList({
+  mode,
+  bindings,
+  listening,
+  setListening,
+  onReset,
+}: {
+  mode: Mode;
+  bindings: Record<AnyAction, KeyBinding>;
+  listening: AnyAction | null;
+  setListening: (a: AnyAction | null) => void;
+  onReset: () => void;
+}) {
+  const actions = ACTIONS[mode] as readonly AnyAction[];
+  const labels = ACTION_LABELS[mode] as Record<AnyAction, string>;
+  return (
+    <>
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {actions.map((action) => {
+          const binding = bindings[action];
+          const isListeningThis = listening === action;
+          return (
+            <div
+              key={action}
+              style={{
+                display: "flex",
+                justifyContent: "space-between",
+                alignItems: "center",
+                padding: "6px 8px",
+                borderRadius: 6,
+                background: isListeningThis ? "#e8f0fe" : "#f8f8f8",
+              }}
+            >
+              <span style={{ fontSize: 13, color: "#333" }}>{labels[action]}</span>
+              <button
+                onClick={() => setListening(isListeningThis ? null : action)}
+                style={{
+                  minWidth: 60,
+                  padding: "4px 10px",
+                  border: isListeningThis ? "2px solid #4285f4" : "1px solid #ccc",
+                  borderRadius: 4,
+                  background: "#fff",
+                  cursor: "pointer",
+                  fontSize: 13,
+                  fontFamily: "monospace",
+                  color: isListeningThis ? "#4285f4" : "#333",
+                  textAlign: "center",
+                }}
+              >
+                {isListeningThis ? "Press a key…" : bindingToLabel(binding)}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <div style={{ marginTop: 14, textAlign: "right" }}>
+        <button
+          onClick={onReset}
+          style={{
+            background: "none",
+            border: "1px solid #ccc",
+            borderRadius: 6,
+            padding: "5px 12px",
+            fontSize: 12,
+            cursor: "pointer",
+            color: "#555",
+          }}
+        >
+          Reset {TAB_LABELS[mode]} to defaults
+        </button>
+      </div>
+    </>
   );
 }

--- a/piper_draw/gui/src/stores/blockStore.ts
+++ b/piper_draw/gui/src/stores/blockStore.ts
@@ -261,6 +261,17 @@ interface BlockStore {
   freeBuild: boolean;
   toggleFreeBuild: () => void;
 
+  // View-chrome visibility toggles (keyboard shortcuts G / H).
+  showGrid: boolean;
+  showHints: boolean;
+  toggleShowGrid: () => void;
+  toggleShowHints: () => void;
+
+  // In-memory clipboard for copy/paste (Ctrl+C / Ctrl+V). Not persisted.
+  clipboard: Map<string, Block> | null;
+  copySelection: () => void;
+  paste: () => void;
+
   // Photo export — transient flag consumed by ScreenshotCapture inside <Canvas>.
   photoRequest: boolean;
   requestPhoto: () => void;
@@ -445,6 +456,29 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
   freeBuild: false,
   toggleFreeBuild: () => set((s) => ({ freeBuild: !s.freeBuild })),
+
+  showGrid: true,
+  showHints: true,
+  toggleShowGrid: () => set((s) => ({ showGrid: !s.showGrid })),
+  toggleShowHints: () => set((s) => ({ showHints: !s.showHints })),
+
+  clipboard: null,
+  copySelection: () => {
+    const s = get();
+    if (s.selectedKeys.size === 0) return;
+    const cb = new Map<string, Block>();
+    for (const key of s.selectedKeys) {
+      const b = s.blocks.get(key);
+      if (b) cb.set(key, b);
+    }
+    if (cb.size === 0) return;
+    set({ clipboard: cb });
+  },
+  paste: () => {
+    const s = get();
+    if (!s.clipboard || s.clipboard.size === 0) return;
+    s.insertBlocks(s.clipboard);
+  },
 
   photoRequest: false,
   requestPhoto: () => set({ photoRequest: true }),


### PR DESCRIPTION
## Summary

- Adds globally-active shortcuts: **Tab** (toggle mode), **1/2/3/4** (iso X/Y/Z + 3D with re-center), **.** (focus selection), **T** (fit to scene), **G/H** (toggle grid / hint bar), **Ctrl+C/V** (copy/paste via existing \`insertBlocks\`), **Ctrl+S** (export .dae), **?** (show shortcut list).
- Unifies the three keybinding popups (hint-bar "Customize", Settings → Edit keybindings, and \`?\`) into one \`KeybindEditor\` with a new read-only **General** tab listing the hardcoded globals, alongside the existing Drag/Drop and Keyboard Build tabs.
- Adds \`showGrid\` / \`showHints\` state and a \`clipboard\` to \`blockStore\`.

## Test plan

- [ ] Verify each global shortcut: Tab, 1/2/3/4, ., T, G, H, ?, Ctrl+C, Ctrl+V, Ctrl+S
- [ ] Confirm \`?\` and Settings → Edit keybindings and hint-bar Customize all open the same \`KeybindEditor\`
- [ ] Confirm General tab is read-only and the Drag/Drop and Keyboard Build tabs still rebind keys and persist to localStorage
- [ ] Copy a multi-block selection, paste, confirm it's offset and selected (undo returns scene to prior state)
- [ ] Ctrl+S triggers the same .dae download as the Export toolbar button

🤖 Generated with [Claude Code](https://claude.com/claude-code)