### PR TITLE
feat: arm Port tool on fresh start and after Clear All

### DIFF
--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -555,7 +555,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   history: [],
   future: [],
   mode: "edit",
-  armedTool: "cube",
+  armedTool: "port",
   xHeld: false,
   cubeType: "XZZ",
   pipeVariant: null,
@@ -2045,6 +2045,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         portPositions: new Set<string>(),
         selectionPivot: null,
         undeterminedCubes: new Map(),
+        armedTool: "port",
+        pipeVariant: null,
       };
     }),
 


### PR DESCRIPTION
## Summary
- On initial app load, the toolbar now arms the Port tool instead of the XZZ cube.
- `clearAll` also resets `armedTool` to `"port"` (and clears `pipeVariant`) so a Clear All returns to the same fresh-start state.

## Test plan
- [ ] Reload the app — Port button is highlighted in the toolbar, clicking the canvas places a port.
- [ ] Place some blocks, then Clear All — Port is re-armed and ready to place.
- [ ] Selecting a cube/pipe tool after Clear All still works normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)