### PR TITLE
fix: Shift+drag rotates camera in Select mode; W/S for z-nudge (#202)

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -771,15 +771,13 @@ export default function App() {
           store.redo();
           return;
         case "stepForward":
-          // Skip slice-step when the pointer tool has a selection — SelectModePointer
-          // handles ↑/↓ as a Z-nudge of the selection.
-          if (store.viewMode.kind === "iso" && !(store.armedTool === "pointer" && store.selectedKeys.size > 0)) {
+          if (store.viewMode.kind === "iso") {
             e.preventDefault();
             store.stepSlice(3);
           }
           return;
         case "stepBack":
-          if (store.viewMode.kind === "iso" && !(store.armedTool === "pointer" && store.selectedKeys.size > 0)) {
+          if (store.viewMode.kind === "iso") {
             e.preventDefault();
             store.stepSlice(-3);
           }

--- a/gui/src/components/EditModeHints.tsx
+++ b/gui/src/components/EditModeHints.tsx
@@ -50,8 +50,12 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
       [bindingToLabel(b.paste), "Paste"],
     );
     if (hasSelection) {
-      hints.push(["↑/↓", "Nudge z ±1"]);
-    } else if (isIso) {
+      hints.push([
+        `${bindingToLabel(b.nudgeUp)}/${bindingToLabel(b.nudgeDown)}`,
+        "Nudge z ±1",
+      ]);
+    }
+    if (isIso && !hasSelection) {
       hints.push([
         `${bindingToLabel(b.stepForward)}/${bindingToLabel(b.stepBack)}`,
         `Step in ${viewMode.axis.toUpperCase()} direction`,

--- a/gui/src/components/SelectModePointer.tsx
+++ b/gui/src/components/SelectModePointer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
+import { actionForKey, useKeybindStore } from "../stores/keybindStore";
 import { getBlockKeysInScreenRect, getPortKeysInScreenRect } from "../utils/projection";
 import { pointerGroundPoint } from "../utils/groundPlane";
 import { isMoveValid } from "../utils/dragValidate";
@@ -52,7 +53,7 @@ type DraggingSelection = {
   planeY: number;
   /** TQEC-space start point of the pointer projected onto the drag plane (horizontal mode). */
   startTqec: { x: number; y: number } | null;
-  /** Accumulated z-nudge from ArrowUp/ArrowDown during the gesture, in TQEC units (multiples of 3). */
+  /** Accumulated z-nudge from nudgeUp/nudgeDown during the gesture, in TQEC units (multiples of 3). */
   zOffset: number;
   lastValidDelta: Position3D;
 };
@@ -226,12 +227,11 @@ export function SelectModePointer({
         hitKey = pickSelectedBlockAt(ts.camera, ndcX, ndcY, store.selectedKeys, store.blocks);
       }
 
-      // Ctrl+Shift forces marquee. Shift alone is reserved for select-mode
-      // gestures (vertical block drag) and must be swallowed so OrbitControls'
-      // built-in Shift-swap doesn't orbit the camera. Unmodified empty-space
-      // drags fall through to OrbitControls for the usual camera controls.
+      // Ctrl+Shift forces marquee. Shift+drag on a selected block is a
+      // vertical (z) drag. Empty-space drags — with or without Shift — fall
+      // through to OrbitControls so Shift+drag rotates the camera as usual.
       const marqueeRequested = e.ctrlKey && e.shiftKey;
-      if (!e.shiftKey && !hitKey) return;
+      if (!hitKey && !marqueeRequested) return;
 
       dragRef.current = {
         kind: "pending",
@@ -309,12 +309,6 @@ export function SelectModePointer({
           useBlockStore.getState().setDragState({ isDragging: true, delta: { x: 0, y: 0, z: 0 }, valid: true });
           latestEventRef.current = { clientX: e.clientX, clientY: e.clientY, shiftKey: e.shiftKey };
           scheduleFrame();
-          return;
-        }
-
-        if (!state.marqueeRequested) {
-          // Shift-only on empty space: swallow the gesture so OrbitControls
-          // doesn't orbit. Leave in pending; pointerup will clean up.
           return;
         }
 
@@ -438,12 +432,17 @@ export function SelectModePointer({
         cancelDrag();
         return;
       }
-      if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+      const bindings = useKeybindStore.getState().bindings.edit;
+      const key = e.key.toLowerCase();
+      const ctrl = e.metaKey || e.ctrlKey;
+      const action = actionForKey(bindings, key, ctrl, e.shiftKey, e.altKey);
+      if (action !== "nudgeUp" && action !== "nudgeDown") return;
+      const dz = action === "nudgeUp" ? 3 : -3;
 
       if (state?.kind === "selection") {
         e.preventDefault();
         e.stopImmediatePropagation();
-        state.zOffset += e.key === "ArrowUp" ? 3 : -3;
+        state.zOffset += dz;
         scheduleFrame();
         return;
       }
@@ -454,7 +453,7 @@ export function SelectModePointer({
       if (store.selectedKeys.size === 0) return;
       e.preventDefault();
       e.stopImmediatePropagation();
-      store.moveSelection({ x: 0, y: 0, z: e.key === "ArrowUp" ? 3 : -3 });
+      store.moveSelection({ x: 0, y: 0, z: dz });
     },
     [cancelDrag, isSelectActive, scheduleFrame],
   );

--- a/gui/src/stores/keybindStore.ts
+++ b/gui/src/stores/keybindStore.ts
@@ -29,6 +29,8 @@ export type EditAction =
   | "redo"
   | "stepForward"
   | "stepBack"
+  | "nudgeUp"
+  | "nudgeDown"
   | "cyclePrev"
   | "cycleNext"
   | "copy"
@@ -57,7 +59,8 @@ export const ACTIONS: { [M in Mode]: readonly ActionForMode[M][] } = {
   edit: [
     "selectAll", "deleteSelection", "clearSelection", "flipColors", "holdToDelete",
     "rotateCcw", "rotateCw",
-    "undo", "redo", "stepForward", "stepBack", "cyclePrev", "cycleNext",
+    "undo", "redo", "stepForward", "stepBack", "nudgeUp", "nudgeDown",
+    "cyclePrev", "cycleNext",
     "copy", "paste",
   ],
 };
@@ -88,6 +91,8 @@ export const ACTION_LABELS: { [M in Mode]: Record<ActionForMode[M], string> } = 
     redo: "Redo",
     stepForward: "Step forward (iso)",
     stepBack: "Step back (iso)",
+    nudgeUp: "Nudge selection +z",
+    nudgeDown: "Nudge selection −z",
     cyclePrev: "Previous block / pipe",
     cycleNext: "Next block / pipe",
     copy: "Copy selection",
@@ -121,6 +126,8 @@ export const DEFAULT_BINDINGS: { [M in Mode]: Record<ActionForMode[M], KeyBindin
     redo: { key: "z", ctrl: true, shift: true },
     stepForward: { key: "arrowup" },
     stepBack: { key: "arrowdown" },
+    nudgeUp: { key: "w" },
+    nudgeDown: { key: "s" },
     cyclePrev: { key: "arrowleft" },
     cycleNext: { key: "arrowright" },
     copy: { key: "c", ctrl: true },
@@ -268,7 +275,7 @@ export const useKeybindStore = create<KeybindState>()(
     }),
     {
       name: "piper-draw-keybinds",
-      version: 12,
+      version: 13,
       migrate: () => ({ bindings: cloneDefaults() }),
       merge: (persisted, current) => {
         const p = persisted as Partial<KeybindState>;


### PR DESCRIPTION
## Summary
- Shift+drag on empty canvas in Select mode now falls through to OrbitControls so the camera rotates (matches the help-panel docs). Shift+drag on a selected block still performs a vertical z-drag, and Ctrl+Shift still marquees.
- Adds `nudgeUp`/`nudgeDown` edit keybindings (default `W`/`S`) and replaces the hardcoded `ArrowUp`/`ArrowDown` z-nudge in `SelectModePointer` so the selection nudge respects rebinds.
- Iso `stepForward`/`stepBack` (↑/↓) now always steps the slice, no longer suppressed when a selection exists.

## Test plan
- [ ] In Select mode, Shift+drag on empty space rotates the camera (default Pan nav style).
- [ ] Shift+drag on a selected block still lifts/lowers it along z.
- [ ] Ctrl+Shift+drag still draws a marquee.
- [ ] With a selection, pressing `W`/`S` nudges it ±z; mid-drag `W`/`S` adjusts the z-offset live.
- [ ] In iso mode without a selection, ↑/↓ steps the slice; in iso mode with a selection, ↑/↓ still steps the slice.
- [ ] Rebinding `nudgeUp`/`nudgeDown` in the keybind editor works.

Closes #202

🧙 Built with [WOZCODE](https://wozcode.com)