### PR TITLE
chore: wire up slop-scan (npm run slop:diff)

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -30,6 +30,7 @@
         "globals": "^17.4.0",
         "jsdom": "^29.0.2",
         "rollup-plugin-license": "^3.7.1",
+        "slop-scan": "^0.3.0",
         "typescript": "~6.0.2",
         "typescript-eslint": "^8.58.0",
         "vite": "^8.0.4",
@@ -1273,6 +1274,44 @@
         "@emnapi/runtime": "^1.7.1"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.126.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.126.0.tgz",
@@ -1985,6 +2024,19 @@
         "win32"
       ]
     },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -2641,6 +2693,19 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -3317,6 +3382,36 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3330,6 +3425,16 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -3366,6 +3471,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/find-up": {
@@ -3465,6 +3583,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+      "integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^4.0.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.5",
+        "is-path-inside": "^4.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/glsl-noise": {
@@ -3596,6 +3745,29 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -4095,6 +4267,16 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/meshline": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
@@ -4109,6 +4291,33 @@
       "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
       "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
       "license": "MIT"
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/minimatch": {
       "version": "10.2.5",
@@ -4373,6 +4582,27 @@
         "node": ">=6"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.5",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
@@ -4425,6 +4655,17 @@
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "license": "MIT",
       "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
     },
