### PR TITLE
ci: pin Main CI pytest to Python 3.13

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-      - run: uv python install 3.14
+      - run: uv python install 3.13
       - run: uv sync
       - run: uv run pytest
 


### PR DESCRIPTION
## Summary
- Changes `uv python install 3.14` → `3.13` in `fly-deploy.yml`
- Python 3.14 has no prebuilt wheels for our scientific deps, so `uv sync` compiles from source on every run (~21 min). Tests themselves run in 6s.
- 3.13 matches `python-pr-checks.yml` and `pyproject.toml`'s `requires-python = ">=3.13"` floor
- Expected impact: Main CI + Deploy drops from ~22 min to ~2-3 min

## Test plan
- [ ] CI green on this PR
- [ ] After merge + promotion to main, observe Main CI + Deploy runtime drop

🧙 Built with [WOZCODE](https://wozcode.com)