### PR TITLE
Marquee-select ports and sweep orphaned markers on pipe delete

### DIFF
--- a/gui/src/components/SelectModePointer.tsx
+++ b/gui/src/components/SelectModePointer.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
-import { getBlockKeysInScreenRect } from "../utils/projection";
+import { getBlockKeysInScreenRect, getPortKeysInScreenRect } from "../utils/projection";
 import { pointerGroundPoint } from "../utils/groundPlane";
 import { isMoveValid } from "../utils/dragValidate";
 import { isEditableTarget } from "../utils/editableFocus";
-import { blockThreeSize, tqecToThree, yBlockZOffset } from "../types";
+import { blockThreeSize, getAllPortPositions, tqecToThree, yBlockZOffset } from "../types";
 import type { Block, Position3D } from "../types";
 
 /** Minimum drag distance (px) before a gesture commits to marquee or drag. */
@@ -391,7 +391,8 @@ export function SelectModePointer({
           x2: Math.max(e.clientX, state.startX) - canvasRect.left,
           y2: Math.max(e.clientY, state.startY) - canvasRect.top,
         };
-        const blocks = useBlockStore.getState().blocks;
+        const store = useBlockStore.getState();
+        const blocks = store.blocks;
         const keys = getBlockKeysInScreenRect(
           blocks,
           ts.camera,
@@ -399,7 +400,14 @@ export function SelectModePointer({
           canvasRect.height,
           screenRect,
         );
-        useBlockStore.getState().selectBlocks(keys, e.shiftKey);
+        const portKeys = getPortKeysInScreenRect(
+          getAllPortPositions(blocks, store.portPositions),
+          ts.camera,
+          canvasRect.width,
+          canvasRect.height,
+          screenRect,
+        );
+        store.selectBlocks(keys, e.shiftKey, portKeys);
         return;
       }
 

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -370,6 +370,63 @@ describe("blockStore", () => {
       useBlockStore.getState().undo();
       expect(useBlockStore.getState().blocks.size).toBe(3);
     });
+
+    it("removes a user-placed port marker left orphaned by deleting its only pipe", () => {
+      useBlockStore.getState().addPortAt({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(true);
+      useBlockStore.setState({ selectedKeys: new Set(["1,0,0"]) });
+      useBlockStore.getState().deleteSelected();
+      expect(useBlockStore.getState().blocks.size).toBe(0);
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(false);
+    });
+
+    it("keeps a user-placed port marker if a cube still occupies its slot", () => {
+      // Two colinear pipes share endpoint 0,0,0 → auto-promoted to a cube there.
+      const incoming = new Map<string, Block>([
+        ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: "OZX" }],
+        ["-2,0,0", { pos: { x: -2, y: 0, z: 0 }, type: "OZX" }],
+      ]);
+      useBlockStore.getState().loadBlocks(incoming);
+      // Record explicit port intent at the cube slot (user placed it there earlier).
+      useBlockStore.setState({ portPositions: new Set(["0,0,0"]) });
+      // Deleting one pipe leaves the cube (cubes don't auto-demote) — marker survives.
+      useBlockStore.setState({ selectedKeys: new Set(["1,0,0"]) });
+      useBlockStore.getState().deleteSelected();
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(true);
+    });
+
+    it("undo of port-orphan cleanup restores both pipe and marker", () => {
+      useBlockStore.getState().addPortAt({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.setState({ selectedKeys: new Set(["1,0,0"]) });
+      useBlockStore.getState().deleteSelected();
+      useBlockStore.getState().undo();
+      expect(useBlockStore.getState().blocks.has("1,0,0")).toBe(true);
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(true);
+    });
+  });
+
+  describe("removeBlock port cleanup", () => {
+    it("removes a user-placed port marker left orphaned when its pipe is removed", () => {
+      useBlockStore.getState().addPortAt({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().removeBlock({ x: 1, y: 0, z: 0 });
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(false);
+    });
+
+    it("undo restores the user-placed port marker cleaned up by pipe removal", () => {
+      useBlockStore.getState().addPortAt({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().removeBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().undo();
+      expect(useBlockStore.getState().blocks.has("1,0,0")).toBe(true);
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(true);
+    });
   });
 
   describe("convertBlockToPort", () => {

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -284,7 +284,7 @@ interface BlockStore {
   flipSelected: () => void;
   rotateSelected: (direction: "cw" | "ccw", pivotOverride?: Position3D | null) => { ok: true } | { ok: false; reason: string };
   selectAll: () => void;
-  selectBlocks: (keys: string[], additive: boolean) => void;
+  selectBlocks: (keys: string[], additive: boolean, portKeys?: string[]) => void;
   togglePortSelection: (pos: Position3D, additive: boolean) => void;
   clearPortSelection: () => void;
   /** Allocate fresh `P1`, `P2`, ... labels for any port position missing an entry. Idempotent. */
@@ -443,6 +443,45 @@ function syncPortsAndPromote(
   }
 
   return { blocks: curBlocks, hiddenFaces: curHidden, addedEntries, promotedPortKeys };
+}
+
+/**
+ * User-placed port markers that sit at the dangling endpoint of a pipe lose
+ * their only reason to exist when that pipe is removed — an auto-inferred
+ * port ghost made them visually redundant before, and now neither anchors
+ * them. Collects the keys of such orphaned markers so callers can drop them
+ * as part of the same undo step as the pipe removal.
+ *
+ * `blocksAfter` must reflect the state *after* the pipes are removed so we
+ * don't falsely skip a port whose only remaining pipe just got deleted.
+ */
+function orphanedPortKeysFromRemovedPipes(
+  removedPipes: Array<{ pos: Position3D; type: PipeType }>,
+  blocksAfter: Map<string, Block>,
+  portPositions: Set<string>,
+): string[] {
+  const result: string[] = [];
+  const seen = new Set<string>();
+  for (const pipe of removedPipes) {
+    const base = pipe.type.replace("H", "");
+    const openAxis = base.indexOf("O");
+    const coords: [number, number, number] = [pipe.pos.x, pipe.pos.y, pipe.pos.z];
+    for (const offset of [-1, 2]) {
+      const n: [number, number, number] = [coords[0], coords[1], coords[2]];
+      n[openAxis] += offset;
+      const epPos: Position3D = { x: n[0], y: n[1], z: n[2] };
+      const key = posKey(epPos);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      if (!portPositions.has(key)) continue;
+      // Another cube occupies the slot — the port marker is still meaningful.
+      if (blocksAfter.has(key)) continue;
+      // Other pipes still anchor a port here.
+      if (countAttachedPipes(epPos, blocksAfter) > 0) continue;
+      result.push(key);
+    }
+  }
+  return result;
 }
 
 /**
@@ -1145,12 +1184,36 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
       if (cascadeKeys.length === 0) {
         const { blocks, hiddenFaces } = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, block);
-        const cmd: UndoCommand = { kind: "remove", key, block };
         const newUndetermined = new Map(state.undeterminedCubes);
         newUndetermined.delete(key);
+        const removedPipes = isPipeType(block.type)
+          ? [{ pos: block.pos, type: block.type as PipeType }]
+          : [];
+        const orphanedPortKeys = removedPipes.length > 0
+          ? orphanedPortKeysFromRemovedPipes(removedPipes, blocks, state.portPositions)
+          : [];
+        if (orphanedPortKeys.length === 0) {
+          const cmd: UndoCommand = { kind: "remove", key, block };
+          return {
+            blocks,
+            hiddenFaces,
+            history: [...state.history, cmd].slice(-MAX_HISTORY),
+            future: [],
+            hoveredGridPos: null,
+            undeterminedCubes: newUndetermined,
+          };
+        }
+        const portPositions = new Set(state.portPositions);
+        for (const k of orphanedPortKeys) portPositions.delete(k);
+        const cmd: UndoCommand = {
+          kind: "bulk-remove",
+          entries: [{ key, block }],
+          portKeys: orphanedPortKeys,
+        };
         return {
           blocks,
           hiddenFaces,
+          portPositions,
           history: [...state.history, cmd].slice(-MAX_HISTORY),
           future: [],
           hoveredGridPos: null,
@@ -1159,6 +1222,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       }
 
       const entries: Array<{ key: string; block: Block }> = [{ key, block }];
+      const removedPipes: Array<{ pos: Position3D; type: PipeType }> = isPipeType(block.type)
+        ? [{ pos: block.pos, type: block.type as PipeType }]
+        : [];
       let blocks = state.blocks;
       let hiddenFaces = state.hiddenFaces;
       ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, key, block));
@@ -1168,13 +1234,25 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         const cb = blocks.get(ck);
         if (!cb) continue;
         entries.push({ key: ck, block: cb });
+        if (isPipeType(cb.type)) removedPipes.push({ pos: cb.pos, type: cb.type as PipeType });
         ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, ck, cb));
         newUndetermined.delete(ck);
       }
-      const cmd: UndoCommand = { kind: "bulk-remove", entries };
+      const orphanedPortKeys = orphanedPortKeysFromRemovedPipes(removedPipes, blocks, state.portPositions);
+      let portPositions = state.portPositions;
+      if (orphanedPortKeys.length > 0) {
+        portPositions = new Set(state.portPositions);
+        for (const k of orphanedPortKeys) portPositions.delete(k);
+      }
+      const cmd: UndoCommand = {
+        kind: "bulk-remove",
+        entries,
+        ...(orphanedPortKeys.length > 0 ? { portKeys: orphanedPortKeys } : {}),
+      };
       return {
         blocks,
         hiddenFaces,
+        portPositions,
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
         hoveredGridPos: null,
@@ -2101,6 +2179,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     set((state) => {
       if (state.selectedKeys.size === 0 && state.selectedPortPositions.size === 0) return state;
       const entries: Array<{ key: string; block: Block }> = [];
+      const removedPipes: Array<{ pos: Position3D; type: PipeType }> = [];
       const seen = new Set<string>();
       let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
       for (const key of state.selectedKeys) {
@@ -2113,6 +2192,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           ? getAttachedPipeKeys(block.pos, blocks)
           : [];
         entries.push({ key, block });
+        if (isPipeType(block.type)) removedPipes.push({ pos: block.pos, type: block.type as PipeType });
         seen.add(key);
         ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, key, block));
         for (const ck of cascadeKeys) {
@@ -2120,17 +2200,30 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const cb = blocks.get(ck);
           if (!cb) continue;
           entries.push({ key: ck, block: cb });
+          if (isPipeType(cb.type)) removedPipes.push({ pos: cb.pos, type: cb.type as PipeType });
           seen.add(ck);
           ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, ck, cb));
         }
       }
       const portKeys: string[] = [];
+      const portKeysSet = new Set<string>();
       let portPositions = state.portPositions;
       for (const key of state.selectedPortPositions) {
         if (!portPositions.has(key)) continue;
         if (portKeys.length === 0) portPositions = new Set(portPositions);
         (portPositions as Set<string>).delete(key);
         portKeys.push(key);
+        portKeysSet.add(key);
+      }
+      if (removedPipes.length > 0) {
+        const orphaned = orphanedPortKeysFromRemovedPipes(removedPipes, blocks, portPositions);
+        for (const k of orphaned) {
+          if (portKeysSet.has(k)) continue;
+          if (portKeys.length === 0) portPositions = new Set(portPositions);
+          (portPositions as Set<string>).delete(k);
+          portKeys.push(k);
+          portKeysSet.add(k);
+        }
       }
       if (entries.length === 0 && portKeys.length === 0) return state;
       const cmd: UndoCommand = { kind: "bulk-remove", entries, ...(portKeys.length > 0 ? { portKeys } : {}) };
@@ -2339,13 +2432,17 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       return { selectedKeys: new Set(state.blocks.keys()), selectionPivot: null };
     }),
 
-  selectBlocks: (keys, additive) =>
+  selectBlocks: (keys, additive, portKeys) =>
     set((state) => {
       const next = additive ? new Set(state.selectedKeys) : new Set<string>();
       for (const key of keys) {
         if (state.blocks.has(key)) next.add(key);
       }
-      return { selectedKeys: next, selectionPivot: null };
+      const nextPorts = additive ? new Set(state.selectedPortPositions) : new Set<string>();
+      if (portKeys) {
+        for (const pk of portKeys) nextPorts.add(pk);
+      }
+      return { selectedKeys: next, selectedPortPositions: nextPorts, selectionPivot: null };
     }),
 
   setDragState: ({ isDragging, delta, valid }) =>

--- a/gui/src/utils/projection.ts
+++ b/gui/src/utils/projection.ts
@@ -1,6 +1,6 @@
 import * as THREE from "three";
-import type { Block } from "../types";
-import { tqecToThree, yBlockZOffset } from "../types";
+import type { Block, Position3D } from "../types";
+import { posKey, tqecToThree, yBlockZOffset } from "../types";
 
 const _vec3 = new THREE.Vector3();
 
@@ -33,6 +33,38 @@ export function getBlockKeysInScreenRect(
     const sy = ((1 - _vec3.y) / 2) * canvasHeight;
     if (sx >= minX && sx <= maxX && sy >= minY && sy <= maxY) {
       result.push(key);
+    }
+  }
+  return result;
+}
+
+/**
+ * Returns the position keys of all ports (user-placed markers and auto-inferred
+ * open pipe endpoints) whose projected center falls inside the given rectangle.
+ * Ports are rendered as 1×1×1 ghost cubes, so the default tqecToThree center applies.
+ */
+export function getPortKeysInScreenRect(
+  positions: Position3D[],
+  camera: THREE.Camera,
+  canvasWidth: number,
+  canvasHeight: number,
+  rect: { x1: number; y1: number; x2: number; y2: number },
+): string[] {
+  const minX = Math.min(rect.x1, rect.x2);
+  const maxX = Math.max(rect.x1, rect.x2);
+  const minY = Math.min(rect.y1, rect.y2);
+  const maxY = Math.max(rect.y1, rect.y2);
+
+  const result: string[] = [];
+  for (const pos of positions) {
+    const [tx, ty, tz] = tqecToThree(pos);
+    _vec3.set(tx, ty, tz);
+    _vec3.project(camera);
+    if (_vec3.z > 1) continue;
+    const sx = ((_vec3.x + 1) / 2) * canvasWidth;
+    const sy = ((1 - _vec3.y) / 2) * canvasHeight;
+    if (sx >= minX && sx <= maxX && sy >= minY && sy <= maxY) {
+      result.push(posKey(pos));
     }
   }
   return result;


### PR DESCRIPTION
## Summary
- Extends marquee selection in edit mode to include port ghosts (user-placed markers and auto-inferred open pipe endpoints) so they can be selected alongside cubes and pipes.
- When a pipe is removed (via `removeBlock`, junction-cube cascade, or `deleteSelected`), user-placed port markers at its endpoints are swept if nothing else anchors them — so the original port and the auto-spawned one at the other end vanish together.
- Marker removals ride the pipe's `bulk-remove` undo step, so undo restores both the pipe and the marker.

## Test plan
- [x] `npm run build` (tsc + vite) passes
- [x] `npm test` — 280 tests pass, including 5 new ones covering orphan cleanup and undo
- [ ] Manually: place port + attached pipe, marquee-select the pipe, delete — both disappear; undo restores both
- [ ] Manually: marquee-drag over a cluster of ports — all highlight/select
- [ ] Manually: delete just the explicit port of a pipe-attached port — auto-port ghost reappears at the pipe's open end

🤖 Generated with [Claude Code](https://claude.com/claude-code)