@@ -4537,6 +4778,30 @@
         "rollup": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
       }
     },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/rxjs": {
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
@@ -4616,6 +4881,49 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/slop-scan": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/slop-scan/-/slop-scan-0.3.0.tgz",
+      "integrity": "sha512-uviaHdntkRX5+4RZhzk/N3wYzoW9FMe9XrA4uCuNUslTt8GxbXc8B99YE9map78hJ9/FbXDpmn3phG/EsD7TZQ==",
+      "dev": true,
+      "dependencies": {
+        "globby": "^16.2.0",
+        "typescript": "^5.8.3"
+      },
+      "bin": {
+        "slop-scan": "bin/slop-scan.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/slop-scan/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -4932,6 +5240,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
@@ -5122,6 +5443,19 @@
       "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+      "integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",

--- a/gui/package.json
+++ b/gui/package.json
@@ -15,6 +15,7 @@
     "lint": "eslint .",
     "test": "node --require ./scripts/vitest-crypto-shim.cjs ./node_modules/vitest/vitest.mjs run --run",
     "test:watch": "node --require ./scripts/vitest-crypto-shim.cjs ./node_modules/vitest/vitest.mjs",
+    "slop:diff": "node scripts/slop-diff.mjs",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -39,6 +40,7 @@
     "globals": "^17.4.0",
     "jsdom": "^29.0.2",
     "rollup-plugin-license": "^3.7.1",
+    "slop-scan": "^0.3.0",
     "typescript": "~6.0.2",
     "typescript-eslint": "^8.58.0",
     "vite": "^8.0.4",

--- a/gui/scripts/slop-diff.mjs
+++ b/gui/scripts/slop-diff.mjs
@@ -1,0 +1,179 @@
+#!/usr/bin/env node
+// slop-diff: show NEW slop-scan findings introduced on this branch.
+//
+// Runs slop-scan on HEAD and on the merge-base, then diffs the results
+// to show only findings that were added. Line-number-insensitive comparison
+// so shifting code doesn't create false positives.
+//
+// Usage:
+//   npm run slop:diff                    # diff against origin/dev
+//   npm run slop:diff -- origin/release  # diff against another base
+//
+// Vendored from gstack 1.14.0.0; ported from .ts to .mjs to match repo conventions.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+const base = process.argv[2] || "origin/dev";
+
+// 1. Find changed files
+const diffResult = spawnSync("git", ["diff", "--name-only", `${base}...HEAD`], {
+  encoding: "utf-8",
+  timeout: 10000,
+});
+const changedFiles = new Set(
+  (diffResult.stdout || "").trim().split("\n").filter(Boolean),
+);
+if (changedFiles.size === 0) {
+  console.log(`No files changed vs ${base} — nothing to check.`);
+  process.exit(0);
+}
+
+// 2. Run slop-scan on HEAD
+const scanHead = spawnSync("npx", ["slop-scan", "scan", ".", "--json"], {
+  encoding: "utf-8",
+  timeout: 120000,
+  shell: process.platform === "win32",
+});
+if (!scanHead.stdout) {
+  console.log("slop-scan not available. Install: npm i -D slop-scan");
+  process.exit(0);
+}
+let headReport;
+try {
+  headReport = JSON.parse(scanHead.stdout);
+} catch {
+  console.log("slop-scan returned invalid JSON.");
+  process.exit(0);
+}
+
+// 3. Get base branch findings using a temp worktree
+const mergeBase = spawnSync("git", ["merge-base", base, "HEAD"], {
+  encoding: "utf-8",
+  timeout: 5000,
+}).stdout?.trim();
+
+// Fingerprint: strip line numbers so shifting code doesn't create false positives.
+// "line 142: empty catch, boundary=none" -> "empty catch, boundary=none"
+function stripLineNum(evidence) {
+  return evidence.replace(/^line \d+: /, "").replace(/ at line \d+ /, " ");
+}
+
+const baseCounts = new Map();
+
+if (mergeBase) {
+  const tmpWorktree = path.join(os.tmpdir(), `slop-base-${Date.now()}`);
+  const wtResult = spawnSync(
+    "git",
+    ["worktree", "add", "--detach", tmpWorktree, mergeBase],
+    { encoding: "utf-8", timeout: 30000 },
+  );
+
+  if (wtResult.status === 0) {
+    const configFile = "slop-scan.config.json";
+    if (fs.existsSync(configFile)) {
+      try {
+        fs.copyFileSync(configFile, path.join(tmpWorktree, configFile));
+      } catch {
+        // best-effort
+      }
+    }
+
+    const scanBase = spawnSync(
+      "npx",
+      ["slop-scan", "scan", tmpWorktree, "--json"],
+      {
+        encoding: "utf-8",
+        timeout: 120000,
+        shell: process.platform === "win32",
+      },
+    );
+
+    if (scanBase.stdout) {
+      try {
+        const baseReport = JSON.parse(scanBase.stdout);
+        for (const f of baseReport.findings) {
+          const realPath = f.path.replace(tmpWorktree + "/", "");
+          if (!changedFiles.has(realPath)) continue;
+          for (const ev of f.evidence || []) {
+            const key = `${f.ruleId}|${realPath}|${stripLineNum(ev)}`;
+            baseCounts.set(key, (baseCounts.get(key) || 0) + 1);
+          }
+        }
+      } catch {
+        // ignore — base scan unavailable just means we treat all findings as new
+      }
+    }
+
+    spawnSync("git", ["worktree", "remove", "--force", tmpWorktree], {
+      timeout: 10000,
+    });
+  }
+}
+
+// 4. Find genuinely new findings via counts (handles duplicates).
+const headCounts = new Map();
+const headFindings = headReport.findings.filter((f) => changedFiles.has(f.path));
+
+for (const f of headFindings) {
+  for (const ev of f.evidence || []) {
+    const key = `${f.ruleId}|${f.path}|${stripLineNum(ev)}`;
+    const entry = headCounts.get(key) || { count: 0, evidence: [] };
+    entry.count++;
+    entry.evidence.push(ev);
+    headCounts.set(key, entry);
+  }
+}
+
+const newFindings = [];
+let removedCount = 0;
+
+for (const [key, entry] of headCounts) {
+  const baseCount = baseCounts.get(key) || 0;
+  const netNew = entry.count - baseCount;
+  if (netNew > 0) {
+    const [ruleId, filePath] = key.split("|");
+    for (const ev of entry.evidence.slice(-netNew)) {
+      newFindings.push({ ruleId, filePath, evidence: ev });
+    }
+  }
+}
+
+for (const [key, baseCount] of baseCounts) {
+  const headCount = headCounts.get(key)?.count || 0;
+  if (headCount < baseCount) removedCount += baseCount - headCount;
+}
+
+// 5. Print results
+if (newFindings.length === 0) {
+  if (removedCount > 0) {
+    console.log(`\n  slop-scan: no new findings. Removed ${removedCount} pre-existing findings.\n`);
+  } else {
+    console.log(`\n  slop-scan: no new findings in ${changedFiles.size} changed files.\n`);
+  }
+  process.exit(0);
+}
+
+console.log(`\n── slop-scan: ${newFindings.length} new findings (+${newFindings.length} / -${removedCount}) ──\n`);
+
+const grouped = new Map();
+for (const { ruleId, filePath, evidence } of newFindings) {
+  if (!grouped.has(filePath)) grouped.set(filePath, new Map());
+  const rules = grouped.get(filePath);
+  if (!rules.has(ruleId)) rules.set(ruleId, []);
+  rules.get(ruleId).push(evidence);
+}
+
+for (const [filePath, rules] of grouped) {
+  console.log(`  ${filePath}`);
+  for (const [ruleId, evidence] of rules) {
+    console.log(`    ${ruleId}:`);
+    for (const ev of evidence) {
+      console.log(`      ${ev}`);
+    }
+  }
+}
+
+console.log(`\n  Net: +${newFindings.length} new, -${removedCount} removed\n`);


### PR DESCRIPTION
## Summary
Adds slop-scan as a devDependency and a \`slop:diff\` npm script that flags only NEW AI-code-quality findings on the current branch (preexisting findings are silenced via merge-base diff). Lets gstack's /review skill run its slop scan, and gives the team a one-line command to check their own diffs. Vendored \`scripts/slop-diff.mjs\` from gstack 1.14.0.0, ported to \`.mjs\` to match repo conventions.

## Usage
\`\`\`
npm run slop:diff                    # vs origin/dev
npm run slop:diff -- origin/release  # vs another base
\`\`\`

## Test plan
- [x] \`npm run slop:diff -- origin/dev\` runs cleanly on this branch (no new findings)
- [ ] Open a PR with a deliberate AI-slop pattern (empty catch, etc.) and confirm it's flagged

🧙 Built with [WOZCODE](https://wozcode.com)