### PR TITLE
Merge dev into main

### DIFF
--- a/.github/workflows/fly-deploy.yml
+++ b/.github/workflows/fly-deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-      - run: uv python install 3.14
+      - run: uv python install 3.13
       - run: uv sync
       - run: uv run pytest
 


### PR DESCRIPTION
## Summary
- Pin Fly deploy workflow to Python 3.13 (#219)

## Test plan
- [ ] Confirm CI green on dev
- [ ] Verify Fly deploy uses Python 3.13 after merge

🧙 Built with [WOZCODE](https://wozcode.com)