### PR TITLE
fix: iso-mode build UX — slice auto-advance, camera follow, preview/hint consistency

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -45,7 +45,7 @@ import {
   type KeyBinding,
 } from "./stores/keybindStore";
 import { useValidationStore } from "./stores/validationStore";
-import { wasdToBuildDirection, tqecToThree, posKey, blockTqecSize, type Block, type ViewMode } from "./types";
+import { wasdToBuildDirection, tqecToThree, posKey, blockTqecSize, type Block, type IsoAxis, type ViewMode } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 import { downloadPng } from "./utils/photoExport";
@@ -55,6 +55,7 @@ import {
   ISO_INITIAL_ZOOM,
   isoBuildDirection,
   isoCameraThree,
+  isoCameraOffset,
   isoGridMeshTransform,
   isoTargetThree,
   isoUpThree,
@@ -264,16 +265,33 @@ function IsoViewport({
   controlsRef: React.RefObject<any>;
 }) {
   const cameraRef = useRef<THREE.OrthographicCamera>(null);
+  const prevAxisRef = useRef<IsoAxis | null>(null);
 
   // Position the orthographic camera + orbit target whenever the iso slice/axis changes.
+  // On axis change: full reset (centers view at origin in-plane).
+  // On slice-only change: preserve in-plane target (respects user pan and
+  // cursor-follow pans), only update the depth component.
   useEffect(() => {
     const cam = cameraRef.current;
     const ctrl = controlsRef.current;
     if (!cam) return;
-    const target = isoTargetThree(viewMode);
-    const pos = isoCameraThree(viewMode);
+    const axisChanged = prevAxisRef.current !== viewMode.axis;
+    prevAxisRef.current = viewMode.axis;
+
+    const isoTarget = isoTargetThree(viewMode);
+    let target: THREE.Vector3;
+    if (axisChanged || !ctrl) {
+      target = isoTarget;
+    } else {
+      // Keep in-plane (x/y/z components other than the depth axis); only the
+      // depth component comes from isoTargetThree.
+      target = ctrl.target.clone();
+      if (viewMode.axis === "x") target.x = isoTarget.x;
+      else if (viewMode.axis === "y") target.z = isoTarget.z;
+      else target.y = isoTarget.y;
+    }
     cam.up.copy(isoUpThree(viewMode.axis));
-    cam.position.copy(pos);
+    cam.position.copy(target.clone().add(isoCameraOffset(viewMode.axis)));
     cam.lookAt(target);
     cam.updateProjectionMatrix();
     if (ctrl) {
@@ -307,10 +325,9 @@ function IsoViewport({
 
 /**
  * Snaps the camera to the build direction target when cameraSnapTarget changes.
- * In perspective mode, animates camera + orbit target. In iso mode, the camera
- * is locked to the active slice — instead of moving the camera, advance the
- * slice when the cursor moves along the depth axis (the IsoViewport effect
- * then re-positions the ortho camera to follow).
+ * In perspective mode, animates camera + orbit target. In iso mode, pans the
+ * orbit target in-plane (the slice auto-advance is handled atomically in
+ * buildMove, so the camera just needs to follow the cursor's in-plane position).
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> }) {
@@ -318,7 +335,6 @@ function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> })
   const lastBuildAxis = useBlockStore((s) => s.lastBuildAxis);
   const clearCameraSnap = useBlockStore((s) => s.clearCameraSnap);
   const viewMode = useBlockStore((s) => s.viewMode);
-  const stepSlice = useBlockStore((s) => s.stepSlice);
   const { camera } = useThree();
   const prevTarget = useRef<{ azimuth: number | null; targetPos: { x: number; y: number; z: number } } | null>(null);
   const prevBuildAxis = useRef<number | null>(null);
@@ -329,11 +345,19 @@ function CameraBuildSnap({ controlsRef }: { controlsRef: React.RefObject<any> })
     prevTarget.current = cameraSnapTarget;
 
     if (viewMode.kind === "iso") {
-      const target = cameraSnapTarget.targetPos;
-      const cursorDepth =
-        viewMode.axis === "x" ? target.x : viewMode.axis === "y" ? target.y : target.z;
-      const delta = cursorDepth - viewMode.slice;
-      if (delta !== 0) stepSlice(delta);
+      const controls = controlsRef.current;
+      const [tx, ty, tz] = tqecToThree(cameraSnapTarget.targetPos, "XZZ");
+      // Preserve the depth component from isoTargetThree — the camera stays on
+      // the active slice plane; only the in-plane target moves to follow cursor.
+      const isoTarget = isoTargetThree(viewMode);
+      const axis = viewMode.axis;
+      const endTarget = new THREE.Vector3(
+        axis === "x" ? isoTarget.x : tx,
+        axis === "z" ? isoTarget.y : ty,   // iso-z depth = Three y
+        axis === "y" ? isoTarget.z : tz,   // iso-y depth = Three z
+      );
+      const offset = new THREE.Vector3().subVectors(camera.position, controls.target);
+      animateCamera(controls, endTarget, endTarget.clone().add(offset));
       clearCameraSnap();
       return;
     }

--- a/gui/src/components/BuildModeHints.tsx
+++ b/gui/src/components/BuildModeHints.tsx
@@ -4,18 +4,30 @@ import { HintBar, CustomizeLink } from "./HintBar";
 
 export function BuildModeHints({ onCustomize }: { onCustomize: () => void }) {
   const mode = useBlockStore((s) => s.mode);
+  const viewMode = useBlockStore((s) => s.viewMode);
   const b = useKeybindStore((s) => s.bindings.build);
   const axisAbsoluteWasd = useKeybindStore((s) => s.axisAbsoluteWasd);
   if (mode !== "build") return null;
 
-  const moveLabel = axisAbsoluteWasd ? "Move ±X / ±Y" : "Move XY";
+  // Iso mode uses axis-absolute WASD per the active slice plane; persp mode
+  // follows the axisAbsoluteWasd toggle (camera-relative vs world-aligned).
+  let moveLabel: string;
+  let depthLabel: string;
+  if (viewMode.kind === "iso") {
+    if (viewMode.axis === "x") { moveLabel = "Move YZ"; depthLabel = "Move X"; }
+    else if (viewMode.axis === "y") { moveLabel = "Move XZ"; depthLabel = "Move Y"; }
+    else { moveLabel = "Move XY"; depthLabel = "Move Z"; }
+  } else {
+    moveLabel = axisAbsoluteWasd ? "Move ±X / ±Y" : "Move XY";
+    depthLabel = "Move Z";
+  }
   const hints: Array<readonly [string, string]> = [
     ["Click cube", "Move cursor here"],
     [
       `${bindingToLabel(b.moveForward)}/${bindingToLabel(b.moveLeft)}/${bindingToLabel(b.moveBack)}/${bindingToLabel(b.moveRight)}`,
       moveLabel,
     ],
-    [`${bindingToLabel(b.moveUp)}/${bindingToLabel(b.moveDown)}`, "Move Z"],
+    [`${bindingToLabel(b.moveUp)}/${bindingToLabel(b.moveDown)}`, depthLabel],
     [bindingToLabel(b.cycleBlock), "Cycle block"],
     [bindingToLabel(b.cyclePipe), "Cycle pipe"],
     [bindingToLabel(b.exitBuild), "Exit build"],

--- a/gui/src/components/PreviewRenderer.tsx
+++ b/gui/src/components/PreviewRenderer.tsx
@@ -23,9 +23,10 @@ import type { ThreeAxis } from "../utils/isoFoldOut";
  * the `Port` entry (a plain ghost cube — no per-face colours, so iso fold-out
  * variants reuse the same ghost preview).
  *
- * `isoZBlockType` (pipes only) overrides `blockType` in iso-z mode so that
- * the preview shows a horizontal pipe (lying in the xy plane) as seen from
- * above, matching how the pipe will actually be placed in that mode.
+ * `isoZBlockType` (pipes only) overrides `blockType` in iso-z mode. The default
+ * `blockType` is the Z-axis pipe which points into the screen in iso-z (invisible),
+ * so we substitute the Y-axis pipe — an in-plane pipe rendered vertically on
+ * screen, matching the vertical orientation shown in iso-x / iso-y.
  */
 const PREVIEW_TYPES: { key: string; blockType: BlockType | null; isoZBlockType?: BlockType }[] = [
   { key: "Port", blockType: null },
@@ -34,7 +35,7 @@ const PREVIEW_TYPES: { key: string; blockType: BlockType | null; isoZBlockType?:
   ...(["ZX", "XZ", "ZXH", "XZH"] as PipeVariant[]).map((v) => ({
     key: v,
     blockType: VARIANT_AXIS_MAP[v][2] as BlockType,
-    isoZBlockType: VARIANT_AXIS_MAP[v][0] as BlockType,
+    isoZBlockType: VARIANT_AXIS_MAP[v][1] as BlockType,
   })),
 ];
 

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -2466,6 +2466,21 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           }
         : {};
 
+    // Slice auto-advance in iso mode: if the build cursor crosses the depth
+    // axis, move the visible slice with it so the freshly built cell stays
+    // on-screen. Independent of cameraFollowsBuild — without this, building
+    // along the depth axis is invisible.
+    const sliceUpdate: { viewMode?: ViewMode; lastIsoSlice?: { x: number; y: number; z: number } } = (() => {
+      if (state.viewMode.kind !== "iso") return {};
+      const axis = state.viewMode.axis;
+      const destDepth = axis === "x" ? destPos.x : axis === "y" ? destPos.y : destPos.z;
+      if (destDepth === state.viewMode.slice) return {};
+      return {
+        viewMode: { ...state.viewMode, slice: destDepth },
+        lastIsoSlice: { ...state.lastIsoSlice, [axis]: destDepth },
+      };
+    })();
+
     const reject = (reason?: string) => {
       if (reason) set({ hoveredInvalidReason: reason });
       return false;
@@ -2481,6 +2496,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       set({
         buildCursor: destPos,
         ...snapUpdate,
+        ...sliceUpdate,
         hoveredInvalidReason: null,
       });
       return true;
@@ -2760,6 +2776,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         undeterminedCubes: newUndetermined,
         portPositions: nextPortPositions,
         ...snapUpdate,
+        ...sliceUpdate,
         history: [...s.history, { kind: "build-step" as const, step }].slice(-MAX_HISTORY),
         future: [],
         hoveredInvalidReason: null,
@@ -2861,6 +2878,20 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         newUndetermined.delete(step.originCube.key);
       }
 
+      // Iso: mirror buildMove's slice auto-advance so undo moves the visible
+      // slice back with the cursor (otherwise the reverted cursor is off-slab).
+      const sliceUpdate: { viewMode?: ViewMode; lastIsoSlice?: { x: number; y: number; z: number } } = (() => {
+        if (s.viewMode.kind !== "iso") return {};
+        const axis = s.viewMode.axis;
+        const p = step.prevCursorPos;
+        const destDepth = axis === "x" ? p.x : axis === "y" ? p.y : p.z;
+        if (destDepth === s.viewMode.slice) return {};
+        return {
+          viewMode: { ...s.viewMode, slice: destDepth },
+          lastIsoSlice: { ...s.lastIsoSlice, [axis]: destDepth },
+        };
+      })();
+
       // Also pop from general undo history if the last command is a matching build-step
       const newHistory = [...s.history];
       if (newHistory.length > 0 && newHistory[newHistory.length - 1].kind === "build-step") {
@@ -2874,6 +2905,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           portPositions: nextPortPositions,
           cameraSnapTarget: { azimuth: null, targetPos: step.prevCursorPos },
           lastBuildAxis: null,
+          ...sliceUpdate,
           history: newHistory,
           future: [cmd, ...s.future].slice(0, MAX_HISTORY),
           hoveredGridPos: null,
@@ -2889,6 +2921,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         portPositions: nextPortPositions,
         cameraSnapTarget: { azimuth: null, targetPos: step.prevCursorPos },
         lastBuildAxis: null,
+        ...sliceUpdate,
         hoveredGridPos: null,
       };
     });

--- a/gui/src/utils/isoView.ts
+++ b/gui/src/utils/isoView.ts
@@ -19,7 +19,7 @@ export function isoCameraThree(viewMode: IsoMode): THREE.Vector3 {
   return isoTargetThree(viewMode).add(isoCameraOffset(viewMode.axis));
 }
 
-function isoCameraOffset(axis: IsoAxis): THREE.Vector3 {
+export function isoCameraOffset(axis: IsoAxis): THREE.Vector3 {
   if (axis === "x") return new THREE.Vector3(ISO_DISTANCE, 0, 0);
   if (axis === "y") return new THREE.Vector3(0, 0, ISO_DISTANCE);
   return new THREE.Vector3(0, ISO_DISTANCE, 0);


### PR DESCRIPTION
## Summary
- Slice auto-advances atomically with the build cursor along the depth axis in iso mode, independent of the camera-follow toggle — depth-axis builds now stay on-screen.
- "Camera follows build cursor" now actually pans the iso orbit target in-plane (via the existing `animateCamera` helper, no rotation).
- `IsoViewport` preserves in-plane pans across slice-only changes so user pans and cursor-follow pans aren't clobbered on every slice step.
- Pipe toolbar previews render vertically in iso-z (Y-axis variant) for visual parity with iso-x / iso-y; build-mode WASD/arrow hints now show the correct plane per iso axis (e.g. "Move YZ" / "Move X" in iso-x).

## Test plan
- [ ] Enter each iso view (1/2/3). Pipe previews are vertical in all three.
- [ ] In Build mode, hint bar shows the correct plane per iso axis (YZ/X, XZ/Y, XY/Z).
- [ ] With "Camera follows build cursor" **off**, press ArrowUp in iso-z — slice advances and the new cube is visible.
- [ ] With the setting **on**, press W/A/S/D — the camera smoothly pans to keep the cursor centered (no rotation).
- [ ] Manually pan the view in iso-z, then press ArrowUp — in-plane pan is preserved, only depth moves. Switching axis (1→2) does a full reset.
- [ ] Regression: perspective-mode build follow, `.` recenter, `t` fit-view, and `4` return-to-persp still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)