### PR TITLE
Select-mode camera controls + Ctrl+Shift marquee

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -247,7 +247,7 @@ function ViewportCamera({ controlsRef }: { controlsRef: React.RefObject<any> }) 
           zoomToCursor
           maxDistance={50000}
           screenSpacePanning={false}
-          mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN }}
+          mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: -1 as THREE.MOUSE }}
         />
       </>
     );
@@ -299,7 +299,7 @@ function IsoViewport({
         maxZoom={500}
         minZoom={2}
         screenSpacePanning
-        mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: THREE.MOUSE.PAN }}
+        mouseButtons={{ LEFT: THREE.MOUSE.PAN, MIDDLE: THREE.MOUSE.DOLLY, RIGHT: -1 as THREE.MOUSE }}
       />
     </>
   );

--- a/gui/src/components/BuildModeHints.tsx
+++ b/gui/src/components/BuildModeHints.tsx
@@ -4,20 +4,13 @@ import { HintBar, CustomizeLink } from "./HintBar";
 
 export function BuildModeHints({ onCustomize }: { onCustomize: () => void }) {
   const mode = useBlockStore((s) => s.mode);
-  const viewMode = useBlockStore((s) => s.viewMode);
   const b = useKeybindStore((s) => s.bindings.build);
   const axisAbsoluteWasd = useKeybindStore((s) => s.axisAbsoluteWasd);
-  const navStyle = useKeybindStore((s) => s.navStyle);
   if (mode !== "build") return null;
 
-  const isIso = viewMode.kind === "iso";
   const moveLabel = axisAbsoluteWasd ? "Move ±X / ±Y" : "Move XY";
-  const dragRotates = !isIso && navStyle === "rotate";
   const hints: Array<readonly [string, string]> = [
     ["Click cube", "Move cursor here"],
-    ["Drag", dragRotates ? "Rotate" : "Pan"],
-    ...(isIso ? [] : [["Shift+Drag", dragRotates ? "Pan" : "Rotate"] as const]),
-    ["Scroll", "Zoom"],
     [
       `${bindingToLabel(b.moveForward)}/${bindingToLabel(b.moveLeft)}/${bindingToLabel(b.moveBack)}/${bindingToLabel(b.moveRight)}`,
       moveLabel,

--- a/gui/src/components/EditModeHints.tsx
+++ b/gui/src/components/EditModeHints.tsx
@@ -39,6 +39,7 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
     hints.push(
       ["Click", "Select"],
       ["Shift+Click", "Add/remove"],
+      ["Ctrl+Shift+Drag", "Marquee select"],
       [bindingToLabel(b.selectAll), "Select all"],
       [bindingToLabel(b.flipColors), "Flip colors"],
       [`${bindingToLabel(b.rotateCcw)}/${bindingToLabel(b.rotateCw)}`, "Rotate CCW/CW (Z)"],

--- a/gui/src/components/EditModeHints.tsx
+++ b/gui/src/components/EditModeHints.tsx
@@ -1,7 +1,6 @@
 import { useBlockStore } from "../stores/blockStore";
 import { bindingToLabel, useKeybindStore } from "../stores/keybindStore";
 import { HintBar, CustomizeLink } from "./HintBar";
-import { altKey } from "./keyLabels";
 
 export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
   const mode = useBlockStore((s) => s.mode);
@@ -10,11 +9,9 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
   const viewMode = useBlockStore((s) => s.viewMode);
   const hasSelection = useBlockStore((s) => s.selectedKeys.size > 0);
   const b = useKeybindStore((s) => s.bindings.edit);
-  const navStyle = useKeybindStore((s) => s.navStyle);
   if (mode !== "edit") return null;
 
   const isIso = viewMode.kind === "iso";
-  const dragRotates = !isIso && navStyle === "rotate";
 
   // X-held overrides the normal hint set — show the delete affordances.
   if (xHeld) {
@@ -41,12 +38,7 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
   if (armedTool === "pointer") {
     hints.push(
       ["Click", "Select"],
-      ["Drag", "Box select / Move selection"],
       ["Shift+Click", "Add/remove"],
-      ["Shift+Drag", "Add to selection"],
-      ...(isIso ? [] : [[`${altKey}Drag`, "Orbit"] as const]),
-      ["Right Drag", "Pan"],
-      ["Scroll", "Zoom"],
       [bindingToLabel(b.selectAll), "Select all"],
       [bindingToLabel(b.flipColors), "Flip colors"],
       [`${bindingToLabel(b.rotateCcw)}/${bindingToLabel(b.rotateCw)}`, "Rotate CCW/CW (Z)"],
@@ -71,13 +63,6 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
           : "Place block";
     hints.push(
       ["Click", placeLabel],
-      ["Drag", dragRotates ? "Rotate" : "Pan"],
-      ...(isIso
-        ? []
-        : dragRotates
-          ? [["Shift+Drag", "Pan"] as const]
-          : [[`${altKey}Drag`, "Rotate"] as const]),
-      ["Scroll", "Zoom"],
       [`Hold ${bindingToLabel(b.holdToDelete)}`, "Click-to-delete"],
       [bindingToLabel(b.clearSelection), "Disarm (→ pointer)"],
     );

--- a/gui/src/components/HelpPanel.tsx
+++ b/gui/src/components/HelpPanel.tsx
@@ -85,6 +85,16 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
           .
         </p>
 
+        <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Tips</h4>
+        <ul style={{ margin: 0, paddingLeft: 18 }}>
+          <li>Use <b>Undo</b>/<b>Redo</b> or Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z.</li>
+          <li>
+            <b>Camera</b> — scroll to zoom, <kbd>Opt</kbd>/<kbd>Alt</kbd>+drag
+            to rotate, drag to pan. Use the <b>Iso ▾</b> menu in the toolbar
+            to snap to an axis-locked orthographic view.
+          </li>
+        </ul>
+
         <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Modes</h4>
         <ul style={{ margin: 0, paddingLeft: 18 }}>
           <li>
@@ -99,13 +109,11 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
           </li>
         </ul>
 
-        <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Tips</h4>
+        <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Features</h4>
         <ul style={{ margin: 0, paddingLeft: 18 }}>
-          <li>Use <b>Undo</b>/<b>Redo</b> or Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z.</li>
           <li><b>Verify (tqec)</b> checks that the diagram is a valid TQEC structure via the <a href="https://github.com/tqec/tqec" target="_blank" rel="noreferrer">tqec</a> package.</li>
           <li><b>Flows (tqec)</b> computes stabilizer flows (correlation surfaces) for the diagram via the <a href="https://github.com/tqec/tqec" target="_blank" rel="noreferrer">tqec</a> package.</li>
           <li><b>Import</b>/<b>Export</b> round-trip through Collada (.dae) files.</li>
-          <li>Use the X / Y / Z view buttons or drag to rotate the camera.</li>
         </ul>
 
         <p style={{ margin: "14px 0 0", fontSize: 12, color: "#666" }}>

--- a/gui/src/components/NavControlsModifier.tsx
+++ b/gui/src/components/NavControlsModifier.tsx
@@ -9,8 +9,6 @@ export function NavControlsModifier({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   controlsRef: React.RefObject<any>;
 }) {
-  const mode = useBlockStore((s) => s.mode);
-  const armedTool = useBlockStore((s) => s.armedTool);
   const viewMode = useBlockStore((s) => s.viewMode);
   const navStyle = useKeybindStore((s) => s.navStyle);
 
@@ -22,11 +20,6 @@ export function NavControlsModifier({
     const apply = (alt: boolean) => {
       const controls = controlsRef.current;
       if (!controls || !controls.mouseButtons) return;
-      // Pointer tool takes left-drag for marquee/move; disable camera left-drag.
-      if (mode === "edit" && armedTool === "pointer") {
-        controls.mouseButtons.LEFT = THREE.MOUSE.ROTATE;
-        return;
-      }
       if (navStyle === "rotate") {
         // Drag = rotate, Shift+Drag = pan (handled by OrbitControls' built-in swap).
         controls.mouseButtons.LEFT = THREE.MOUSE.ROTATE;
@@ -62,7 +55,7 @@ export function NavControlsModifier({
       window.removeEventListener("keyup", onKeyUp);
       window.removeEventListener("blur", onBlur);
     };
-  }, [mode, armedTool, viewMode, navStyle, controlsRef]);
+  }, [viewMode, navStyle, controlsRef]);
 
   return null;
 }

--- a/gui/src/components/SelectModePointer.tsx
+++ b/gui/src/components/SelectModePointer.tsx
@@ -28,6 +28,7 @@ type Pending = {
   startY: number;
   hitBlockKey: string | null;
   shiftAtDown: boolean;
+  marqueeRequested: boolean;
 };
 
 type DraggingMarquee = {
@@ -225,6 +226,13 @@ export function SelectModePointer({
         hitKey = pickSelectedBlockAt(ts.camera, ndcX, ndcY, store.selectedKeys, store.blocks);
       }
 
+      // Ctrl+Shift forces marquee. Shift alone is reserved for select-mode
+      // gestures (vertical block drag) and must be swallowed so OrbitControls'
+      // built-in Shift-swap doesn't orbit the camera. Unmodified empty-space
+      // drags fall through to OrbitControls for the usual camera controls.
+      const marqueeRequested = e.ctrlKey && e.shiftKey;
+      if (!e.shiftKey && !hitKey) return;
+
       dragRef.current = {
         kind: "pending",
         pointerId: e.pointerId,
@@ -232,8 +240,9 @@ export function SelectModePointer({
         canvasRect,
         startX: e.clientX,
         startY: e.clientY,
-        hitBlockKey: hitKey,
-        shiftAtDown: e.shiftKey,
+        hitBlockKey: marqueeRequested ? null : hitKey,
+        shiftAtDown: e.shiftKey && !e.ctrlKey,
+        marqueeRequested,
       };
       // Lock out OrbitControls for the duration of the gesture. Without this,
       // Shift-swapping of OrbitControls' LEFT button (ROTATE↔PAN) lets the camera
@@ -300,6 +309,12 @@ export function SelectModePointer({
           useBlockStore.getState().setDragState({ isDragging: true, delta: { x: 0, y: 0, z: 0 }, valid: true });
           latestEventRef.current = { clientX: e.clientX, clientY: e.clientY, shiftKey: e.shiftKey };
           scheduleFrame();
+          return;
+        }
+
+        if (!state.marqueeRequested) {
+          // Shift-only on empty space: swallow the gesture so OrbitControls
+          // doesn't orbit. Leave in pending; pointerup will clean up.
           return;
         }
 

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -510,7 +510,7 @@ export function Toolbar({
               cursor: historyLen === 0 ? "default" : "pointer",
             }}
           >
-            ↶
+            ↩
           </button>
           <button
             onClick={redo}
@@ -524,7 +524,7 @@ export function Toolbar({
               cursor: futureLen === 0 ? "default" : "pointer",
             }}
           >
-            ↷
+            ↪
           </button>
         </div>
         <AnalyzeMenu />
@@ -559,7 +559,7 @@ export function Toolbar({
               if (mode === "build") setMode("edit");
               setArmedTool("pointer");
             }}
-            title="Select and move blocks"
+            title="Select and move blocks — Ctrl+Shift+drag for marquee select"
             style={blockBtnStyle(mode === "edit" && armedTool === "pointer")}
           >
             Select


### PR DESCRIPTION
## Summary
- Select mode now uses the standard OrbitControls camera (drag = pan/rotate per navStyle, Opt/Alt = swap, scroll = zoom). Pointer handler only intercepts on block hit (move) or Ctrl+Shift (marquee). Shift alone is swallowed so OrbitControls' built-in Shift-swap can't orbit the camera.
- Disabled right-click pan (`mouseButtons.RIGHT = -1`) on both perspective and iso viewports; trimmed drag/zoom rows from the hint bars (camera guidance now lives in the `?` help modal as a new Camera tip).
- Reordered help modal sections to Tips → Modes → Features, moved Verify/Flows/Import-Export under **Features**, updated the Iso menu reference, swapped undo/redo glyphs to macOS hook arrows (↩ / ↪), and added a "Ctrl+Shift+drag for marquee" hint to the Select tool's tooltip.

## Test plan
- [ ] In edit + pointer mode, confirm drag on empty space pans/orbits (per navStyle) and drag on a selected block moves it.
- [ ] Ctrl+Shift+drag draws the marquee rectangle and selects blocks underneath.
- [ ] Shift+drag on empty space does nothing (no orbit/pan).
- [ ] Shift+drag on a selected block still moves it vertically (z-drag).
- [ ] Right-click drag does nothing in both persp and iso viewports.
- [ ] `?` modal shows Tips → Modes → Features with the Camera tip and Iso menu reference; undo/redo buttons render as ↩ / ↪; Select tool tooltip mentions the marquee shortcut.

🧙 Built with [WOZCODE](https://wozcode.com)