### PR TITLE
docs: update README to reflect current features (closes #210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
   <img src="assets/logo.svg" alt="piper-draw" width="640">
 </p>
 
-An open source web application for building pipe diagrams for topological error correction.
+An open source web application for building pipe diagrams for topological quantum error correction.
 
 ## About
-Piper-draw is a visual editor for TQEC block graphs. You assemble cubes and pipes with drag-and-drop, then export to Collada (`.dae`) or send the diagram to a FastAPI backend that runs [`tqec`](https://github.com/tqec/tqec) for validation and stabilizer-flow (correlation-surface) analysis.
+Piper-draw is a visual editor for [TQEC](https://github.com/tqec/tqec) block graphs. You assemble cubes and pipes on a 3D grid, then export to Collada (`.dae`) or hand the diagram to a FastAPI backend that runs [`tqec`](https://github.com/tqec/tqec) for validation, stabilizer-flow (correlation-surface) analysis, and ZX-calculus conversion.
 
 Cube and pipe naming follows the TQEC convention — see [the terminology guide](https://tqec.github.io/tqec/user_guide/terminology.html).
 
@@ -16,41 +16,47 @@ Cube and pipe naming follows the TQEC convention — see [the terminology guide]
 - [uv](https://docs.astral.sh/uv/) (or any other Python package manager)
 - Node.js and npm
 
-### Starting the webapp
+### Install
+```sh
+make install
+```
+Installs Python dependencies via `uv` and frontend dependencies via `npm`.
 
-1. Install Python dependencies:
-   ```sh
-   uv sync
-   ```
-2. Install frontend dependencies:
-   ```sh
-   cd gui
-   npm install
-   ```
+### Run the dev servers
+```sh
+make dev
+```
+Starts the Vite frontend and the FastAPI backend (`uvicorn`). Open the URL shown in the terminal (typically http://localhost:5173).
 
-### Running tests
-- `make test` runs both Python and GUI tests
-- `make test-python` / `make test-gui` run them individually
-- `make dev` starts the frontend + backend dev servers.
-This launches the Vite frontend dev server and the FastAPI backend (`uvicorn`). Open the URL shown in the terminal (typically http://localhost:5173) in your browser.
+### Other commands
+- `make test` — run Python and GUI tests
+- `make test-python` / `make test-gui` — run them individually
+- `make build` — build the GUI for production
+- `make lint` — lint the GUI
 
-- `make build` builds the production server.
-- `make lint` lint the GUI code
+## Usage
 
-### Usage
-- Assemble stack elements with drag-and-drop.
-- Export the design via the Collada **export** button to generate a `.dae` file.
-- Click **Verify (tqec)** to run server-side validation via the [tqec](https://github.com/tqec/tqec) package; any errors are shown inline on the offending cubes.
-- Click **Flows (tqec)** to compute and inspect stabilizer flows (correlation surfaces) for the current diagram via the [tqec](https://github.com/tqec/tqec) package.
-- Run the provided validation test to check lattice-surgery rules.
-- Use the **Templates** button in the toolbar to load a bundled example diagram (CNOT, CZ, move + rotation, three CNOTs, Steane encoding) and edit it as a starting point.
+Click the **?** button in the app for an in-context summary of modes, tools, and shortcuts.
 
+### Building a diagram
+Piper-draw has two interaction modes for placing blocks:
+
+- **Drag / Drop** — arm a placement tool in the toolbar (cube, pipe, or port) to click-place blocks, or switch to **Select** to pick existing blocks. Shift-click adds/removes from the selection, Ctrl+Shift-drag marquee-selects cubes, pipes, and ports. Hold the delete modifier to click-to-delete.
+- **Keyboard Build** — move a cursor with the arrow keys / WASD to extend from the last block. Cycle cube and pipe variants with `C` and `R`, undo a step with `Q`, exit with `Esc`.
+
+Use the **Iso ▾** menu in the toolbar to snap to an axis-locked orthographic view; slice stepping auto-advances through depth as you build.
+
+### Analysis
+- **Verify (tqec)** — check that the diagram is a valid TQEC block graph. Errors are highlighted inline on the offending cubes.
+- **Flows (tqec)** — compute stabilizer flows (correlation surfaces) and visualize each surface directly in 3D. Edit the Pauli basis on ports to query custom flows.
+- **ZX diagrams (tqec, pyzx)** — convert the diagram to a ZX-calculus graph, optionally simplify it, and extract the corresponding quantum circuit using [PyZX](https://github.com/zxcalc/pyzx). Export to `.qgraph`, `.qasm`, `.qc`, or `.qsim`.
+
+### Files
+- **Import** / **Export** round-trip through Collada (`.dae`) files.
+- **Templates** — load a bundled example diagram (CNOT, CZ, move + rotation, three CNOTs, Steane encoding) as a starting point, or insert one into the current scene.
 
 ### Bundled templates
-The `.dae` files served from `gui/public/templates/` are generated from
-[`tqec.gallery`](https://github.com/tqec/tqec/tree/main/src/tqec/gallery) — they
-originate from the TQEC project and are bundled here for convenience. Re-run the
-generator if TQEC is updated:
+The `.dae` files served from `gui/public/templates/` are generated from [`tqec.gallery`](https://github.com/tqec/tqec/tree/main/src/tqec/gallery) — they originate from the TQEC project and are bundled here for convenience. Re-run the generator if TQEC is updated:
 ```sh
 uv run python scripts/generate_templates.py
 ```


### PR DESCRIPTION
## Summary
- Refresh README usage section to cover Drag/Drop + Keyboard Build modes, the Select tool with marquee, Iso orthographic view, Flows with editable Pauli basis, and ZX diagram export (`.qgraph`/`.qasm`/`.qc`/`.qsim`).
- Replace stale install steps with `make install`, and point users at the in-app **?** help panel for shortcuts.

## Test plan
- [ ] Skim the rendered README on the PR page and confirm links and code blocks render correctly.

Closes #210.

🧙 Built with [WOZCODE](https://wozcode.com)