### PR TITLE
feat: 3D stabilizer flow visualization (WIP)

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -998,7 +998,7 @@ export default function App() {
         <BlockInstances />
         {!photoRequest && !flowVizMode && <FoldOutCubeOverlay />}
         {!photoRequest && !flowVizMode && <InvalidBlockHighlights />}
-        {!photoRequest && !flowVizMode && <LocatePulseHighlight />}
+        {!photoRequest && <LocatePulseHighlight />}
         {!photoRequest && !flowVizMode && <SelectionHighlights />}
         {!photoRequest && !flowVizMode && <DragGhost />}
         {!photoRequest && !flowVizMode && <BuildCursor />}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -1003,7 +1003,7 @@ export default function App() {
         {!photoRequest && !flowVizMode && <DragGhost />}
         {!photoRequest && !flowVizMode && <BuildCursor />}
         {!photoRequest && !flowVizMode && <OpenPipeGhosts />}
-      {!photoRequest && !flowVizMode && (flowsPanelOpen || zxPanelOpen) && <PortLabels3D />}
+      {!photoRequest && (flowsPanelOpen || zxPanelOpen || flowVizMode) && <PortLabels3D />}
         {!photoRequest && <FlowSurfaceOverlay />}
         <CameraBuildSnap controlsRef={controlsRef} />
         <GridPlane />

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -32,6 +32,7 @@ import { FlowsPanel } from "./components/FlowsPanel";
 import { ZXPanel } from "./components/ZXPanel";
 import { PortLabels3D } from "./components/PortLabels3D";
 import { FoldOutCubeOverlay } from "./components/FoldOutCubeOverlay";
+import { FlowSurfaceOverlay } from "./components/FlowSurfaceOverlay";
 import { BuildModeHints } from "./components/BuildModeHints";
 import { EditModeHints } from "./components/EditModeHints";
 import { KeybindEditor, type KeybindEditorTab } from "./components/KeybindEditor";
@@ -472,6 +473,7 @@ export default function App() {
   const photoRequest = useBlockStore((s) => s.photoRequest);
   const flowsPanelOpen = useBlockStore((s) => s.flowsPanelOpen);
   const zxPanelOpen = useBlockStore((s) => s.zxPanelOpen);
+  const flowVizMode = useBlockStore((s) => s.flowVizMode);
   const showGrid = useBlockStore((s) => s.showGrid);
   const showHints = useBlockStore((s) => s.showHints);
 
@@ -994,18 +996,19 @@ export default function App() {
         <ambientLight intensity={1.4} />
         <directionalLight position={[10, 10, 10]} intensity={1.0} />
         <BlockInstances />
-        {!photoRequest && <FoldOutCubeOverlay />}
-        {!photoRequest && <InvalidBlockHighlights />}
-        {!photoRequest && <LocatePulseHighlight />}
-        {!photoRequest && <SelectionHighlights />}
-        {!photoRequest && <DragGhost />}
-        {!photoRequest && <BuildCursor />}
-        {!photoRequest && <OpenPipeGhosts />}
-      {!photoRequest && (flowsPanelOpen || zxPanelOpen) && <PortLabels3D />}
+        {!photoRequest && !flowVizMode && <FoldOutCubeOverlay />}
+        {!photoRequest && !flowVizMode && <InvalidBlockHighlights />}
+        {!photoRequest && !flowVizMode && <LocatePulseHighlight />}
+        {!photoRequest && !flowVizMode && <SelectionHighlights />}
+        {!photoRequest && !flowVizMode && <DragGhost />}
+        {!photoRequest && !flowVizMode && <BuildCursor />}
+        {!photoRequest && !flowVizMode && <OpenPipeGhosts />}
+      {!photoRequest && !flowVizMode && (flowsPanelOpen || zxPanelOpen) && <PortLabels3D />}
+        {!photoRequest && <FlowSurfaceOverlay />}
         <CameraBuildSnap controlsRef={controlsRef} />
         <GridPlane />
-        {!photoRequest && <GhostBlock />}
-        {!photoRequest && <PasteGhost />}
+        {!photoRequest && !flowVizMode && <GhostBlock />}
+        {!photoRequest && !flowVizMode && <PasteGhost />}
         <AxisLabels />
         <FpsSampler targetRef={fpsRef} />
         {!photoRequest && showGrid && <CheckerboardGrid />}

--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -389,6 +389,7 @@ export function BlockInstances() {
   const blocks = useBlockStore((s) => s.blocks);
   const hiddenFaces = useBlockStore((s) => s.hiddenFaces);
   const viewMode = useBlockStore((s) => s.viewMode);
+  const flowVizMode = useBlockStore((s) => s.flowVizMode);
 
   const grouped = useMemo(() => {
     type Group = {
@@ -400,7 +401,9 @@ export function BlockInstances() {
     const map = new Map<string, Group>();
     for (const block of blocks.values()) {
       const hf = hiddenFaces.get(posKey(block.pos)) ?? 0;
-      const dimmed = viewMode.kind === "iso" && !posInActiveSlice(viewMode, block.pos);
+      const dimmed =
+        flowVizMode ||
+        (viewMode.kind === "iso" && !posInActiveSlice(viewMode, block.pos));
       const key = `${block.type}:${hf}:${dimmed ? 1 : 0}`;
       const existing = map.get(key);
       if (existing) {
@@ -415,7 +418,7 @@ export function BlockInstances() {
       }
     }
     return map;
-  }, [blocks, hiddenFaces, viewMode]);
+  }, [blocks, hiddenFaces, viewMode, flowVizMode]);
 
   return (
     <>

--- a/gui/src/components/FlowSurfaceOverlay.tsx
+++ b/gui/src/components/FlowSurfaceOverlay.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useMemo } from "react";
+import * as THREE from "three";
+import { useBlockStore } from "../stores/blockStore";
+
+const X_COLOR = new THREE.Color("#ff7f7f");
+const Z_COLOR = new THREE.Color("#7396ff");
+
+/**
+ * Renders the selected correlation surface's pieces as colored quads in 3D.
+ * Surface vertices arrive from the backend already in Three.js world coords
+ * (see `_quad_vertices_three` in server.py). Returns null unless flow viz
+ * mode is on and a flow is selected.
+ */
+export function FlowSurfaceOverlay() {
+  const flowVizMode = useBlockStore((s) => s.flowVizMode);
+  const flows = useBlockStore((s) => s.flows);
+  const selectedFlowIndex = useBlockStore((s) => s.selectedFlowIndex);
+
+  const flow =
+    flowVizMode && selectedFlowIndex !== null && selectedFlowIndex >= 0
+      ? flows[selectedFlowIndex] ?? null
+      : null;
+
+  // One BufferGeometry per basis (X, Z), aggregating every quad of that basis
+  // into a single mesh. Two triangles per quad: 0-1-2 and 0-2-3.
+  const geometries = useMemo(() => {
+    if (!flow) return null;
+    const perBasis: Record<"X" | "Z", { positions: number[]; indices: number[] }> = {
+      X: { positions: [], indices: [] },
+      Z: { positions: [], indices: [] },
+    };
+    for (const piece of flow.surfaces) {
+      const b = piece.basis === "X" ? "X" : "Z";
+      const bucket = perBasis[b];
+      const baseVert = bucket.positions.length / 3;
+      bucket.positions.push(...piece.vertices);
+      bucket.indices.push(
+        baseVert, baseVert + 1, baseVert + 2,
+        baseVert, baseVert + 2, baseVert + 3,
+      );
+    }
+    const build = (data: { positions: number[]; indices: number[] }) => {
+      if (data.positions.length === 0) return null;
+      const g = new THREE.BufferGeometry();
+      g.setAttribute("position", new THREE.Float32BufferAttribute(data.positions, 3));
+      g.setIndex(data.indices);
+      g.computeVertexNormals();
+      return g;
+    };
+    return { X: build(perBasis.X), Z: build(perBasis.Z) };
+  }, [flow]);
+
+  // Dispose the geometries when they are replaced (new flow selected) or the
+  // overlay unmounts. Skipping this would leak GPU buffers on every selection.
+  useEffect(() => {
+    return () => {
+      geometries?.X?.dispose();
+      geometries?.Z?.dispose();
+    };
+  }, [geometries]);
+
+  if (!geometries) return null;
+
+  return (
+    <>
+      {geometries.X && (
+        <mesh geometry={geometries.X}>
+          <meshBasicMaterial color={X_COLOR} side={THREE.DoubleSide} />
+        </mesh>
+      )}
+      {geometries.Z && (
+        <mesh geometry={geometries.Z}>
+          <meshBasicMaterial color={Z_COLOR} side={THREE.DoubleSide} />
+        </mesh>
+      )}
+    </>
+  );
+}

--- a/gui/src/components/FlowsPanel.tsx
+++ b/gui/src/components/FlowsPanel.tsx
@@ -123,6 +123,11 @@ export function FlowsPanel({
   const portPositions = useBlockStore((s) => s.portPositions);
   const setFlowsPanelOpen = useBlockStore((s) => s.setFlowsPanelOpen);
   const ensurePortLabels = useBlockStore((s) => s.ensurePortLabels);
+  const setFlowsStore = useBlockStore((s) => s.setFlows);
+  const setSelectedFlowIndex = useBlockStore((s) => s.setSelectedFlowIndex);
+  const setFlowVizMode = useBlockStore((s) => s.setFlowVizMode);
+  const flowVizMode = useBlockStore((s) => s.flowVizMode);
+  const selectedFlowIndex = useBlockStore((s) => s.selectedFlowIndex);
 
   const [result, setResult] = useState<FlowsResult | null>(null);
   const [loading, setLoading] = useState(false);
@@ -201,10 +206,20 @@ export function FlowsPanel({
     const s = useBlockStore.getState();
     const res = await computeFlows(s.blocks, s.portMeta);
     setResult(res);
-    setComputedSig(signature(s.blocks, s.portMeta));
+    const sig = signature(s.blocks, s.portMeta);
+    setComputedSig(sig);
     setQueries([]);
     setLoading(false);
-  }, [ensurePortLabels]);
+    // Publish to store so the 3D overlay can read surfaces by index.
+    if (res.ok) setFlowsStore(res.flows, sig);
+    else setFlowsStore([], sig);
+  }, [ensurePortLabels, setFlowsStore]);
+
+  // When the diagram changes after a compute, auto-exit flow viz mode so the
+  // overlay doesn't display surfaces that no longer match the scene.
+  useEffect(() => {
+    if (stale && flowVizMode) setFlowVizMode(false);
+  }, [stale, flowVizMode, setFlowVizMode]);
 
   const generatorSpan = useMemo(() => {
     if (!result || !result.ok) return null;
@@ -327,6 +342,31 @@ export function FlowsPanel({
             }}
           >
             {loading ? "Computing…" : "Compute"}
+          </button>
+          <button
+            onClick={() => setFlowVizMode(!flowVizMode)}
+            disabled={!result?.ok || result.flows.length === 0 || stale}
+            title={
+              flowVizMode
+                ? "Hide correlation surfaces in 3D"
+                : "Show the selected flow's correlation surfaces in 3D"
+            }
+            style={{
+              padding: "4px 10px",
+              fontSize: 12,
+              borderRadius: 4,
+              border: `1px solid ${flowVizMode ? "#4a9eff" : "#888"}`,
+              background: flowVizMode ? "#4a9eff" : "#fff",
+              color: flowVizMode ? "#fff" : "#333",
+              cursor:
+                !result?.ok || result.flows.length === 0 || stale
+                  ? "default"
+                  : "pointer",
+              opacity:
+                !result?.ok || result.flows.length === 0 || stale ? 0.5 : 1,
+            }}
+          >
+            View in 3D
           </button>
           <button
             onClick={() => setFlowsPanelOpen(false)}
@@ -465,27 +505,42 @@ export function FlowsPanel({
                   </tr>
                 </thead>
                 <tbody>
-                  {result.flows.map((flow, i) => (
-                    <tr key={i}>
-                      {result.inputs.map((label) => (
-                        <td
-                          key={`in-${label}`}
-                          style={{ padding: "3px 6px", textAlign: "center" }}
-                        >
-                          <PauliCell pauli={flow.inputs[label] ?? "I"} />
-                        </td>
-                      ))}
-                      <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                      {result.outputs.map((label) => (
-                        <td
-                          key={`out-${label}`}
-                          style={{ padding: "3px 6px", textAlign: "center" }}
-                        >
-                          <PauliCell pauli={flow.outputs[label] ?? "I"} />
-                        </td>
-                      ))}
-                    </tr>
-                  ))}
+                  {result.flows.map((flow, i) => {
+                    const isActive = flowVizMode && selectedFlowIndex === i;
+                    return (
+                      <tr
+                        key={i}
+                        onClick={() => {
+                          if (!result.ok || stale) return;
+                          setSelectedFlowIndex(i);
+                          if (!flowVizMode) setFlowVizMode(true);
+                        }}
+                        style={{
+                          cursor: result.ok && !stale ? "pointer" : "default",
+                          background: isActive ? "#e0efff" : undefined,
+                          outline: isActive ? "2px solid #4a9eff" : undefined,
+                        }}
+                      >
+                        {result.inputs.map((label) => (
+                          <td
+                            key={`in-${label}`}
+                            style={{ padding: "3px 6px", textAlign: "center" }}
+                          >
+                            <PauliCell pauli={flow.inputs[label] ?? "I"} />
+                          </td>
+                        ))}
+                        <td style={{ padding: "0 4px", color: "#888" }}>→</td>
+                        {result.outputs.map((label) => (
+                          <td
+                            key={`out-${label}`}
+                            style={{ padding: "3px 6px", textAlign: "center" }}
+                          >
+                            <PauliCell pauli={flow.outputs[label] ?? "I"} />
+                          </td>
+                        ))}
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
 import { useKeybindStore } from "./keybindStore";
+import type { Flow } from "../utils/flows";
 import type {
   Position3D, Block, BlockType, CubeType, PipeVariant, PipeType, SpatialIndex, FaceMask,
   BuildDirection, UndeterminedCubeInfo, ViewMode, IsoAxis, PortMeta, PortIO,
@@ -189,6 +190,15 @@ interface BlockStore {
   /** Whether the right-docked ZX-diagram panel is visible. */
   zxPanelOpen: boolean;
 
+  /** Last-computed flows (with surface geometry), published by FlowsPanel. */
+  flows: Flow[];
+  /** Signature of the diagram when `flows` was last computed; used to detect stale data. */
+  flowsSignature: string | null;
+  /** Row selected in FlowsPanel (index into `flows`), shown in 3D when flowVizMode is on. */
+  selectedFlowIndex: number | null;
+  /** When on, dim blocks and render only the selected flow's correlation surfaces. */
+  flowVizMode: boolean;
+
   // Drag-selection state (live during a drag of the current selection)
   isDraggingSelection: boolean;
   dragDelta: Position3D | null;
@@ -283,6 +293,11 @@ interface BlockStore {
   setPortIO: (pos: Position3D, io: PortIO) => void;
   setFlowsPanelOpen: (open: boolean) => void;
   toggleFlowsPanel: () => void;
+
+  /** Publish computed flows (with surface geometry) for the 3D overlay to read. */
+  setFlows: (flows: Flow[], signature: string) => void;
+  setSelectedFlowIndex: (index: number | null) => void;
+  setFlowVizMode: (on: boolean) => void;
   setZXPanelOpen: (open: boolean) => void;
   toggleZXPanel: () => void;
   setDragState: (s: { isDragging: boolean; delta: Position3D | null; valid: boolean }) => void;
@@ -557,6 +572,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   portMeta: new Map(),
   flowsPanelOpen: false,
   zxPanelOpen: false,
+  flows: [],
+  flowsSignature: null,
+  selectedFlowIndex: null,
+  flowVizMode: false,
   selectionPivot: null,
   clipboard: null,
 
@@ -3264,6 +3283,15 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
   setFlowsPanelOpen: (open) => set({ flowsPanelOpen: open }),
   toggleFlowsPanel: () => set((s) => ({ flowsPanelOpen: !s.flowsPanelOpen })),
+
+  setFlows: (flows, signature) =>
+    set({
+      flows,
+      flowsSignature: signature,
+      selectedFlowIndex: flows.length > 0 ? 0 : null,
+    }),
+  setSelectedFlowIndex: (index) => set({ selectedFlowIndex: index }),
+  setFlowVizMode: (on) => set({ flowVizMode: on }),
 
   setZXPanelOpen: (open) => set({ zxPanelOpen: open }),
   toggleZXPanel: () => set((s) => ({ zxPanelOpen: !s.zxPanelOpen })),

--- a/gui/src/utils/flows.ts
+++ b/gui/src/utils/flows.ts
@@ -1,8 +1,15 @@
 import type { Block, Position3D, PortMeta } from "../types";
 
+export interface SurfacePiece {
+  basis: "X" | "Z";
+  // 4 quad corners in Three.js world coords, flattened [x0,y0,z0,...,x3,y3,z3]
+  vertices: number[];
+}
+
 export interface Flow {
   inputs: Record<string, string>;
   outputs: Record<string, string>;
+  surfaces: SurfacePiece[];
 }
 
 export interface FlowsResult {

--- a/server.py
+++ b/server.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 import math
 from pathlib import Path
 
+import numpy as np
 import pyzx
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from tqec.computation.block_graph import BlockGraph
+# `_correlation` is a private TQEC module but it's the only public surface
+# that exposes correlation-surface geometry pieces (unit quads with transforms)
+# needed to render flow surfaces in 3D. Pinned via git dep in pyproject.toml.
+from tqec.interop.collada._correlation import CorrelationSurfaceTransformationHelper
 from tqec.utils.exceptions import TQECError
 
 app = FastAPI()
@@ -72,9 +77,16 @@ class FlowsRequest(BaseModel):
     port_io: dict[str, str] = {}
 
 
+class SurfacePiece(BaseModel):
+    basis: str  # "X" or "Z"
+    # 4 quad corners in Three.js world coords, flattened as [x0,y0,z0,...,x3,y3,z3]
+    vertices: list[float]
+
+
 class Flow(BaseModel):
     inputs: dict[str, str]
     outputs: dict[str, str]
+    surfaces: list[SurfacePiece] = []
 
 
 class FlowsResponse(BaseModel):
@@ -270,6 +282,39 @@ def _tqec_to_piper_pos(tqec_pos: tuple[int, int, int]) -> list[float]:
     return [float(c * 3) for c in tqec_pos]
 
 
+# Basis change from TQEC (X spatial, Y spatial, Z temporal) to Three.js
+# (X, Y up, Z out-of-screen). Piper-draw's frontend uses TQEC-X→Three-X,
+# TQEC-Y→Three-(-Z), TQEC-Z→Three-Y; see `tqecToThree` in gui/src/types/index.ts.
+_TQEC_TO_THREE = np.array(
+    [
+        [1, 0, 0],
+        [0, 0, 1],
+        [0, -1, 0],
+    ],
+    dtype=np.float32,
+)
+
+
+def _quad_vertices_three(basis: str, trans) -> list[float]:  # type: ignore[no-untyped-def]
+    """Compute the 4 corner vertices of a correlation-surface quad in Three.js world coords.
+
+    TQEC's helper returns a transform (translation, rotation, scale) that maps a
+    unit XY-plane quad (corners at (0,0,0), (1,0,0), (1,1,0), (0,1,0)) to the
+    piece's world position in TQEC coords. We apply the transform to the four
+    corners, then change basis to Three.js.
+    """
+    corners = np.array(
+        [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0]],
+        dtype=np.float32,
+    )
+    # Scale then rotate then translate, matching the collada convention.
+    scaled = corners * trans.scale
+    rotated = scaled @ trans.rotation.T
+    world_tqec = rotated + trans.translation
+    world_three = world_tqec @ _TQEC_TO_THREE.T
+    return world_three.flatten().tolist()
+
+
 def convert_blocks(
     blocks: list[BlockInput],
     port_labels: dict[str, str] | None = None,
@@ -419,14 +464,24 @@ async def flows(req: FlowsRequest) -> FlowsResponse:
             error=f"find_correlation_surfaces failed: {e}",
         )
 
+    # `pipe_length=2.0` makes the helper's output positions land on piper-draw's
+    # 3-unit grid (cube=1 + pipe=2 per TQEC unit step).
+    helper = CorrelationSurfaceTransformationHelper(graph, pipe_length=2.0)
+
     flows_out: list[Flow] = []
     for surface in surfaces:
         pauli = surface.external_stabilizer_on_graph(graph)
         per_port = dict(zip(ordered_ports, pauli))
+        pieces = helper.get_transformations_for_correlation_surface(surface)
+        surface_out = [
+            SurfacePiece(basis=basis.value, vertices=_quad_vertices_three(basis.value, trans))
+            for basis, trans in pieces
+        ]
         flows_out.append(
             Flow(
                 inputs={p: per_port[p] for p in inputs},
                 outputs={p: per_port[p] for p in outputs},
+                surfaces=surface_out,
             )
         )
 

--- a/server.py
+++ b/server.py
@@ -11,11 +11,12 @@ from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from tqec.computation.block_graph import BlockGraph
+from tqec.interop.collada._correlation import CorrelationSurfaceTransformationHelper
+from tqec.utils.exceptions import TQECError
+
 # `_correlation` is a private TQEC module but it's the only public surface
 # that exposes correlation-surface geometry pieces (unit quads with transforms)
 # needed to render flow surfaces in 3D. Pinned via git dep in pyproject.toml.
-from tqec.interop.collada._correlation import CorrelationSurfaceTransformationHelper
-from tqec.utils.exceptions import TQECError
 
 app = FastAPI()
 


### PR DESCRIPTION
## Summary
- New **View in 3D** toggle on the Stabilizer Flows panel. Clicking a flow row selects it and renders its correlation surfaces as colored planes (red=X, blue=Z) inside the diagram — similar to TQEC's Collada tutorial.
- Backend: \`/api/flows\` now returns per-flow surface geometry (pre-transformed quad vertices in Three.js world coords) by reusing TQEC's \`CorrelationSurfaceTransformationHelper\` with \`pipe_length=2.0\`. No new endpoint.
- Frontend: new \`FlowSurfaceOverlay\` component; blocks dim to ~18% opacity in viz mode (reuses the existing \`dimmed\` path); ghosts/cursors/fold-out/port-labels are hidden while active. Viz mode auto-exits on any diagram edit.

## Status: WIP — do not merge
Opened as a draft for early review. Known gaps:
- Only manually tested with a memory experiment (XZX cube + two XZO pipes). Wider lattice-surgery shapes (CNOT, T-factories, Hadamard flows) not yet exercised.
- Relies on TQEC's private \`_correlation\` module; needs a pinned-version check or upstream stabilization before merging.
- No automated test for the surface geometry serialization path.

## Test plan
- [ ] Place an XZX cube with two XZO pipes ending in open ports; compute flows; toggle **View in 3D** → red (X) and blue (Z) planes appear.
- [ ] Click between flow rows; selection/highlight updates; surfaces swap.
- [ ] Edit the diagram → viz mode exits automatically.
- [ ] Smoke-test a Hadamard pipe → expect two adjacent half-sheets meeting at the band.
- [ ] Verify \`npm run build\` and \`uv run pytest tests/\` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)