### PR TITLE
feat(analytics): add Umami Cloud tracking

### DIFF
--- a/gui/index.html
+++ b/gui/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Piper Draw</title>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="c9fe90a4-6296-4b2d-b0bc-6b272b01786c"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Adds a single `<script>` tag in `gui/index.html` loading `cloud.umami.is/script.js` for page analytics.
- Cookieless, no PII, no consent banner required.
- Dashboard lives at cloud.umami.is; free tier covers 10k events/mo.

## Test plan
- [ ] Deploy to Fly; visit the site and confirm a 200 on `cloud.umami.is/script.js` plus a POST to `cloud.umami.is/api/send`.
- [ ] Confirm the visit appears in the Umami dashboard within ~1 minute.
- [ ] Verify behavior with an ad-blocker enabled (expected: requests blocked, site still works).

🧙 Built with [WOZCODE](https://wozcode.com)