### PR TITLE
Add PR checks on pull requests into main

### DIFF
--- a/.github/workflows/gui-pr-tests.yml
+++ b/.github/workflows/gui-pr-tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
 
 jobs:
   gui-tests:

--- a/.github/workflows/python-pr-checks.yml
+++ b/.github/workflows/python-pr-checks.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
 
 jobs:
   ruff:

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Install gitleaks
         run: |
-          GITLEAKS_VERSION=$(curl -sL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | grep '"tag_name"' | sed 's/.*"v\(.*\)".*/\1/')
+          GITLEAKS_VERSION=$(curl -sSfL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name | sed 's/^v//')
           curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar xz
           sudo mv gitleaks /usr/local/bin/
 

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -481,7 +481,6 @@ export default function App() {
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
-      if (isEditableTarget(e.target)) return;
       const key = e.key.toLowerCase();
       const ctrl = e.ctrlKey || e.metaKey;
       const shift = e.shiftKey;
@@ -489,6 +488,22 @@ export default function App() {
       const store = useBlockStore.getState();
       const bindings = useKeybindStore.getState().bindings;
       const mode = store.mode;
+
+      if (isEditableTarget(e.target)) {
+        // Build-mode shortcuts (W/A/S/D/Q/Cmd+Z/...) must still fire when focus
+        // is on the coordinate inputs, otherwise typing a coord and hitting an
+        // undo shortcut silently inserts the character instead of undoing.
+        // Escape is excluded so it stays a per-input cancel (clearing the draft)
+        // rather than exiting build mode.
+        if (mode !== "build" || key === "escape") return;
+        const editAction = actionForKey(bindings.edit, key, ctrl, shift, alt);
+        const matches =
+          !!actionForKey(bindings.build, key, ctrl, shift, alt) ||
+          editAction === "undo" ||
+          editAction === "redo";
+        if (!matches) return;
+        (e.target as HTMLElement).blur();
+      }
 
       // Global shortcuts (work in both modes). Run before mode-specific bindings.
       // Ctrl/Cmd-modified globals: copy, paste, export.
@@ -640,7 +655,14 @@ export default function App() {
 
       if (mode === "build") {
         const action = actionForKey(bindings.build, key, ctrl, shift, alt);
-        if (!action) return;
+        if (!action) {
+          // Also honor the edit-mode undo/redo bindings (Cmd+Z / Cmd+Shift+Z)
+          // while in build mode — users expect Cmd+Z to undo anywhere.
+          const editAction = actionForKey(bindings.edit, key, ctrl, shift, alt);
+          if (editAction === "undo") { e.preventDefault(); store.undo(); return; }
+          if (editAction === "redo") { e.preventDefault(); store.redo(); return; }
+          return;
+        }
         e.preventDefault();
         switch (action) {
           case "moveForward":


### PR DESCRIPTION
## Summary
Promotes the changes currently on `dev` into `main`:

- **CI:** run PR checks (ruff, pytest, gui-tests, gitleaks) on pull requests targeting `main` in addition to `dev` (#199).
- **Fix:** undo / redo shortcuts (Cmd+Z, Cmd+Shift+Z) now fire in Keyboard Build mode even when a coordinate input has focus (#197).
- **CI fix:** parse the gitleaks release tag with `jq` instead of `grep`+`sed` — the single-line GitHub API JSON broke the previous extraction and made the install step fail.

## Test plan
- [ ] `ruff` check passes
- [ ] `pytest` check passes
- [ ] `gui-tests` check passes
- [ ] `gitleaks` check passes (was failing before the jq fix)