### PR TITLE
fix: find free dev server ports so multiple devs can run make dev (#204)

### DIFF
--- a/gui/package.json
+++ b/gui/package.json
@@ -8,7 +8,7 @@
     "node": ">=22"
   },
   "scripts": {
-    "dev": "concurrently \"npm run dev:frontend\" \"npm run dev:backend\"",
+    "dev": "node scripts/dev.mjs",
     "dev:frontend": "vite",
     "dev:backend": "cd .. && uv run uvicorn server:app --reload --port ${BACKEND_PORT:-8000}",
     "build": "tsc -b && vite build",

--- a/gui/scripts/dev.mjs
+++ b/gui/scripts/dev.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+// Dev runner: find free ports for Vite + FastAPI, then launch concurrently.
+// Honors VITE_PORT / BACKEND_PORT as preferred starting points; if either is
+// in use we walk upward until we find a free one so multiple devs can run
+// `make dev` / `npm run dev` side by side without clashing.
+
+import net from 'node:net';
+import { spawn } from 'node:child_process';
+
+function findFreePort(start) {
+  return new Promise((resolve, reject) => {
+    const attempt = (port) => {
+      const server = net.createServer();
+      server.unref();
+      server.once('error', (err) => {
+        if (err.code === 'EADDRINUSE' && port - start < 100) {
+          attempt(port + 1);
+        } else {
+          reject(err);
+        }
+      });
+      server.listen(port, '127.0.0.1', () => {
+        const { port: bound } = server.address();
+        server.close(() => resolve(bound));
+      });
+    };
+    attempt(start);
+  });
+}
+
+const vitePref = Number(process.env.VITE_PORT ?? 5173);
+const backendPref = Number(process.env.BACKEND_PORT ?? 8000);
+
+const [vitePort, backendPort] = await Promise.all([
+  findFreePort(vitePref),
+  findFreePort(backendPref),
+]);
+
+if (vitePort !== vitePref) {
+  console.log(`[dev] frontend port ${vitePref} in use, using ${vitePort}`);
+}
+if (backendPort !== backendPref) {
+  console.log(`[dev] backend port ${backendPref} in use, using ${backendPort}`);
+}
+console.log(`[dev] frontend http://localhost:${vitePort}  backend http://localhost:${backendPort}`);
+
+const env = {
+  ...process.env,
+  VITE_PORT: String(vitePort),
+  BACKEND_PORT: String(backendPort),
+};
+
+const child = spawn(
+  'npx',
+  ['concurrently', '--kill-others-on-fail', 'npm:dev:frontend', 'npm:dev:backend'],
+  { stdio: 'inherit', env },
+);
+
+child.on('exit', (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});
+
+for (const sig of ['SIGINT', 'SIGTERM']) {
+  process.on(sig, () => child.kill(sig));
+}

--- a/gui/vite.config.ts
+++ b/gui/vite.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
   },
   server: {
     port: Number(process.env.VITE_PORT ?? 5173),
-    strictPort: true,
+    strictPort: false,
     proxy: {
       '/api': `http://localhost:${process.env.BACKEND_PORT ?? 8000}`,
     },


### PR DESCRIPTION
## Summary
- Adds `gui/scripts/dev.mjs`, a small wrapper that probes for free frontend and backend ports (starting from `VITE_PORT`/5173 and `BACKEND_PORT`/8000) and then launches `concurrently` with those ports.
- Points `npm run dev` at the wrapper and flips Vite's `strictPort` to `false`, so a second `make dev` no longer fails on an in-use port.

## Test plan
- [x] GUI test suite (`npm test`) — 284/284 passing
- [x] Start `make dev` twice — second instance reports the backend shift and Vite falls back (seen: backend 8001, frontend 5174)

Closes #204

🧙 Built with [WOZCODE](https://wozcode.com)