### PR TITLE
feat: Y-defect toggle (magenta cylinders along X/Z edges)

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -972,23 +972,17 @@ export default function App() {
     };
   }, []);
 
-  // Persist the Y-defect overlay toggle across sessions.
+  // Persist the Y-defect overlay toggle across sessions. Initial value is
+  // hydrated in the store factory; this effect just writes back on changes.
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem("piperDraw.showYDefects");
-      if (raw === "1") useBlockStore.getState().setShowYDefects(true);
-    } catch {
-      // private mode / unavailable — ignore
-    }
-    const unsub = useBlockStore.subscribe((state, prev) => {
+    return useBlockStore.subscribe((state, prev) => {
       if (state.showYDefects === prev.showYDefects) return;
       try {
         localStorage.setItem("piperDraw.showYDefects", state.showYDefects ? "1" : "0");
       } catch {
-        // ignore
+        // private mode / unavailable — ignore
       }
     });
-    return unsub;
   }, []);
 
   return (

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -33,6 +33,7 @@ import { ZXPanel } from "./components/ZXPanel";
 import { PortLabels3D } from "./components/PortLabels3D";
 import { FoldOutCubeOverlay } from "./components/FoldOutCubeOverlay";
 import { FlowSurfaceOverlay } from "./components/FlowSurfaceOverlay";
+import { YDefectOverlay } from "./components/YDefectOverlay";
 import { BuildModeHints } from "./components/BuildModeHints";
 import { EditModeHints } from "./components/EditModeHints";
 import { KeybindEditor, type KeybindEditorTab } from "./components/KeybindEditor";
@@ -971,6 +972,25 @@ export default function App() {
     };
   }, []);
 
