### PR TITLE
fix(gui): refresh hint bar labels to match current UX (#174)

### DIFF
--- a/gui/src/components/EditModeHints.tsx
+++ b/gui/src/components/EditModeHints.tsx
@@ -42,7 +42,7 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
       ["Ctrl+Shift+Drag", "Marquee select"],
       [bindingToLabel(b.selectAll), "Select all"],
       [bindingToLabel(b.flipColors), "Flip colors"],
-      [`${bindingToLabel(b.rotateCcw)}/${bindingToLabel(b.rotateCw)}`, "Rotate CCW/CW (Z)"],
+      [bindingToLabel(b.rotateCcw), "Rotate"],
       [`Hold ${bindingToLabel(b.holdToDelete)}`, "Click-to-delete"],
       [bindingToLabel(b.deleteSelection), "Delete selected"],
       [bindingToLabel(b.clearSelection), "Clear selection"],
@@ -50,7 +50,7 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
       [bindingToLabel(b.paste), "Paste"],
     );
     if (hasSelection) {
-      hints.push(["↑/↓", "Nudge z ±3"]);
+      hints.push(["↑/↓", "Nudge z ±1"]);
     } else if (isIso) {
       hints.push([
         `${bindingToLabel(b.stepForward)}/${bindingToLabel(b.stepBack)}`,
@@ -65,7 +65,6 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
     hints.push(
       ["Click", placeLabel],
       [`Hold ${bindingToLabel(b.holdToDelete)}`, "Click-to-delete"],
-      [bindingToLabel(b.clearSelection), "Disarm (→ pointer)"],
     );
     if (isIso) {
       hints.push([

--- a/gui/src/components/HelpPanel.tsx
+++ b/gui/src/components/HelpPanel.tsx
@@ -89,7 +89,7 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
         <ul style={{ margin: 0, paddingLeft: 18 }}>
           <li>Use <b>Undo</b>/<b>Redo</b> or Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z.</li>
           <li>
-            <b>Camera</b> — scroll to zoom, <kbd>Opt</kbd>/<kbd>Alt</kbd>+drag
+            <b>Camera</b> — scroll to zoom, <kbd>Shift</kbd>/<kbd>Alt</kbd>+drag
             to rotate, drag to pan. Use the <b>Iso ▾</b> menu in the toolbar
             to snap to an axis-locked orthographic view.
           </li>


### PR DESCRIPTION
## Summary
Fixes #174. The hint bar and help modal had drifted after recent UX work:

- **Help panel** camera tip now says `Shift/Alt+drag` (was `Opt/Alt+drag`) — `Shift+drag` is the modifier the GUI promotes; `Alt` still works so it stays as the alternate.
- **Armed-tool hint bar** no longer shows the stale `Esc → Disarm (→ pointer)` chip (the tool was renamed to "select"; the issue author didn't want this shortcut advertised anyway).
- **Select-mode nudge** label reads `Nudge z ±1` (block units) instead of `±3` (raw TQEC units). Behavior unchanged.
- **Rotate chip** shortened from `R/Shift+R  Rotate CCW/CW (Z)` to `R  Rotate`. `Shift+R` is still bound; just stops taking hint-bar real estate.

## Test plan
- [ ] Open `?` help panel: camera line reads *"Shift/Alt+drag to rotate"*.
- [ ] Arm a cube/pipe/port in the toolbar: hint bar shows `Click` + `Hold X` only (no Esc chip); pressing Esc still disarms.
- [ ] Select a block: hint bar reads `↑/↓  Nudge z ±1`; arrow keys move the selection by one block.
- [ ] Select mode rotate chip reads `R  Rotate`; `R` rotates CCW, `Shift+R` still rotates CW.

🧙 Built with [WOZCODE](https://wozcode.com)