### PR TITLE
feat: user-defined port ordering (closes #209)

### DIFF
--- a/gui/src/components/FlowsPanel.tsx
+++ b/gui/src/components/FlowsPanel.tsx
@@ -221,19 +221,52 @@ export function FlowsPanel({
     if (stale && flowVizMode) setFlowVizMode(false);
   }, [stale, flowVizMode, setFlowVizMode]);
 
+  // Order port labels by user-defined rank (PortMeta.rank). Labels without a
+  // rank fall back to the server's order. This drives the column order in the
+  // generator and membership tables, i.e. the qubit-register position when
+  // the diagram is interpreted as a circuit.
+  const labelRank = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const meta of portMeta.values()) {
+      if (meta.rank !== undefined) m.set(meta.label, meta.rank);
+    }
+    return m;
+  }, [portMeta]);
+  const sortByRank = useCallback(
+    (labels: string[]): string[] => {
+      const indexed = labels.map((l, i) => ({ l, i }));
+      indexed.sort((a, b) => {
+        const ra = labelRank.get(a.l) ?? Number.POSITIVE_INFINITY;
+        const rb = labelRank.get(b.l) ?? Number.POSITIVE_INFINITY;
+        if (ra !== rb) return ra - rb;
+        return a.i - b.i;
+      });
+      return indexed.map(({ l }) => l);
+    },
+    [labelRank],
+  );
+  const orderedInputs = useMemo(
+    () => (result?.ok ? sortByRank(result.inputs) : []),
+    [result, sortByRank],
+  );
+  const orderedOutputs = useMemo(
+    () => (result?.ok ? sortByRank(result.outputs) : []),
+    [result, sortByRank],
+  );
+
   const generatorSpan = useMemo(() => {
     if (!result || !result.ok) return null;
-    const labels = [...result.inputs, ...result.outputs];
+    const labels = [...orderedInputs, ...orderedOutputs];
     const vecs = result.flows.map((flow) => {
       const pauliStr = labels
         .map((l, i) =>
-          i < result.inputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
+          i < orderedInputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
         )
         .join("");
       return pauliToSymplectic(pauliStr);
     });
-    return { labels, vecs, inputCount: result.inputs.length };
-  }, [result]);
+    return { labels, vecs, inputCount: orderedInputs.length };
+  }, [result, orderedInputs, orderedOutputs]);
 
   const addQuery = useCallback(() => {
     if (!generatorSpan) return;
@@ -475,7 +508,7 @@ export function FlowsPanel({
               <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                 <thead>
                   <tr>
-                    {result.inputs.map((label) => (
+                    {orderedInputs.map((label) => (
                       <th
                         key={`in-${label}`}
                         style={{
@@ -489,7 +522,7 @@ export function FlowsPanel({
                       </th>
                     ))}
                     <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>→</th>
-                    {result.outputs.map((label) => (
+                    {orderedOutputs.map((label) => (
                       <th
                         key={`out-${label}`}
                         style={{
@@ -521,7 +554,7 @@ export function FlowsPanel({
                           outline: isActive ? "2px solid #4a9eff" : undefined,
                         }}
                       >
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <td
                             key={`in-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -530,7 +563,7 @@ export function FlowsPanel({
                           </td>
                         ))}
                         <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <td
                             key={`out-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -610,7 +643,7 @@ export function FlowsPanel({
                   <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                     <thead>
                       <tr>
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <th
                             key={`qin-${label}`}
                             style={{
@@ -626,7 +659,7 @@ export function FlowsPanel({
                         <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>
                           →
                         </th>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <th
                             key={`qout-${label}`}
                             style={{
@@ -648,7 +681,7 @@ export function FlowsPanel({
                         const inSpan = isQueryInSpan(q);
                         return (
                           <tr key={q.id}>
-                            {result.inputs.map((label) => (
+                            {orderedInputs.map((label) => (
                               <td
                                 key={`qin-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}
@@ -660,7 +693,7 @@ export function FlowsPanel({
                               </td>
                             ))}
                             <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                            {result.outputs.map((label) => (
+                            {orderedOutputs.map((label) => (
                               <td
                                 key={`qout-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}

--- a/gui/src/components/PortsTable.tsx
+++ b/gui/src/components/PortsTable.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
 import { useLocateStore } from "../stores/locateStore";
-import { getAllPortPositions, posKey, tqecToThree, type Position3D } from "../types";
+import { getOrderedPortPositions, posKey, tqecToThree, type Position3D } from "../types";
 import { animateCamera } from "../utils/cameraAnim";
 
 function PortLabelInput({
@@ -72,6 +72,19 @@ function LocateIcon() {
   );
 }
 
+function GripIcon() {
+  return (
+    <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+      <circle cx="3" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="11" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="11" r="1.1" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function PortsTable({
   controlsRef,
 }: {
@@ -83,9 +96,13 @@ export function PortsTable({
   const portPositions = useBlockStore((s) => s.portPositions);
   const setPortLabel = useBlockStore((s) => s.setPortLabel);
   const setPortIO = useBlockStore((s) => s.setPortIO);
+  const reorderPort = useBlockStore((s) => s.reorderPort);
+
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
 
   const portList = useMemo(() => {
-    const positions = getAllPortPositions(blocks, portPositions);
+    const positions = getOrderedPortPositions(blocks, portPositions, portMeta);
     return positions.map((pos) => {
       const key = posKey(pos);
       const meta = portMeta.get(key);
@@ -119,56 +136,105 @@ export function PortsTable({
           No open ports. Add open pipes or place port markers.
         </div>
       )}
-      {portList.map(({ pos, key, meta }) => (
-        <div
-          key={key}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            marginBottom: 4,
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => handleLocate(pos)}
-            aria-label="Locate port"
-            title="Locate port"
+      {portList.map(({ pos, key, meta }, index) => {
+        const isDragging = dragIndex === index;
+        const showDropAbove =
+          dragIndex !== null && overIndex === index && index < dragIndex;
+        const showDropBelow =
+          dragIndex !== null && overIndex === index && index > dragIndex;
+        return (
+          <div
+            key={key}
+            onDragOver={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              if (overIndex !== index) setOverIndex(index);
+            }}
+            onDrop={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              if (dragIndex !== index) reorderPort(dragIndex, index);
+              setDragIndex(null);
+              setOverIndex(null);
+            }}
             style={{
-              background: "none",
-              border: "none",
-              padding: 2,
-              cursor: "pointer",
-              color: "#666",
-              display: "inline-flex",
+              display: "flex",
               alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
+              gap: 6,
+              marginBottom: 4,
+              padding: "2px 0",
+              opacity: isDragging ? 0.4 : 1,
+              borderTop: showDropAbove ? "2px solid #4a9eff" : "2px solid transparent",
+              borderBottom: showDropBelow ? "2px solid #4a9eff" : "2px solid transparent",
             }}
           >
-            <LocateIcon />
-          </button>
-          <PortLabelInput
-            pos={pos}
-            label={meta?.label ?? ""}
-            onCommit={setPortLabel}
-          />
-          <select
-            value={meta?.io ?? "in"}
-            onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
-            style={{ fontSize: 12, padding: "2px 4px" }}
-          >
-            <option value="in">in</option>
-            <option value="out">out</option>
-          </select>
-          <span
-            title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
-            style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
-          >
-            {pos.x / 3},{pos.y / 3},{pos.z / 3}
-          </span>
-        </div>
-      ))}
+            <span
+              draggable
+              onDragStart={(e) => {
+                setDragIndex(index);
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", String(index));
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setOverIndex(null);
+              }}
+              aria-label="Drag to reorder"
+              title="Drag to reorder"
+              style={{
+                cursor: "grab",
+                color: "#aaa",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                padding: "0 2px",
+              }}
+            >
+              <GripIcon />
+            </span>
+            <button
+              type="button"
+              onClick={() => handleLocate(pos)}
+              aria-label="Locate port"
+              title="Locate port"
+              style={{
+                background: "none",
+                border: "none",
+                padding: 2,
+                cursor: "pointer",
+                color: "#666",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <LocateIcon />
+            </button>
+            <PortLabelInput
+              pos={pos}
+              label={meta?.label ?? ""}
+              onCommit={setPortLabel}
+            />
+            <select
+              value={meta?.io ?? "in"}
+              onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
+              style={{ fontSize: 12, padding: "2px 4px" }}
+            >
+              <option value="in">in</option>
+              <option value="out">out</option>
+            </select>
+            <span
+              title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
+              style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
+            >
+              {pos.x / 3},{pos.y / 3},{pos.z / 3}
+            </span>
+          </div>
+        );
+      })}
     </section>
   );
 }

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1283,6 +1283,62 @@ describe("blockStore", () => {
     });
   });
 
+  describe("reorderPort", () => {
+    function seedFourPorts() {
+      useBlockStore.setState({
+        blocks: new Map(),
+        portPositions: new Set(["0,0,0", "3,0,0", "6,0,0", "9,0,0"]),
+        portMeta: new Map(),
+      });
+      useBlockStore.getState().ensurePortLabels();
+    }
+
+    function ranksByX(): Record<number, number | undefined> {
+      const out: Record<number, number | undefined> = {};
+      for (const [k, m] of useBlockStore.getState().portMeta) {
+        const x = Number(k.split(",")[0]);
+        out[x] = m.rank;
+      }
+      return out;
+    }
+
+    it("ensurePortLabels assigns sequential ranks 0..N-1 in spatial order", () => {
+      seedFourPorts();
+      // Spatial sort is by x ascending → ranks should match the x order.
+      expect(ranksByX()).toEqual({ 0: 0, 3: 1, 6: 2, 9: 3 });
+    });
+
+    it("moves a port forward and rewrites all ranks to 0..N-1", () => {
+      seedFourPorts();
+      // Move the port at index 3 (x=9) to index 0.
+      useBlockStore.getState().reorderPort(3, 0);
+      expect(ranksByX()).toEqual({ 9: 0, 0: 1, 3: 2, 6: 3 });
+    });
+
+    it("moves a port backward and rewrites all ranks", () => {
+      seedFourPorts();
+      // Move the port at index 0 (x=0) to index 2.
+      useBlockStore.getState().reorderPort(0, 2);
+      expect(ranksByX()).toEqual({ 3: 0, 6: 1, 0: 2, 9: 3 });
+    });
+
+    it("is a no-op when from === to", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(2, 2);
+      // Object identity preserved (set returned `state` unchanged).
+      expect(useBlockStore.getState().portMeta).toBe(before);
+    });
+
+    it("is a no-op when indices are out of range", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(-1, 2);
+      useBlockStore.getState().reorderPort(0, 99);
+      expect(useBlockStore.getState().portMeta).toBe(before);
+    });
+  });
+
   describe("copy / paste", () => {
     it("copySelection snapshots selected blocks normalized to origin", () => {
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -8,6 +8,7 @@ import type {
 import {
   posKey,
   getAllPortPositions,
+  getOrderedPortPositions,
   defaultPortIO,
   hasBlockOverlap,
   hasCubeColorConflict,
@@ -291,6 +292,12 @@ interface BlockStore {
   ensurePortLabels: () => void;
   setPortLabel: (pos: Position3D, label: string) => void;
   setPortIO: (pos: Position3D, io: PortIO) => void;
+  /**
+   * Reorder ports by moving the port at `fromIndex` (in the current
+   * user-ordered port list) to `toIndex`, then rewriting all ranks
+   * 0..N-1 so the array indices match the stored ranks.
+   */
+  reorderPort: (fromIndex: number, toIndex: number) => void;
   setFlowsPanelOpen: (open: boolean) => void;
   toggleFlowsPanel: () => void;
 
@@ -3439,7 +3446,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       for (const k of stale) next.delete(k);
 
       const used = new Set<string>();
-      for (const meta of next.values()) used.add(meta.label);
+      let maxRank = -1;
+      for (const meta of next.values()) {
+        used.add(meta.label);
+        if (meta.rank !== undefined && meta.rank > maxRank) maxRank = meta.rank;
+      }
       let nextId = 1;
       const allocLabel = (): string => {
         while (used.has(`P${nextId}`)) nextId++;
@@ -3449,9 +3460,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       };
 
       for (const pos of missing) {
+        maxRank += 1;
         next.set(posKey(pos), {
           label: allocLabel(),
           io: defaultPortIO(pos, state.blocks),
+          rank: maxRank,
         });
       }
       return { portMeta: next };
@@ -3493,6 +3506,34 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       if (!existing || existing.io === io) return state;
       const next = new Map(state.portMeta);
       next.set(key, { ...existing, io });
+      return { portMeta: next };
+    }),
+
+  reorderPort: (fromIndex, toIndex) =>
+    set((state) => {
+      const ordered = getOrderedPortPositions(
+        state.blocks,
+        state.portPositions,
+        state.portMeta,
+      );
+      if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= ordered.length ||
+        toIndex >= ordered.length
+      ) {
+        return state;
+      }
+      const keys = ordered.map(posKey);
+      const [moved] = keys.splice(fromIndex, 1);
+      keys.splice(toIndex, 0, moved);
+
+      const next = new Map(state.portMeta);
+      keys.forEach((k, i) => {
+        const m = next.get(k);
+        if (m && m.rank !== i) next.set(k, { ...m, rank: i });
+      });
       return { portMeta: next };
     }),
 

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, CUBE_TYPES, PIPE_TYPES } from "./index";
-import type { PipeType, CubeType } from "./index";
+import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, CUBE_TYPES, PIPE_TYPES } from "./index";
+import type { PipeType, CubeType, PortMeta } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
 
@@ -600,5 +600,62 @@ describe("createYDefectEdges", () => {
     // Sanity: hiding everything yields zero edges.
     const all = FACE_POS_X | FACE_NEG_X | FACE_POS_Y | FACE_NEG_Y | FACE_POS_Z | FACE_NEG_Z;
     expect(edgeCount(createYDefectEdges("XZZ", all))).toBe(0);
+  });
+});
+
+describe("getOrderedPortPositions", () => {
+  const explicitPorts = new Set([
+    "0,0,0",
+    "3,0,0",
+    "6,0,0",
+    "9,0,0",
+  ]);
+  const blocks = new Map<
+    string,
+    { pos: { x: number; y: number; z: number }; type: BlockType }
+  >();
+
+  it("falls back to spatial sort when no ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["3,0,0", { label: "P1", io: "in" }],
+      ["0,0,0", { label: "P2", io: "in" }],
+      ["9,0,0", { label: "P3", io: "in" }],
+      ["6,0,0", { label: "P4", io: "in" }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 3, 6, 9]);
+  });
+
+  it("orders ports by rank when ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["0,0,0", { label: "P1", io: "in", rank: 3 }],
+      ["3,0,0", { label: "P2", io: "in", rank: 1 }],
+      ["6,0,0", { label: "P3", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P4", io: "in", rank: 2 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([6, 3, 9, 0]);
+  });
+
+  it("places ranked ports before unranked ones; unranked sort spatially", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["9,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["3,0,0", { label: "P2", io: "in" }],
+      ["0,0,0", { label: "P3", io: "in" }],
+      // P4 at (6,0,0) has no PortMeta entry at all — also unranked.
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([9, 0, 3, 6]);
+  });
+
+  it("breaks ties between equal ranks by spatial order", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["6,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["0,0,0", { label: "P2", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P3", io: "in", rank: 1 }],
+      ["3,0,0", { label: "P4", io: "in", rank: 1 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 6, 3, 9]);
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -109,6 +109,13 @@ export type PortIO = "in" | "out";
 export interface PortMeta {
   label: string;
   io: PortIO;
+  /**
+   * User-defined display order, used by the Ports table and Stabilizer Flows
+   * panel to determine the qubit-register position of each port. Lower ranks
+   * sort first; ports without a rank fall back to spatial sort and appear
+   * after ranked ports.
+   */
+  rank?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -1403,6 +1410,28 @@ export function getAllPortPositions(
 
   result.sort((a, b) => a.x - b.x || a.y - b.y || a.z - b.z);
   return result;
+}
+
+/**
+ * Like `getAllPortPositions`, but ordered by user-defined `PortMeta.rank`
+ * with spatial sort as fallback for any port without a rank. This is the
+ * order shown in the Ports table and used to position qubits in the
+ * Stabilizer Flows table when interpreted as a circuit.
+ */
+export function getOrderedPortPositions(
+  blocks: Map<string, Block>,
+  explicitPorts: Set<string>,
+  portMeta: Map<string, PortMeta>,
+): Position3D[] {
+  const positions = getAllPortPositions(blocks, explicitPorts);
+  return positions.slice().sort((a, b) => {
+    const ra = portMeta.get(posKey(a))?.rank;
+    const rb = portMeta.get(posKey(b))?.rank;
+    const ka = ra ?? Number.POSITIVE_INFINITY;
+    const kb = rb ?? Number.POSITIVE_INFINITY;
+    if (ka !== kb) return ka - kb;
+    return a.x - b.x || a.y - b.y || a.z - b.z;
+  });
 }
 
 /**

--- a/gui/src/utils/flows.ts
+++ b/gui/src/utils/flows.ts
@@ -36,7 +36,7 @@ export async function computeFlows(
   }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) portIO[meta.label] = meta.io;

--- a/gui/src/utils/zx.ts
+++ b/gui/src/utils/zx.ts
@@ -68,7 +68,7 @@ export async function computeZX(
   }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) {

--- a/server.py
+++ b/server.py
@@ -56,6 +56,10 @@ class BlockInput(BaseModel):
 class PortLabelInput(BaseModel):
     pos: list[float]
     label: str
+    # User-defined display rank from the Ports table. Lower ranks come first.
+    # When provided, the /api/zx endpoint sorts the extracted circuit's qubit
+    # register by this value so it matches the order shown in the GUI.
+    rank: int | None = None
 
 
 class ValidateRequest(BaseModel):
@@ -450,8 +454,26 @@ async def flows(req: FlowsRequest) -> FlowsResponse:
             error="Diagram has no open ports",
         )
 
-    inputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "in"]
-    outputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "out"]
+    # Sort by user-defined rank from the Ports table (matches /api/zx) so the
+    # qubit-register position when this diagram is interpreted as a circuit
+    # follows the GUI order. Unranked ports fall through to TQEC's
+    # alphabetical order.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _flows_sort_key(label: str) -> tuple[int, str]:
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    inputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "in"),
+        key=_flows_sort_key,
+    )
+    outputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "out"),
+        key=_flows_sort_key,
+    )
 
     try:
         surfaces = graph.find_correlation_surfaces()
@@ -534,6 +556,21 @@ async def zx(req: ZXRequest) -> ZXResponse:
             port_label_by_vertex[v] = cube.label
             io = req.port_io.get(cube.label, "in")
             (output_vs if io == "out" else input_vs).append(v)
+
+    # Sort input/output vertex lists by user-defined rank from the Ports table
+    # so the extracted circuit's qubit register matches the GUI order.
+    # Unranked ports sort last, then alphabetically by label.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _port_sort_key(v: int) -> tuple[int, str]:
+        label = port_label_by_vertex.get(v, "")
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    input_vs.sort(key=_port_sort_key)
+    output_vs.sort(key=_port_sort_key)
 
     # Register boundary vertices as pyzx inputs/outputs (required by
     # pyzx.extract_circuit, harmless otherwise).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -724,6 +724,74 @@ class TestZXEndpoint:
         labels = {v["label"] for v in result["vertices"] if v["label"]}
         assert labels == {"a", "b"}
 
+    def test_extract_qubit_register_follows_port_rank(self):
+        # Two parallel identity chains → 2 inputs, 2 outputs. The qubit-index
+        # of each input is determined by the user-defined rank on PortLabelInput
+        # (matching the Ports table order), not by alphabetical label sort.
+        # Swapping the ranks must swap which port maps to qubit 0.
+        blocks = [
+            # Chain 1 at y=0
+            BlockInput(pos=[0, 0, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 0, 0], type="OXZ"),
+            BlockInput(pos=[1, 0, 0], type="OXZ"),
+            # Chain 2 at y=3
+            BlockInput(pos=[0, 3, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 3, 0], type="OXZ"),
+            BlockInput(pos=[1, 3, 0], type="OXZ"),
+        ]
+        port_io = {"a_in": "in", "a_out": "out", "b_in": "in", "b_out": "out"}
+
+        def qubit_of_input_label(result: dict, label: str) -> int:
+            # After extract, vertex pos is [row, 0, -qubit]; inputs land at the
+            # smallest row in the layout. Find the vertex carrying `label` and
+            # return its qubit index.
+            for v in result["vertices"]:
+                if v["label"] == label and v["pos"] is not None:
+                    return int(round(-v["pos"][2]))
+            raise AssertionError(f"no vertex labelled {label!r}")
+
+        # Case A: rank a_in=0, b_in=1 → a_in is qubit 0, b_in is qubit 1.
+        port_labels_a = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=0),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=1),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_a = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_a,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_a["ok"] is True, result_a
+        assert result_a["circuit_error"] is None, result_a["circuit_error"]
+        assert qubit_of_input_label(result_a, "a_in") == 0
+        assert qubit_of_input_label(result_a, "b_in") == 1
+
+        # Case B: swap input ranks → b_in is now qubit 0, a_in is qubit 1.
+        port_labels_b = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=1),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=0),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_b = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_b,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_b["ok"] is True, result_b
+        assert result_b["circuit_error"] is None, result_b["circuit_error"]
+        assert qubit_of_input_label(result_b, "a_in") == 1
+        assert qubit_of_input_label(result_b, "b_in") == 0
+
     def test_extract_without_outputs_errors(self):
         result = self._run(
             ZXRequest(


### PR DESCRIPTION
## Summary
- Drag-to-reorder rows in the Ports table; the user's order is persisted as a new optional `PortMeta.rank` field and falls back to spatial sort when no rank is set.
- `/api/zx` now sorts the extracted circuit's qubit register by rank before `pyzx.set_inputs` / `set_outputs`, so the GUI order maps to qubit indices. Swapping two input ranks swaps their roles in the extracted circuit (e.g. control/target of a CNOT).
- `/api/flows` mirrors the server-side sort for parity, so the column order in the Stabilizer Flows table matches the Ports table.

## Test plan
- [ ] Open the Stabilizer flows panel, drag a port row by its grip handle, confirm the row reorders and the highlight insertion line shows above/below the drop target.
- [ ] Click **Compute** → the generator table's input/output columns follow the new order.
- [ ] Open the ZX panel with `simplify` + `extract` on a 2-input / 2-output diagram; swap the two input ranks and verify the qubit indices flip in the QASM output (and in the boundary vertex labels).
- [ ] 10 new automated tests: 4 for `getOrderedPortPositions`, 5 for `reorderPort` store action, 1 server test (`test_extract_qubit_register_follows_port_rank`) covering the rank → qubit-index mapping. All pass alongside the existing 303 GUI + 60 server tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)