+  // Persist the Y-defect overlay toggle across sessions.
+  useEffect(() => {
+    try {
+      const raw = localStorage.getItem("piperDraw.showYDefects");
+      if (raw === "1") useBlockStore.getState().setShowYDefects(true);
+    } catch {
+      // private mode / unavailable — ignore
+    }
+    const unsub = useBlockStore.subscribe((state, prev) => {
+      if (state.showYDefects === prev.showYDefects) return;
+      try {
+        localStorage.setItem("piperDraw.showYDefects", state.showYDefects ? "1" : "0");
+      } catch {
+        // ignore
+      }
+    });
+    return unsub;
+  }, []);
+
   return (
     <>
       <Toolbar
@@ -1062,6 +1082,7 @@ export default function App() {
         {!photoRequest && !flowVizMode && <OpenPipeGhosts />}
       {!photoRequest && (flowsPanelOpen || zxPanelOpen || flowVizMode) && <PortLabels3D />}
         {!photoRequest && <FlowSurfaceOverlay />}
+        {!photoRequest && <YDefectOverlay />}
         <CameraBuildSnap controlsRef={controlsRef} />
         <GridPlane />
         {!photoRequest && !flowVizMode && <GhostBlock />}

--- a/gui/src/components/PreviewRenderer.tsx
+++ b/gui/src/components/PreviewRenderer.tsx
@@ -5,7 +5,9 @@ import {
   VARIANT_AXIS_MAP,
   createBlockGeometry,
   createBlockEdges,
+  createYDefectCylinderGroup,
   blockThreeSize,
+  Y_DEFECT_HEX,
 } from "../types";
 import type { BlockType, PipeVariant, ViewMode } from "../types";
 import { useBlockStore } from "../stores/blockStore";
@@ -46,6 +48,7 @@ const HALF = 0.5;
 
 const vertexColorMaterial = new THREE.MeshBasicMaterial({ vertexColors: true, side: THREE.DoubleSide });
 const edgeMaterial = new THREE.LineBasicMaterial({ color: 0x000000 });
+const yDefectMaterial = new THREE.MeshBasicMaterial({ color: Y_DEFECT_HEX });
 /** Ghost-cube material for the PORT preview — matches OpenPipeGhosts.tsx styling. */
 const portGhostMaterial = new THREE.MeshBasicMaterial({
   color: 0xdddddd,
@@ -89,6 +92,7 @@ function variantKey(key: string, variant: Variant): string {
 type PreviewEntry = {
   obj: THREE.Object3D;
   edges: THREE.Object3D;
+  yDefects: THREE.Object3D | null;
   center: THREE.Vector3;
   radius: number;
 };
@@ -101,11 +105,14 @@ function buildRegularEntry(blockType: BlockType): PreviewEntry {
   const edgeGeo = createBlockEdges(blockType, 0, previewBandHH);
   const edges = new THREE.LineSegments(edgeGeo, edgeMaterial);
 
+  const yDefectGroup = createYDefectCylinderGroup(blockType, 0, yDefectMaterial);
+  const yDefects = yDefectGroup.children.length > 0 ? yDefectGroup : null;
+
   const [sx, sy, sz] = blockThreeSize(blockType);
   const center = new THREE.Vector3(0, 0, 0);
   const radius = Math.sqrt(sx * sx + sy * sy + sz * sz) / 2;
 
-  return { obj: mesh, edges, center, radius };
+  return { obj: mesh, edges, yDefects, center, radius };
 }
 
 function addFoldOutFace(
@@ -169,7 +176,7 @@ function buildFoldOutCubeEntry(blockType: string, topAxis: ThreeAxis): PreviewEn
 
   // After fold by π/6, max corner extends to ~1.18 from origin; pick a slightly smaller
   // radius so the camera frames the cube body comparably to the regular preview.
-  return { obj: meshGroup, edges: edgeGroup, center: new THREE.Vector3(0, 0, 0), radius: 1.05 };
+  return { obj: meshGroup, edges: edgeGroup, yDefects: null, center: new THREE.Vector3(0, 0, 0), radius: 1.05 };
 }
 
 /**
@@ -187,6 +194,7 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
   const meshesRef = useRef<Map<string, PreviewEntry>>(new Map());
   const lastQuatRef = useRef(new THREE.Quaternion());
   const lastVariantRef = useRef<Variant>("persp");
+  const lastShowYDefectsRef = useRef<boolean>(false);
   const rafRef = useRef(0);
   const lastRenderRef = useRef(0);
   const dirVec = useRef(new THREE.Vector3());
@@ -225,6 +233,7 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
         const portEntry: PreviewEntry = {
           obj: mesh,
           edges,
+          yDefects: null,
           center: new THREE.Vector3(0, 0, 0),
           radius: Math.sqrt(3) / 2,
         };
@@ -265,13 +274,17 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
       const mainCamera = controls.object as THREE.PerspectiveCamera;
       if (!mainCamera) return;
 
-      const variant = variantForViewMode(useBlockStore.getState().viewMode);
+      const storeState = useBlockStore.getState();
+      const variant = variantForViewMode(storeState.viewMode);
+      const showYDefects = storeState.showYDefects;
       const quat = mainCamera.quaternion;
       const quatChanged = lastQuatRef.current.angleTo(quat) >= 0.005;
       const variantChanged = lastVariantRef.current !== variant;
-      if (!quatChanged && !variantChanged) return;
+      const yDefectsChanged = lastShowYDefectsRef.current !== showYDefects;
+      if (!quatChanged && !variantChanged && !yDefectsChanged) return;
       lastQuatRef.current.copy(quat);
       lastVariantRef.current = variant;
+      lastShowYDefectsRef.current = showYDefects;
       lastRenderRef.current = now;
 
       const renderer = rendererRef.current!;
@@ -286,13 +299,13 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
       for (const { key } of PREVIEW_TYPES) {
         const entry = meshesRef.current.get(variantKey(key, variant))!;
 
-        // Swap preview object: remove previous, add current
-        if (scene.children.length > 2) {
-          scene.remove(scene.children[scene.children.length - 1]);
+        // Pop any previously-added preview children (lights occupy children[0..1]).
+        while (scene.children.length > 2) {
           scene.remove(scene.children[scene.children.length - 1]);
         }
         scene.add(entry.obj);
         scene.add(entry.edges);
+        if (showYDefects && entry.yDefects) scene.add(entry.yDefects);
 
         // Position camera to frame the block
         const dist = entry.radius / Math.tan((FOV * Math.PI) / 360) * 1.3;
@@ -321,6 +334,10 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
         entry.edges.traverse((node) => {
           const ls = node as THREE.LineSegments;
           if (ls.isLineSegments) ls.geometry.dispose();
+        });
+        entry.yDefects?.traverse((node) => {
+          const mesh = node as THREE.Mesh;
+          if (mesh.isMesh) mesh.geometry.dispose();
         });
       }
       meshesRef.current.clear();

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -408,6 +408,8 @@ export function Toolbar({
   const setPerspView = useBlockStore((s) => s.setPerspView);
   const setIsoView = useBlockStore((s) => s.setIsoView);
   const stepSlice = useBlockStore((s) => s.stepSlice);
+  const showYDefects = useBlockStore((s) => s.showYDefects);
+  const toggleShowYDefects = useBlockStore((s) => s.toggleShowYDefects);
 
   const previewImg = (key: string) => {
     const src = previewImages.get(key);
@@ -492,6 +494,13 @@ export function Toolbar({
         )}
         <button onClick={onResetCamera} style={btnStyle(false)} title="Recenter the camera on the origin">
           Origin
+        </button>
+        <button
+          onClick={toggleShowYDefects}
+          style={btnStyle(showYDefects)}
+          title="Highlight Y-type defects (twists) along edges where X and Z faces meet"
+        >
+          Y defects
         </button>
       </div>
 

--- a/gui/src/components/YDefectOverlay.tsx
+++ b/gui/src/components/YDefectOverlay.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from "react";
+import * as THREE from "three";
+import { useBlockStore } from "../stores/blockStore";
+import {
+  createYDefectCylinderGroup,
+  posKey,
+  tqecToThree,
+  yBlockZOffset,
+  Y_DEFECT_HEX,
+} from "../types";
+import type { BlockType, FaceMask } from "../types";
+
+const yDefectMaterial = new THREE.MeshLambertMaterial({ color: Y_DEFECT_HEX });
+
+type CylinderInstance = {
+  geometry: THREE.CylinderGeometry;
+  position: THREE.Vector3;
+  quaternion: THREE.Quaternion;
+};
+
+const templateCache = new Map<string, CylinderInstance[]>();
+
+function getCachedTemplate(blockType: BlockType, hiddenFaces: FaceMask): CylinderInstance[] {
+  const key = `${blockType}:${hiddenFaces}`;
+  let arr = templateCache.get(key);
+  if (!arr) {
+    const group = createYDefectCylinderGroup(blockType, hiddenFaces, yDefectMaterial);
+    arr = group.children.map((child) => {
+      const mesh = child as THREE.Mesh;
+      return {
+        geometry: mesh.geometry as THREE.CylinderGeometry,
+        position: mesh.position.clone(),
+        quaternion: mesh.quaternion.clone(),
+      };
+    });
+    templateCache.set(key, arr);
+  }
+  return arr;
+}
+
+export function YDefectOverlay() {
+  const blocks = useBlockStore((s) => s.blocks);
+  const hiddenFaces = useBlockStore((s) => s.hiddenFaces);
+  const showYDefects = useBlockStore((s) => s.showYDefects);
+
+  const items = useMemo(() => {
+    if (!showYDefects) return [];
+    const out: Array<{
+      key: string;
+      worldPos: [number, number, number];
+      cylinders: CylinderInstance[];
+    }> = [];
+    for (const block of blocks.values()) {
+      const k = posKey(block.pos);
+      const hf = hiddenFaces.get(k) ?? 0;
+      const cylinders = getCachedTemplate(block.type, hf);
+      if (cylinders.length === 0) continue;
+      const zo = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+      out.push({ key: k, worldPos: tqecToThree(block.pos, block.type, zo), cylinders });
+    }
+    return out;
+  }, [blocks, hiddenFaces, showYDefects]);
+
+  if (!showYDefects || items.length === 0) return null;
+
+  return (
+    <>
+      {items.map(({ key, worldPos, cylinders }) => (
+        <group key={key} position={worldPos}>
+          {cylinders.map((c, i) => (
+            <mesh
+              key={i}
+              geometry={c.geometry}
+              material={yDefectMaterial}
+              position={c.position}
+              quaternion={c.quaternion}
+            />
+          ))}
+        </group>
+      ))}
+    </>
+  );
+}

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -592,6 +592,15 @@ function computeDerivedFromBlocks(blocks: Map<string, Block>): {
   return { spatialIndex, hiddenFaces, undeterminedCubes };
 }
 
+function readShowYDefects(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem("piperDraw.showYDefects") === "1";
+  } catch {
+    return false;
+  }
+}
+
 export const useBlockStore = create<BlockStore>((set, get) => ({
   blocks: new Map(),
   spatialIndex: new Map(),
@@ -642,7 +651,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   toggleShowGrid: () => set((s) => ({ showGrid: !s.showGrid })),
   toggleShowHints: () => set((s) => ({ showHints: !s.showHints })),
 
-  showYDefects: false,
+  // Hydrate from localStorage at store creation so the toolbar paints the
+  // correct state on first render — avoids a one-frame flicker on reload.
+  showYDefects: readShowYDefects(),
   toggleShowYDefects: () => set((s) => ({ showYDefects: !s.showYDefects })),
   setShowYDefects: (on) => set({ showYDefects: on }),
 

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -322,6 +322,11 @@ interface BlockStore {
   toggleShowGrid: () => void;
   toggleShowHints: () => void;
 
+  // Y-defect overlay: highlight X/Z transition edges (twists) in magenta.
+  showYDefects: boolean;
+  toggleShowYDefects: () => void;
+  setShowYDefects: (on: boolean) => void;
+
   // Photo export — transient flag consumed by ScreenshotCapture inside <Canvas>.
   photoRequest: boolean;
   requestPhoto: () => void;
@@ -636,6 +641,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   showHints: true,
   toggleShowGrid: () => set((s) => ({ showGrid: !s.showGrid })),
   toggleShowHints: () => set((s) => ({ showHints: !s.showHints })),
+
+  showYDefects: false,
+  toggleShowYDefects: () => set((s) => ({ showYDefects: !s.showYDefects })),
+  setShowYDefects: (on) => set({ showYDefects: on }),
 
   photoRequest: false,
   requestPhoto: () => set({ photoRequest: true }),

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, getHiddenFaceMaskForPos, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, CUBE_TYPES, PIPE_TYPES } from "./index";
+import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, CUBE_TYPES, PIPE_TYPES } from "./index";
 import type { PipeType, CubeType } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
@@ -552,5 +552,53 @@ describe("defaultPortIO", () => {
 
   it("port with no surrounding pipe defaults to 'in'", () => {
     expect(defaultPortIO({ x: 0, y: 0, z: 0 }, makeBlocks([]))).toBe("in");
+  });
+});
+
+describe("createYDefectEdges", () => {
+  function edgeCount(geo: ReturnType<typeof createYDefectEdges>): number {
+    const arr = geo.getAttribute("position").array as Float32Array;
+    // 2 endpoints × 3 coords = 6 floats per edge
+    return arr.length / 6;
+  }
+
+  it("Y blocks have no Y-defect edges (single basis)", () => {
+    expect(edgeCount(createYDefectEdges("Y"))).toBe(0);
+  });
+
+  it.each(CUBE_TYPES)("cube %s emits 8 Y-defect edges (12 - 4 same-basis)", (cube) => {
+    expect(edgeCount(createYDefectEdges(cube))).toBe(8);
+  });
+
+  it("non-Hadamard ZX pipe emits 4 Y-defect edges along the open axis", () => {
+    expect(edgeCount(createYDefectEdges("OZX"))).toBe(4);
+    expect(edgeCount(createYDefectEdges("ZOX"))).toBe(4);
+    expect(edgeCount(createYDefectEdges("ZXO"))).toBe(4);
+  });
+
+  it("Hadamard pipes emit the same 4 wall-meeting edges (band ring is v1 follow-up)", () => {
+    expect(edgeCount(createYDefectEdges("OZXH"))).toBe(4);
+    expect(edgeCount(createYDefectEdges("XZOH"))).toBe(4);
+  });
+
+  it("skips every edge adjacent to a hidden face (continuous surface across the join)", () => {
+    // XZZ cube: +X face is X-basis (red); ±Y, ±Z all Z-basis (blue).
+    // 8 Y-defect edges total: 4 around +X face, 4 around -X face.
+    // Hiding +X removes those 4 edges (the seam-side defects vanish because
+    // the neighboring pipe/cube extends the surrounding Z faces seamlessly).
+    expect(edgeCount(createYDefectEdges("XZZ", FACE_POS_X))).toBe(4);
+    // Hiding +X plus a Z face: +X removes 4; the +Y face additionally hides
+    // the +Y/-X edge (a defect not yet skipped), giving 8 - 5 = 3.
+    expect(edgeCount(createYDefectEdges("XZZ", FACE_POS_X | FACE_POS_Y))).toBe(3);
+    expect(edgeCount(createYDefectEdges("XZZ", FACE_POS_X | FACE_POS_Z))).toBe(3);
+    // Hiding two same-basis faces (+Y and +Z) skips their 4 unique adjacent
+    // defects: ±X/+Y and ±X/+Z, leaving the four around -X.
+    expect(edgeCount(createYDefectEdges("XZZ", FACE_POS_Y | FACE_POS_Z))).toBe(4);
+    // Hiding the whole +X side: skips 4 (+X-adjacent) + 1 (-X/+Y from +Y)
+    // + 1 (-X/+Z from +Z) = 6. Remaining: 2 (the -X/-Y and -X/-Z edges).
+    expect(edgeCount(createYDefectEdges("XZZ", FACE_POS_X | FACE_POS_Y | FACE_POS_Z))).toBe(2);
+    // Sanity: hiding everything yields zero edges.
+    const all = FACE_POS_X | FACE_NEG_X | FACE_POS_Y | FACE_NEG_Y | FACE_POS_Z | FACE_NEG_Z;
+    expect(edgeCount(createYDefectEdges("XZZ", all))).toBe(0);
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -117,13 +117,17 @@ export interface PortMeta {
 
 export const X_COLOR = new THREE.Color("#ff7f7f"); // red
 export const Z_COLOR = new THREE.Color("#7396ff"); // blue
-export const Y_COLOR = new THREE.Color("#63c676"); // green
+export const Y_COLOR = new THREE.Color("#63c676"); // green (Y half-cube blocks)
 export const H_COLOR = new THREE.Color("#ffff65"); // yellow
+// Y-type defect ("twist") edges per Gidney's defect-diagram convention.
+// Distinct from Y_COLOR so Y blocks (green) and Y defects (magenta) read apart.
+export const Y_DEFECT_COLOR = new THREE.Color("#ff39c2");
 
 export const X_HEX = "#ff7f7f";
 export const Z_HEX = "#7396ff";
 export const Y_HEX = "#63c676";
 export const H_HEX = "#ffff65";
+export const Y_DEFECT_HEX = "#ff39c2";
 
 const H_BAND_HALF_HEIGHT = 0.08;
 /** Inset so pipe walls are never coplanar with adjacent blocks/pipes. */
@@ -642,6 +646,161 @@ export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0
   const geo = new THREE.BufferGeometry();
   geo.setAttribute("position", new THREE.BufferAttribute(new Float32Array(linePoints), 3));
   return geo;
+}
+
+/**
+ * Y-defect edges: the subset of block edges where the two adjacent faces have
+ * different basis (one X, one Z). These are the "twist" defects in TQEC defect
+ * diagrams — see Gidney's "Understanding Defect Diagrams".
+ *
+ * Cubes: 8 of 12 edges qualify for any TQEC cube type (the 4 edges parallel to
+ * the matched-basis axis are the same-basis pair and are skipped).
+ * Pipes: the 4 edges along the open axis (where the two wall-pairs of opposite
+ * basis meet). End caps and band rings are not emitted in v1; the H-pipe band
+ * ring is a known follow-up.
+ * Y blocks: empty (single-basis block, no X/Z transitions).
+ *
+ * An edge is skipped if both adjacent faces are hidden.
+ */
+export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask = 0): THREE.BufferGeometry {
+  const empty = () => {
+    const g = new THREE.BufferGeometry();
+    g.setAttribute("position", new THREE.BufferAttribute(new Float32Array(0), 3));
+    return g;
+  };
+
+  if (blockType === "Y") return empty();
+
+  const [bx, by, bz] = blockThreeSize(blockType);
+  const pipe = isPipeType(blockType);
+  const e2 = pipe ? 2 * WALL_EPS : 0;
+  const hx = bx / 2 - e2 / 2;
+  const hy = by / 2 - e2 / 2;
+  const hz = bz / 2 - e2 / 2;
+  const corners: Array<[number, number, number]> = [
+    [-hx, -hy, -hz],
+    [-hx, -hy,  hz],
+    [-hx,  hy, -hz],
+    [-hx,  hy,  hz],
+    [ hx, -hy, -hz],
+    [ hx, -hy,  hz],
+    [ hx,  hy, -hz],
+    [ hx,  hy,  hz],
+  ];
+
+  // Each cube edge with the two face bits that share it.
+  // Corner index bits: 0=±X, 1=±Y, 2=±Z (0=neg, 1=pos).
+  const edgeFacePairs: Array<{ i: number; j: number; faceA: number; faceB: number }> = [
+    // X-aligned edges (vary X bit)
+    { i: 0, j: 4, faceA: FACE_NEG_Y, faceB: FACE_NEG_Z },
+    { i: 1, j: 5, faceA: FACE_NEG_Y, faceB: FACE_POS_Z },
+    { i: 2, j: 6, faceA: FACE_POS_Y, faceB: FACE_NEG_Z },
+    { i: 3, j: 7, faceA: FACE_POS_Y, faceB: FACE_POS_Z },
+    // Y-aligned edges (vary Y bit)
+    { i: 0, j: 2, faceA: FACE_NEG_X, faceB: FACE_NEG_Z },
+    { i: 1, j: 3, faceA: FACE_NEG_X, faceB: FACE_POS_Z },
+    { i: 4, j: 6, faceA: FACE_POS_X, faceB: FACE_NEG_Z },
+    { i: 5, j: 7, faceA: FACE_POS_X, faceB: FACE_POS_Z },
+    // Z-aligned edges (vary Z bit)
+    { i: 0, j: 1, faceA: FACE_NEG_X, faceB: FACE_NEG_Y },
+    { i: 2, j: 3, faceA: FACE_NEG_X, faceB: FACE_POS_Y },
+    { i: 4, j: 5, faceA: FACE_POS_X, faceB: FACE_NEG_Y },
+    { i: 6, j: 7, faceA: FACE_POS_X, faceB: FACE_POS_Y },
+  ];
+
+  // Resolve the basis ('X' | 'Z' | null) of each Three.js face for this block.
+  // null = open / no-basis face (pipe end caps).
+  const faceBasis: Record<number, "X" | "Z" | null> = {
+    [FACE_POS_X]: null, [FACE_NEG_X]: null,
+    [FACE_POS_Y]: null, [FACE_NEG_Y]: null,
+    [FACE_POS_Z]: null, [FACE_NEG_Z]: null,
+  };
+
+  if (pipe) {
+    const base = blockType.replace("H", "");
+    const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
+    const threeOpen = TQEC_TO_THREE_AXIS[tqecOpen];
+    const closed = [0, 1, 2].filter(a => a !== threeOpen) as [number, number];
+    for (const ta of closed) {
+      const ch = base[THREE_TO_TQEC_AXIS[ta]] as "X" | "Z";
+      faceBasis[FACE_BIT_BY_INDEX[ta * 2]] = ch;
+      faceBasis[FACE_BIT_BY_INDEX[ta * 2 + 1]] = ch;
+    }
+    // Open-axis faces stay null (no basis).
+  } else {
+    // Cube type. Three.js face → TQEC axis: +X/-X→X(0), +Y/-Y→Z(2), +Z/-Z→Y(1).
+    const xCh = blockType[0] as "X" | "Z";
+    const yCh = blockType[1] as "X" | "Z";
+    const zCh = blockType[2] as "X" | "Z";
+    faceBasis[FACE_POS_X] = xCh; faceBasis[FACE_NEG_X] = xCh;
+    faceBasis[FACE_POS_Y] = zCh; faceBasis[FACE_NEG_Y] = zCh;
+    faceBasis[FACE_POS_Z] = yCh; faceBasis[FACE_NEG_Z] = yCh;
+  }
+
+  const linePoints: number[] = [];
+  for (const { i, j, faceA, faceB } of edgeFacePairs) {
+    const ba = faceBasis[faceA];
+    const bb = faceBasis[faceB];
+    if (!ba || !bb) continue;          // open / no-basis face
+    if (ba === bb) continue;           // same basis → not a Y defect
+    // If either adjacent face is hidden, the visible surface continues into the
+    // neighboring block. Piper-draw's color rules guarantee the neighbor extends
+    // that face with the same basis, so the merged surface has no transition at
+    // this edge — the Y-defect "vanishes into the join". (In free-build mode the
+    // color rules can be violated, in which case we'd miss a real transition.
+    // Acceptable trade-off; tagged as known limitation.)
+    if ((hiddenFaces & faceA) || (hiddenFaces & faceB)) continue;
+    linePoints.push(...corners[i], ...corners[j]);
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(new Float32Array(linePoints), 3));
+  return geo;
+}
+
+/** Default cylinder radius for Y-defect tubes, in Three.js units (block edge = 1). */
+export const Y_DEFECT_CYLINDER_RADIUS = 0.05;
+
+/**
+ * Returns a Group of cylinder meshes representing Y-defect edges as 3D tubes,
+ * matching the Gidney defect-diagram convention (magenta cylinders along
+ * X/Z-transition edges). Uses createYDefectEdges as the geometric source so
+ * tube placement and line-segment placement are guaranteed to agree.
+ *
+ * Geometry only — caller supplies the material. Cylinders are oriented from
+ * each edge's first endpoint to its second; the group is centered in the
+ * block's local space so it can be added directly alongside the block mesh.
+ */
+export function createYDefectCylinderGroup(
+  blockType: BlockType,
+  hiddenFaces: FaceMask = 0,
+  material: THREE.Material,
+  radius: number = Y_DEFECT_CYLINDER_RADIUS,
+): THREE.Group {
+  const group = new THREE.Group();
+  const edges = createYDefectEdges(blockType, hiddenFaces);
+  const positions = edges.getAttribute("position").array as Float32Array;
+  edges.dispose();
+
+  const up = new THREE.Vector3(0, 1, 0);
+  const a = new THREE.Vector3();
+  const b = new THREE.Vector3();
+  const dir = new THREE.Vector3();
+
+  for (let i = 0; i < positions.length; i += 6) {
+    a.set(positions[i], positions[i + 1], positions[i + 2]);
+    b.set(positions[i + 3], positions[i + 4], positions[i + 5]);
+    dir.subVectors(b, a);
+    const length = dir.length();
+    if (length < 1e-6) continue;
+
+    const cyl = new THREE.CylinderGeometry(radius, radius, length, 12);
+    const mesh = new THREE.Mesh(cyl, material);
+    mesh.position.copy(a).addScaledVector(dir, 0.5);
+    mesh.quaternion.setFromUnitVectors(up, dir.divideScalar(length));
+    group.add(mesh);
+  }
+  return group;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Adds a persistent toolbar toggle that overlays magenta cylinders along block edges where two opposite-basis (X / Z) faces meet — the "Type Y twist" rendering from Gidney's *Understanding Defect Diagrams* deck. Same cylinders render in the toolbar block thumbnails so placement is verifiable at a glance. Edges adjacent to a hidden face are skipped, so the tube correctly vanishes into seams where a pipe extends a cube face with the same basis.

## Test plan
- [x] tsc + eslint clean, 294 vitest tests pass (10 new for `createYDefectEdges`)
- [ ] Toggle the **Y defects** button on a single cube, a cube+pipe stack, and a Y half-cube; verify the magenta tubes match the toolbar previews and the seam between cube and pipe has no extra ring

🧙 Built with [WOZCODE](https://wozcode.com)