### PR TITLE
Per-workspace ports so multiple Conductor workspaces can run the GUI concurrently

### DIFF
--- a/.claude/skills/open-gui/SKILL.md
+++ b/.claude/skills/open-gui/SKILL.md
@@ -4,131 +4,22 @@ description: |
   Start the piper-draw dev server (Vite frontend + FastAPI backend) and open
   the GUI in the default browser. Use when the user says "open the gui",
   "open the website", "launch the app", "start the dev server", or similar.
-  Handles Node version selection via nvm (if present), dependency install,
-  and port cleanup. Cross-platform (macOS / Linux, arm64 / x64).
+  Uses per-workspace ports so multiple Conductor workspaces run side by side.
 ---
 
 # /open-gui — Launch the piper-draw GUI
 
-Start both dev servers (Vite on :5173, uvicorn on :8000) and open the frontend
-in a browser.
-
-## Step 0: Locate the gui directory
-
-Every subsequent step runs from this dir. Never hardcode absolute paths —
-derive from git so the skill works for every contributor.
+Run the helper script and print its final line. One bash call, no follow-ups.
 
 ```bash
-GUI_DIR="$(git rev-parse --show-toplevel)/piper_draw/gui"
-cd "$GUI_DIR"
+.claude/skills/open-gui/start.sh
 ```
 
-If `git rev-parse` fails, the user is outside the repo — tell them to `cd`
-into the piper-draw checkout and re-run.
+The script handles everything: derives per-workspace ports, short-circuits if
+the server is already up, sources nvm for Node 22, backgrounds `make dev`,
+waits for Vite, and opens the browser. On success it prints one line like:
 
-## Step 1: Check if it's already running
+    started in 4s  frontend=http://localhost:5245/  backend=http://127.0.0.1:8072  log=/tmp/open-gui-manama.log
 
-```bash
-if curl -sf http://localhost:5173/ >/dev/null 2>&1; then
-  echo "ALREADY_RUNNING"
-else
-  echo "NEEDS_START"
-fi
-```
-
-If `ALREADY_RUNNING`, skip to Step 5.
-
-## Step 2: Ensure Node 22+ is active
-
-The frontend toolchain requires Node >=22 (`camera-controls@3.x`,
-`rolldown`). With `engine-strict=true` in `.npmrc`, `npm install` hard-fails
-on older versions.
-
-Try nvm first, fall back to the system Node:
-
-```bash
-if [ -s "$HOME/.nvm/nvm.sh" ]; then
-  source "$HOME/.nvm/nvm.sh"
-  # Honor the repo's .nvmrc (pinned to 22)
-  nvm use >/dev/null 2>&1 || nvm use 22 >/dev/null 2>&1 || true
-fi
-node --version
-```
-
-If the active Node is <22, stop and tell the user:
-
-> This project needs Node >=22. You have `$(node --version)`. Install Node 22:
-> - nvm: `nvm install 22 && nvm use 22`
-> - brew (macOS): `brew install node@22 && brew link --overwrite node@22`
-> - apt (Linux): follow https://github.com/nodesource/distributions
-
-## Step 3: Install frontend deps if missing or stale
-
-The rolldown native binary is platform-specific. Detect by glob (works on
-darwin-arm64, darwin-x64, linux-x64, linux-arm64) instead of a fixed name.
-
-```bash
-needs_install=0
-if [ ! -d node_modules ]; then
-  needs_install=1
-elif ! ls node_modules/@rolldown/binding-* >/dev/null 2>&1; then
-  # Deps installed under a Node version that skipped the native binary
-  needs_install=1
-fi
-
-if [ "$needs_install" = 1 ]; then
-  echo "Installing frontend deps on $(node --version)..."
-  rm -rf node_modules
-  npm ci || npm install
-else
-  echo "Deps OK"
-fi
-```
-
-Prefer `npm ci` when the lockfile is present so the install matches the
-committed tree exactly; fall back to `npm install` only if `npm ci` rejects
-(e.g. missing lockfile).
-
-## Step 4: Clear stale processes and start dev server
-
-```bash
-# Portable lsof kill (the -r flag on xargs is GNU-only)
-for port in 5173 8000; do
-  pids=$(lsof -ti:$port 2>/dev/null || true)
-  [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
-done
-```
-
-Start the dev server with the Bash tool using `run_in_background: true`:
-
-```bash
-cd "$(git rev-parse --show-toplevel)/piper_draw/gui"
-[ -s "$HOME/.nvm/nvm.sh" ] && source "$HOME/.nvm/nvm.sh" && nvm use >/dev/null 2>&1
-npm run dev
-```
-
-Wait ~10 seconds, then read the background task output file and confirm
-both lines appear:
-- `VITE v... ready` (frontend)
-- `Uvicorn running on http://127.0.0.1:8000` (backend)
-
-If either is missing, read the full output, report the error, and stop.
-
-## Step 5: Open the browser
-
-Pick the right command for the platform:
-
-```bash
-case "$(uname)" in
-  Darwin) open http://localhost:5173/ ;;
-  Linux)  xdg-open http://localhost:5173/ >/dev/null 2>&1 || \
-          echo "Open http://localhost:5173/ manually" ;;
-  *)      echo "Open http://localhost:5173/ manually" ;;
-esac
-```
-
-Tell the user:
-- Frontend: http://localhost:5173/
-- Backend: http://127.0.0.1:8000
-- Dev server runs in the background with hot reload. Kill it with
-  `lsof -ti:5173,8000 | xargs kill` when done.
+On failure it prints a tail of the log and exits non-zero — relay that to
+the user unchanged.

