### PR TITLE
chore(fly): always-on + suspend for instant resume

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -11,9 +11,9 @@ primary_region = "ams"
 [http_service]
   internal_port = 8000
   force_https = true
-  auto_stop_machines = "stop"
+  auto_stop_machines = "suspend"
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
 
 [[vm]]
   memory = "1gb"


### PR DESCRIPTION
## Summary
- \`min_machines_running = 1\` so the Fly machine stays awake 24/7 — no cold starts.
- \`auto_stop_machines = "suspend"\` (from \`stop\`) for ~1s resume if we ever scale up and idle.

Trade-off: ~\$2-3/month for the always-on machine vs 5-10s cold start on every first hit after idle.

## Test plan
- [ ] \`fly deploy\` succeeds
- [ ] \`fly status\` shows 1 machine running
- [ ] Leave the app idle for 10+ min, hit \`https://piper-draw.walruscomputing.com\`, response is instant

🧙 Built with [WOZCODE](https://wozcode.com)