### PR TITLE
fix: undo shortcuts work in Keyboard Build mode

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -481,7 +481,6 @@ export default function App() {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (isEditableTarget(e.target)) return;
       const key = e.key.toLowerCase();
       const ctrl = e.ctrlKey || e.metaKey;
       const shift = e.shiftKey;
@@ -489,6 +488,22 @@ export default function App() {
       const store = useBlockStore.getState();
       const bindings = useKeybindStore.getState().bindings;
       const mode = store.mode;
+
+      if (isEditableTarget(e.target)) {
+        // Build-mode shortcuts (W/A/S/D/Q/Cmd+Z/...) must still fire when focus
+        // is on the coordinate inputs, otherwise typing a coord and hitting an
+        // undo shortcut silently inserts the character instead of undoing.
+        // Escape is excluded so it stays a per-input cancel (clearing the draft)
+        // rather than exiting build mode.
+        if (mode !== "build" || key === "escape") return;
+        const editAction = actionForKey(bindings.edit, key, ctrl, shift, alt);
+        const matches =
+          !!actionForKey(bindings.build, key, ctrl, shift, alt) ||
+          editAction === "undo" ||
+          editAction === "redo";
+        if (!matches) return;
+        (e.target as HTMLElement).blur();
+      }
 
       // Global shortcuts (work in both modes). Run before mode-specific bindings.
       // Ctrl/Cmd-modified globals: copy, paste, export.
@@ -640,7 +655,14 @@ export default function App() {
 
       if (mode === "build") {
         const action = actionForKey(bindings.build, key, ctrl, shift, alt);
-        if (!action) return;
+        if (!action) {
+          // Also honor the edit-mode undo/redo bindings (Cmd+Z / Cmd+Shift+Z)
+          // while in build mode — users expect Cmd+Z to undo anywhere.
+          const editAction = actionForKey(bindings.edit, key, ctrl, shift, alt);
+          if (editAction === "undo") { e.preventDefault(); store.undo(); return; }
+          if (editAction === "redo") { e.preventDefault(); store.redo(); return; }
+          return;
+        }
         e.preventDefault();
         switch (action) {
           case "moveForward":


### PR DESCRIPTION
## Summary

- Cmd+Z / Cmd+Shift+Z now undo and redo while in Keyboard Build mode by consulting the edit-mode bindings as a fallback when no build-mode binding matches.
- When a coordinate input has focus, build-mode shortcuts (W/A/S/D/Q/Cmd+Z/etc.) now blur the input and execute instead of being typed as characters; Escape is preserved as a per-input cancel.

## Test plan

- [ ] Enter Keyboard Build mode, press Cmd+Z — last step is undone.
- [ ] Focus an X/Y/Z coord input, press Q or Cmd+Z — input blurs and undo fires; digits still type normally; Enter still commits; Escape still cancels the draft without exiting build mode.

🧙 Built with [WOZCODE](https://wozcode.com)