--- a/.claude/skills/open-gui/start.sh
+++ b/.claude/skills/open-gui/start.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Launch piper-draw dev servers on per-workspace ports, then open the GUI.
+# Fast path: if already running, just open the browser.
+# Cold path: source nvm, background `make dev`, poll, open.
+
+set -u
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "error: not in a git repo — cd into the piper-draw checkout and retry" >&2
+  exit 2
+}
+WS="$(basename "$ROOT")"
+OFFSET=$(( $(printf '%s' "$WS" | cksum | awk '{print $1}') % 100 ))
+VITE_PORT=$((5173 + OFFSET))
+BACKEND_PORT=$((8000 + OFFSET))
+URL="http://localhost:$VITE_PORT/"
+
+open_url() {
+  case "$(uname)" in
+    Darwin) open "$URL" 2>/dev/null || true ;;
+    Linux)  xdg-open "$URL" >/dev/null 2>&1 || echo "open $URL manually" ;;
+    *)      echo "open $URL manually" ;;
+  esac
+}
+
+# Fast path
+if curl -sf "$URL" >/dev/null 2>&1; then
+  open_url
+  echo "already running  frontend=$URL  backend=http://127.0.0.1:$BACKEND_PORT"
+  exit 0
+fi
+
+# Cold path: source nvm from gui/ (where .nvmrc lives), then make dev in the bg.
+cd "$ROOT/gui"
+if [ -s "$HOME/.nvm/nvm.sh" ]; then
+  # shellcheck disable=SC1091
+  . "$HOME/.nvm/nvm.sh"
+  nvm use >/dev/null 2>&1 || true
+fi
+node_major=$(node --version 2>/dev/null | sed -E 's/^v([0-9]+).*/\1/')
+if [ -z "${node_major:-}" ] || [ "$node_major" -lt 22 ]; then
+  echo "error: need Node 22+, got $(node --version 2>/dev/null || echo none). Try: nvm install 22" >&2
+  exit 3
+fi
+
+cd "$ROOT"
+export VITE_PORT BACKEND_PORT
+LOG="/tmp/open-gui-$WS.log"
+nohup make dev >"$LOG" 2>&1 </dev/null &
+disown 2>/dev/null || true
+
+for i in $(seq 1 30); do
+  if curl -sf "$URL" >/dev/null 2>&1; then
+    open_url
+    echo "started in ${i}s  frontend=$URL  backend=http://127.0.0.1:$BACKEND_PORT  log=$LOG"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "TIMEOUT after 30s. Tail of $LOG:" >&2
+tail -30 "$LOG" >&2
+exit 1

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -34,6 +34,9 @@
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
         "vitest": "^3.2.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "concurrently \"npm run dev:frontend\" \"npm run dev:backend\"",
     "dev:frontend": "vite",
-    "dev:backend": "cd .. && uv run uvicorn server:app --reload --port 8000",
+    "dev:backend": "cd .. && uv run uvicorn server:app --reload --port ${BACKEND_PORT:-8000}",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "test": "node --require ./scripts/vitest-crypto-shim.cjs ./node_modules/vitest/vitest.mjs run --run",

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -20,8 +20,10 @@ export default defineConfig({
     },
   },
   server: {
+    port: Number(process.env.VITE_PORT ?? 5173),
+    strictPort: true,
     proxy: {
-      '/api': 'http://localhost:8000',
+      '/api': `http://localhost:${process.env.BACKEND_PORT ?? 8000}`,
     },
   },
 })


### PR DESCRIPTION
## Summary
- `gui/vite.config.ts` reads `VITE_PORT` / `BACKEND_PORT` (defaults 5173/8000, `strictPort: true`) and points the `/api` proxy at `BACKEND_PORT`. `gui/package.json`'s `dev:backend` passes `BACKEND_PORT` to uvicorn. Plain `make dev` without env still binds the old defaults.
- The `/open-gui` skill now runs a single helper `.claude/skills/open-gui/start.sh` that derives a workspace-specific port offset from the repo's basename (`cksum % 100`), fast-paths when the server is already up, backgrounds `make dev`, and opens the browser. SKILL.md shrinks from ~135 lines to ~20.
- Net result: different Conductor workspaces get different port pairs (e.g. `manama` → 5245/8072) and can run side-by-side without colliding.

## Test plan
- [ ] `make dev` in a fresh checkout still binds 5173/8000.
- [ ] `/open-gui` in two different Conductor workspaces opens two independent GUIs at different localhost ports.
- [ ] Hot path (server already up) returns in <1s; cold start completes in ~3-5s.
- [ ] Port collision (two workspace names hashing to the same offset) fails fast with EADDRINUSE rather than silently clobbering.

🧙 Built with [WOZCODE](https://wozcode.com)