### PR TITLE
fix: skip pyzx normalize when only output ports are set (#221)

### DIFF
--- a/server.py
+++ b/server.py
@@ -549,8 +549,13 @@ async def zx(req: ZXRequest) -> ZXResponse:
     if req.simplify:
         pyzx.simplify.full_reduce(pzx.g)
         # normalize() places inputs/outputs at sensible (qubit, row) — required
-        # before extract_circuit and nicer for display.
-        pzx.g.normalize()
+        # before extract_circuit and nicer for display. Skip it when only
+        # outputs are set: pyzx.normalize() invokes auto_detect_io() whenever
+        # num_inputs() == 0, which clobbers our explicit outputs and raises
+        # TypeError on boundary vertices that share a row with their neighbor
+        # (issue #221). Frontend falls back to a circle layout in that case.
+        if pzx.g.num_inputs() > 0 or pzx.g.num_outputs() == 0:
+            pzx.g.normalize()
 
     circuit_info: ZXCircuit | None = None
     circuit_error: str | None = None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -378,6 +378,54 @@ class TestZXEndpoint:
         assert simplified["simplified"] is True
         assert len(simplified["vertices"]) <= len(raw["vertices"])
 
+    def test_simplify_with_all_output_ports(self):
+        # Regression for #221: full_reduce + normalize raised TypeError when
+        # every port was marked 'out', because pyzx auto_detect_io fires
+        # whenever num_inputs() == 0 and can't classify boundary vertices that
+        # share a row with their neighbor.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "out", "P2": "out"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+        assert result["simplified"] is True
+        # Both output boundaries should survive full_reduce.
+        assert len(result["vertices"]) == 2
+
+    def test_simplify_with_all_input_ports(self):
+        # Sister case to test_simplify_with_all_output_ports: locks in that
+        # all-input diagrams keep working, since pyzx's auto_detect_io guard
+        # only triggers when num_inputs() == 0.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "in", "P2": "in"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+
     def test_invalid_diagram_returns_error(self):
         # Mismatched pipe colors -> tqec validation error surfaces
         result = self._run(


### PR DESCRIPTION
## Summary
- `/api/zx` returned a 500 whenever every port was marked `out`. Root cause: `pyzx.normalize()` invokes `auto_detect_io()` when `num_inputs() == 0`, which both clobbers our explicit outputs and raises `TypeError` on boundary vertices that share a row with their neighbor (issue #221).
- Gate `normalize()` on `num_inputs() > 0 or num_outputs() == 0`. The frontend's `ZXPanel` already falls back to a circle layout for vertices with `pos === null`, so the all-output case still renders.
- Added regression tests for both the all-output (the bug) and all-input (sister case) configurations.

## Test plan
- [x] `uv run pytest` — 59 tests pass, including the two new ZX endpoint tests
- [ ] Manually verify in the browser with the exact diagram from the issue screenshot: open the dev server, label both ports as `out`, hit Full Reduce, and confirm the diagram renders without a server error

🤖 Generated with [Claude Code](https://claude.com/claude-code)