### PR TITLE
ci: run PR checks on pull requests into main

### DIFF
--- a/.github/workflows/gui-pr-tests.yml
+++ b/.github/workflows/gui-pr-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
 
 jobs:
   gui-tests:

--- a/.github/workflows/python-pr-checks.yml
+++ b/.github/workflows/python-pr-checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
 
 jobs:
   ruff:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary
- Adds `main` to the `pull_request.branches` list for `gui-pr-tests.yml`, `python-pr-checks.yml`, and `secret-scan.yml` so lint/test/build/gitleaks run on PRs into `main`, not only into `dev`.
- Previously those checks only ran post-merge (via the push-to-main workflow), so failures were caught after the merge commit had already landed.
- Note: branch protection on `main` is not configurable on the free plan for this private repo, so these remain a soft gate (visible red checks) unless the repo is upgraded or made public.

## Test plan
- [ ] Open this PR and confirm the three PR workflows run against `dev` as before.
- [ ] On a follow-up PR targeting `main`, confirm the same workflows are triggered.

🧙 Built with [WOZCODE](https://wozcode.com)