### PR TITLE
fix(flows): disable 3D view mode when stabilizer flows panel closes

### DIFF
--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -3281,8 +3281,14 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       return { portMeta: next };
     }),
 
-  setFlowsPanelOpen: (open) => set({ flowsPanelOpen: open }),
-  toggleFlowsPanel: () => set((s) => ({ flowsPanelOpen: !s.flowsPanelOpen })),
+  setFlowsPanelOpen: (open) =>
+    set(open ? { flowsPanelOpen: true } : { flowsPanelOpen: false, flowVizMode: false }),
+  toggleFlowsPanel: () =>
+    set((s) =>
+      s.flowsPanelOpen
+        ? { flowsPanelOpen: false, flowVizMode: false }
+        : { flowsPanelOpen: true },
+    ),
 
   setFlows: (flows, signature) =>
     set({


### PR DESCRIPTION
## Summary
- Closing the stabilizer flows panel (via ✕, Escape, or Toolbar toggle) now also resets `flowVizMode` to `false`, so the 3D diagram returns to normal view mode. Centralized the behavior in `setFlowsPanelOpen`/`toggleFlowsPanel` so all close paths stay in sync.

## Test plan
- [ ] Open the stabilizer flows panel, click "View in 3D", then close the panel via ✕ — diagram returns to normal mode.
- [ ] Repeat, closing via Escape key.
- [ ] Repeat, closing via the Toolbar toggle.

🧙 Built with [WOZCODE](https://wozcode.com)