### PR TITLE
docs: add live site URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 An open source web application for building pipe diagrams for topological quantum error correction.
 
+Live at [piper-draw.walruscomputing.com](https://piper-draw.walruscomputing.com).
+
 ## About
 Piper-draw is a visual editor for [TQEC](https://github.com/tqec/tqec) block graphs. You assemble cubes and pipes on a 3D grid, then export to Collada (`.dae`) or hand the diagram to a FastAPI backend that runs [`tqec`](https://github.com/tqec/tqec) for validation, stabilizer-flow (correlation-surface) analysis, and ZX-calculus conversion.
 


### PR DESCRIPTION
## Summary
- Add a link to the live site (piper-draw.walruscomputing.com) near the top of the README.

## Test plan
- [x] Link renders correctly in rendered markdown

🧙 Built with [WOZCODE](https://wozcode.com)