### PR TITLE
feat: Fly.io deployment (Dockerfile + fly.toml + static serving)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+**/__pycache__
+**/.venv
+**/node_modules
+**/dist
+.git
+.github
+tests
+.pytest_cache
+.ruff_cache
+.gstack
+.vscode
+.context
+.claude
+*.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+# Stage 1: build the Vite/React frontend
+FROM node:22-slim AS frontend
+WORKDIR /app/gui
+COPY gui/package.json gui/package-lock.json ./
+RUN npm ci
+COPY gui/ ./
+RUN npm run build
+
+# Stage 2: Python runtime serving FastAPI + the built frontend
+FROM python:3.14-slim-bookworm
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY pyproject.toml uv.lock ./
+RUN uv sync --frozen --no-install-project --no-dev
+
+COPY server.py ./
+COPY --from=frontend /app/gui/dist ./gui/dist
+
+ENV PATH="/app/.venv/bin:$PATH"
+EXPOSE 8000
+CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,21 @@
+# Fly.io config for piper-draw.
+# Change `app` to a unique name (Fly will reject duplicates) and `primary_region`
+# to the three-letter code closest to you (e.g. ams, fra, iad, sjc).
+# See: https://fly.io/docs/reference/regions/
+
+app = "piper-draw"
+primary_region = "ams"
+
+[build]
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/server.py
+++ b/server.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import math
+from pathlib import Path
 
 from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from tqec.computation.block_graph import BlockGraph
 from tqec.utils.exceptions import TQECError
@@ -275,3 +277,8 @@ async def flows(req: FlowsRequest) -> FlowsResponse:
         outputs=outputs,
         flows=flows_out,
     )
+
+
+_DIST = Path(__file__).parent / "gui" / "dist"
+if _DIST.is_dir():
+    app.mount("/", StaticFiles(directory=_DIST, html=True), name="static")


### PR DESCRIPTION
## Summary
- Two-stage Dockerfile: Node 22 builds the Vite frontend, Python 3.14 runs FastAPI and serves the built `gui/dist/` files from the same process.
- `fly.toml` configured for single-region (ams), HTTPS, auto-stop when idle, 1GB RAM.
- `server.py` mounts `gui/dist/` as static files only when the directory exists, so `make dev` is unaffected.

## Test plan
- [ ] \`brew install flyctl && fly auth signup\`
- [ ] \`fly launch --copy-config --no-deploy\` (pick a unique app name + region)
- [ ] \`fly deploy\` — expect ~3–5 min first build (tqec + stim compile from source)
- [ ] \`fly open\` — GUI loads over HTTPS, Validate and Flows buttons hit \`/api/*\` successfully
- [ ] \`make dev\` still works locally unchanged

🧙 Built with [WOZCODE](https://wozcode.com)