### PR TITLE
feat: ground shadow + projection line for elevated ghosts

### DIFF
--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@react-three/test-renderer": "^9.1.0",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1408,6 +1409,18 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-three/test-renderer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@react-three/test-renderer/-/test-renderer-9.1.0.tgz",
+      "integrity": "sha512-bLjG+cdpVW69wG1W3TuziHrHvA1JQbLesYddY94QMaFF8yzpgwovWK8hGaHWBET1dvsCPIOWVNYHbKAbRj2xSg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-three/fiber": ">=9.0.0",
+        "react": "^19.0.0",
+        "three": ">=0.156"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@react-three/test-renderer": "^9.1.0",
     "@types/three": "^0.184.0",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.1.2",

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -26,6 +26,7 @@ import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
 import { SelectModePointer, type ThreeState } from "./components/SelectModePointer";
 import { DragGhost } from "./components/DragGhost";
+import { DragShadow } from "./components/DragShadow";
 import { NavControlsModifier } from "./components/NavControlsModifier";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
 import { FlowsPanel } from "./components/FlowsPanel";
@@ -1072,6 +1073,7 @@ export default function App() {
         {!photoRequest && <LocatePulseHighlight />}
         {!photoRequest && !flowVizMode && <SelectionHighlights />}
         {!photoRequest && !flowVizMode && <DragGhost />}
+        {!photoRequest && !flowVizMode && <DragShadow />}
         {!photoRequest && !flowVizMode && <BuildCursor />}
         {!photoRequest && !flowVizMode && <OpenPipeGhosts />}
       {!photoRequest && (flowsPanelOpen || zxPanelOpen || flowVizMode) && <PortLabels3D />}

--- a/gui/src/components/DragShadow.test.tsx
+++ b/gui/src/components/DragShadow.test.tsx
@@ -1,0 +1,165 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block } from "../types";
+import { DragShadow, MAX_SHADOWS } from "./DragShadow";
+
+function mk(pos: { x: number; y: number; z: number }, type: Block["type"] = "XZZ"): Block {
+  return { pos, type };
+}
+
+function setup(opts: {
+  blocks?: Array<[string, Block]>;
+  selected?: string[];
+  dragDelta?: { x: number; y: number; z: number } | null;
+  dragValid?: boolean;
+}) {
+  useBlockStore.setState(
+    {
+      blocks: new Map(opts.blocks ?? []),
+      selectedKeys: new Set(opts.selected ?? []),
+      dragDelta: opts.dragDelta ?? null,
+      dragValid: opts.dragValid ?? true,
+      isDraggingSelection: opts.dragDelta != null,
+    },
+    false,
+  );
+}
+
+beforeEach(() => {
+  // Hard reset all fields DragShadow reads, plus closely-related drag state.
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      selectedKeys: new Set(),
+      dragDelta: null,
+      dragValid: true,
+      isDraggingSelection: false,
+    },
+    false,
+  );
+});
+
+describe("<DragShadow>", () => {
+  it("renders nothing with empty selection", async () => {
+    setup({});
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("renders one shadow per elevated selected block at rest, none for z=0 blocks", async () => {
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["0,0,3", mk({ x: 0, y: 0, z: 3 })],
+        ["3,0,3", mk({ x: 3, y: 0, z: 3 })],
+      ],
+      selected: ["0,0,0", "0,0,3", "3,0,3"],
+      dragDelta: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // Two elevated blocks -> two GroundShadowAbsolute groups.
+    expect(r.scene.findAllByType("Group")).toHaveLength(2);
+  });
+
+  it("renders nothing if all selected blocks are on the ground", async () => {
+    setup({
+      blocks: [["0,0,0", mk({ x: 0, y: 0, z: 0 })]],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("uses shifted positions when dragDelta is non-zero", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 6, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const group = r.scene.findByType("Group");
+    // Shifted block at (6, 0, 3) -> ground center cx = 6.5, cz = -0.5
+    expect(group.instance.position.x).toBeCloseTo(6.5);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+
+  it("treats {0,0,0} dragDelta as at-rest mode (no shift, neutral validity)", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 0, y: 0, z: 0 },
+      dragValid: false, // would turn red if drag mode kicked in
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const mesh = r.scene.findByType("Mesh");
+    const matColor = (
+      mesh.instance.material as { color: { getHex: () => number } }
+    ).color.getHex();
+    // At-rest -> always-valid -> black mesh, not red
+    expect(matColor).toBe(0x000000);
+  });
+
+  it("renders red shadows when dragValid=false during a real drag", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 3, y: 0, z: 0 },
+      dragValid: false,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const mesh = r.scene.findByType("Mesh");
+    const matColor = (
+      mesh.instance.material as { color: { getHex: () => number } }
+    ).color.getHex();
+    expect(matColor).toBe(0xff5555);
+  });
+
+  it("caps at MAX_SHADOWS for huge selections", async () => {
+    const blocks: Array<[string, Block]> = [];
+    const selected: string[] = [];
+    // Build 250 elevated blocks, all selected
+    for (let i = 0; i < 250; i++) {
+      const key = `${i * 3},0,3`;
+      blocks.push([key, mk({ x: i * 3, y: 0, z: 3 })]);
+      selected.push(key);
+    }
+    setup({ blocks, selected });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(MAX_SHADOWS);
+  });
+
+  it("applies yBlockZOffset to at-rest Y-cube under a pipe (visually lifted)", async () => {
+    // Y-cube at logical z=0 with a pipe at z=1 above it -> visually lifted by 0.5
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")], // Z-open pipe above
+      ],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // With the lift, the Y-cube's effective z is 0.5 -> shadow appears.
+    expect(r.scene.findAllByType("Group")).toHaveLength(1);
+    const line = r.scene.findByType("Line");
+    // Line len = 0.5 - Y_OFFSET ≈ 0.49
+    expect(line.instance.scale.y).toBeCloseTo(0.49, 2);
+  });
+
+  it("does NOT apply yBlockZOffset during drag (mirrors DragGhost behavior)", async () => {
+    // Y-cube being dragged from z=0 to z=3. During drag we use shifted logical
+    // pos (z=3), no lift even if a pipe sits at z=4 in the destination.
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["3,0,4", mk({ x: 3, y: 0, z: 4 }, "ZXO")], // pipe at destination top
+      ],
+      selected: ["0,0,0"],
+      dragDelta: { x: 3, y: 0, z: 3 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const line = r.scene.findByType("Line");
+    // Pure shifted z=3, line len = 3 - Y_OFFSET ≈ 2.99
+    expect(line.instance.scale.y).toBeCloseTo(2.99, 2);
+  });
+});

--- a/gui/src/components/DragShadow.test.tsx
+++ b/gui/src/components/DragShadow.test.tsx
@@ -1,8 +1,13 @@
 import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useBlockStore } from "../stores/blockStore";
 import type { Block } from "../types";
 import { DragShadow, MAX_SHADOWS } from "./DragShadow";
+
+function meshColor(node: { instance: unknown }): number {
+  return ((node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial).color.getHex();
+}
 
 function mk(pos: { x: number; y: number; z: number }, type: Block["type"] = "XZZ"): Block {
   return { pos, type };
@@ -92,12 +97,8 @@ describe("<DragShadow>", () => {
       dragValid: false, // would turn red if drag mode kicked in
     });
     const r = await ReactThreeTestRenderer.create(<DragShadow />);
-    const mesh = r.scene.findByType("Mesh");
-    const matColor = (
-      mesh.instance.material as { color: { getHex: () => number } }
-    ).color.getHex();
     // At-rest -> always-valid -> black mesh, not red
-    expect(matColor).toBe(0x000000);
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0x000000);
   });
 
   it("renders red shadows when dragValid=false during a real drag", async () => {
@@ -108,11 +109,7 @@ describe("<DragShadow>", () => {
       dragValid: false,
     });
     const r = await ReactThreeTestRenderer.create(<DragShadow />);
-    const mesh = r.scene.findByType("Mesh");
-    const matColor = (
-      mesh.instance.material as { color: { getHex: () => number } }
-    ).color.getHex();
-    expect(matColor).toBe(0xff5555);
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0xff5555);
   });
 
   it("caps at MAX_SHADOWS for huge selections", async () => {
@@ -141,7 +138,7 @@ describe("<DragShadow>", () => {
     const r = await ReactThreeTestRenderer.create(<DragShadow />);
     // With the lift, the Y-cube's effective z is 0.5 -> shadow appears.
     expect(r.scene.findAllByType("Group")).toHaveLength(1);
-    const line = r.scene.findByType("Line");
+    const line = r.scene.findByType("LineSegments");
     // Line len = 0.5 - Y_OFFSET ≈ 0.49
     expect(line.instance.scale.y).toBeCloseTo(0.49, 2);
   });
@@ -158,7 +155,7 @@ describe("<DragShadow>", () => {
       dragDelta: { x: 3, y: 0, z: 3 },
     });
     const r = await ReactThreeTestRenderer.create(<DragShadow />);
-    const line = r.scene.findByType("Line");
+    const line = r.scene.findByType("LineSegments");
     // Pure shifted z=3, line len = 3 - Y_OFFSET ≈ 2.99
     expect(line.instance.scale.y).toBeCloseTo(2.99, 2);
   });

--- a/gui/src/components/DragShadow.tsx
+++ b/gui/src/components/DragShadow.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import { useBlockStore } from "../stores/blockStore";
+import { yBlockZOffset } from "../types";
+import type { Block, Position3D } from "../types";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+export const MAX_SHADOWS = 200;
+
+export function DragShadow() {
+  const dragDelta = useBlockStore((s) => s.dragDelta);
+  const dragValid = useBlockStore((s) => s.dragValid);
+  const selectedKeys = useBlockStore((s) => s.selectedKeys);
+  const blocks = useBlockStore((s) => s.blocks);
+
+  // Stable list keyed on selectedKeys/blocks (same pattern as DragGhost) so
+  // rAF-driven dragDelta/dragValid only re-render leaves.
+  const shadows = useMemo(() => {
+    const result: Array<{ key: string; block: Block }> = [];
+    for (const key of selectedKeys) {
+      const block = blocks.get(key);
+      if (!block) continue;
+      result.push({ key, block });
+      if (result.length >= MAX_SHADOWS) break;
+    }
+    return result;
+  }, [selectedKeys, blocks]);
+
+  if (shadows.length === 0) return null;
+
+  // {0,0,0} delta = at-rest mode (treated as null). Drag commits a non-zero
+  // delta the moment the pointer crosses the drag threshold.
+  const liveDelta =
+    dragDelta && (dragDelta.x !== 0 || dragDelta.y !== 0 || dragDelta.z !== 0)
+      ? dragDelta
+      : null;
+  const valid = liveDelta ? dragValid : true;
+
+  return (
+    <>
+      {shadows.map(({ key, block }) => {
+        let pos: Position3D;
+        if (liveDelta) {
+          // Drag mode: shifted logical position, no Y-cube lift (matches
+          // DragGhost which renders the dragged ghost at the logical destination).
+          pos = {
+            x: block.pos.x + liveDelta.x,
+            y: block.pos.y + liveDelta.y,
+            z: block.pos.z + liveDelta.z,
+          };
+        } else {
+          // At-rest mode: committed block is rendered by BlockInstances with
+          // yBlockZOffset applied to Y-cubes that have a pipe above. Mirror
+          // that lift here so the shadow reflects what the user actually SEES,
+          // not the bare logical z.
+          const lift = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+          pos = { ...block.pos, z: block.pos.z + lift };
+        }
+        return (
+          <GroundShadowAbsolute
+            key={key}
+            pos={pos}
+            blockType={block.type}
+            valid={valid}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/gui/src/components/GhostBlock.test.tsx
+++ b/gui/src/components/GhostBlock.test.tsx
@@ -1,0 +1,166 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { GhostBlock } from "./GhostBlock";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+describe("<GhostBlock>", () => {
+  it("renders nothing when hoveredGridPos is null", async () => {
+    useBlockStore.setState({ hoveredGridPos: null }, false);
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in build mode", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, mode: "build" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is pointer", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "pointer" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is paste", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "paste" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders cube ghost only (no shadow) at ground level", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 0 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // The ghost itself is one positioned group + inner scaled group; no second
+    // GroundShadowAbsolute group because z=0 -> shouldRenderShadow false.
+    const groups = r.scene.findAllByType("Group");
+    // 1 outer positioned group + 1 inner scaled group = 2 (no shadow group)
+    expect(groups.length).toBe(2);
+  });
+
+  it("renders cube ghost + GroundShadowAbsolute at z=2", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    const groups = r.scene.findAllByType("Group");
+    // ghost outer + ghost inner-scaled + GroundShadowAbsolute world-positioned group = 3
+    expect(groups.length).toBe(3);
+    // Shadow's mesh and line should be present
+    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+  });
+
+  it("Y-cube placement preview at z=0 with pipe above gets a lifted shadow", async () => {
+    // A Z-open pipe sits at z=1 directly above the hovered Y placement at z=0.
+    // yBlockZOffset returns 0.5 → effective z = 0.5 → shadow renders.
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 0 },
+        armedTool: "cube",
+        cubeType: "Y",
+        blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Without the yBlockZOffset adjustment, no shadow would render (logical z=0).
+    // With it, effective z=0.5 → shadow + line appear.
+    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+  });
+
+  it("port placement preview at z=2 renders port ghost + GroundShadow", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "port" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Port ghost positioned group + GroundShadowAbsolute group = 2
+    const groups = r.scene.findAllByType("Group");
+    expect(groups.length).toBe(2);
+    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+  });
+
+  it("isInvalid hover at z=2 renders red shadow (invalid color)", async () => {
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        hoveredInvalid: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    const line = r.scene.findByType("Line");
+    const lineColor = (
+      line.instance.material as { color: { getHex: () => number } }
+    ).color.getHex();
+    // Invalid line color = #ff0000
+    expect(lineColor).toBe(0xff0000);
+  });
+
+  it("isDelete (xHeld in edit mode) renders delete preview but NO shadow", async () => {
+    // xHeld + edit mode = isDelete. We render the existing block being targeted
+    // for removal in red, but explicitly do NOT add a ground shadow (it's a
+    // "remove this" cue, not a "place here" cue).
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        xHeld: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.findAllByType("Line")).toHaveLength(0);
+  });
+});

--- a/gui/src/components/GhostBlock.test.tsx
+++ b/gui/src/components/GhostBlock.test.tsx
@@ -1,4 +1,5 @@
 import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useBlockStore } from "../stores/blockStore";
 import type { Block, BlockType, Position3D } from "../types";
@@ -94,8 +95,8 @@ describe("<GhostBlock>", () => {
     const groups = r.scene.findAllByType("Group");
     // ghost outer + ghost inner-scaled + GroundShadowAbsolute world-positioned group = 3
     expect(groups.length).toBe(3);
-    // Shadow's mesh and line should be present
-    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+    // 2 LineSegments: ghost-block edges (existing) + shadow projection line (new).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
   });
 
   it("Y-cube placement preview at z=0 with pipe above gets a lifted shadow", async () => {
@@ -112,8 +113,9 @@ describe("<GhostBlock>", () => {
     );
     const r = await ReactThreeTestRenderer.create(<GhostBlock />);
     // Without the yBlockZOffset adjustment, no shadow would render (logical z=0).
-    // With it, effective z=0.5 → shadow + line appear.
-    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+    // With it, effective z=0.5 → shadow + line appear. 2 LineSegments total:
+    // ghost-block edges + shadow projection line.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
   });
 
   it("port placement preview at z=2 renders port ghost + GroundShadow", async () => {
@@ -125,7 +127,8 @@ describe("<GhostBlock>", () => {
     // Port ghost positioned group + GroundShadowAbsolute group = 2
     const groups = r.scene.findAllByType("Group");
     expect(groups.length).toBe(2);
-    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+    // port-ghost edges (existing) + shadow line (new) = 2 LineSegments.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
   });
 
   it("isInvalid hover at z=2 renders red shadow (invalid color)", async () => {
@@ -139,12 +142,15 @@ describe("<GhostBlock>", () => {
       false,
     );
     const r = await ReactThreeTestRenderer.create(<GhostBlock />);
-    const line = r.scene.findByType("Line");
-    const lineColor = (
-      line.instance.material as { color: { getHex: () => number } }
-    ).color.getHex();
-    // Invalid line color = #ff0000
-    expect(lineColor).toBe(0xff0000);
+    // Both the ghost edges and the shadow line render in red for invalid hover.
+    // GhostBlock uses #ff0000 lineMaterial; GroundShadowAbsolute uses #ff0000.
+    // Assert all LineSegments are red.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
   });
 
   it("isDelete (xHeld in edit mode) renders delete preview but NO shadow", async () => {
@@ -161,6 +167,7 @@ describe("<GhostBlock>", () => {
       false,
     );
     const r = await ReactThreeTestRenderer.create(<GhostBlock />);
-    expect(r.scene.findAllByType("Line")).toHaveLength(0);
+    // Delete branch renders only a mesh (no edges). No shadow either.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(0);
   });
 });

--- a/gui/src/components/GhostBlock.tsx
+++ b/gui/src/components/GhostBlock.tsx
@@ -13,6 +13,7 @@ import { isoTopThreeAxis } from "../utils/isoFoldOut";
 import type { ThreeAxis } from "../utils/isoFoldOut";
 import { getCachedGeometry, getCachedEdges, getCachedFullBox } from "./BlockInstances";
 import { FoldOutCubeFaces } from "./FoldOutCube";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
 
 const noRaycast = () => {};
 
@@ -116,16 +117,19 @@ function GhostBlockInner() {
   if (armedTool === "port" && mode === "edit" && !xHeld) {
     const [x, y, z] = tqecToThree(hoveredGridPos, "XZZ");
     return (
-      <group position={[x, y, z]}>
-        <mesh raycast={noRaycast}>
-          <primitive object={portGhostBox} attach="geometry" />
-          <primitive object={portGhostMaterial} attach="material" />
-        </mesh>
-        <lineSegments raycast={noRaycast}>
-          <primitive object={portGhostEdges} attach="geometry" />
-          <primitive object={validLineMaterial} attach="material" />
-        </lineSegments>
-      </group>
+      <>
+        <group position={[x, y, z]}>
+          <mesh raycast={noRaycast}>
+            <primitive object={portGhostBox} attach="geometry" />
+            <primitive object={portGhostMaterial} attach="material" />
+          </mesh>
+          <lineSegments raycast={noRaycast}>
+            <primitive object={portGhostEdges} attach="geometry" />
+            <primitive object={validLineMaterial} attach="material" />
+          </lineSegments>
+        </group>
+        <GroundShadowAbsolute pos={hoveredGridPos} blockType="XZZ" valid />
+      </>
     );
   }
 
@@ -178,39 +182,54 @@ function GhostBlockInner() {
     (CUBE_TYPES as readonly string[]).includes(activeType);
   const foldTopAxis: ThreeAxis = viewMode.kind === "iso" ? isoTopThreeAxis(viewMode.axis) : 0;
 
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // a Y-cube placement preview lifted by an above pipe still gets a shadow
+  // whose projection line reaches the rendered block bottom. No shadow for
+  // delete previews — that's a "remove this" cue, not a "place here" cue.
+  const shadowPos = { ...hoveredGridPos, z: hoveredGridPos.z + zo };
+
   return (
-    <group position={[x, y, z]}>
-      {isDelete ? (
-        <mesh scale={1.01} raycast={noRaycast}>
-          <primitive object={getCachedFullBox(activeType)} attach="geometry" />
-          <primitive object={deleteMaterial} attach="material" />
-        </mesh>
-      ) : (
-        <group scale={scale}>
-          {!showFoldOutCube && (
-            <>
-              <mesh>
-                <primitive object={ghostGeometry} attach="geometry" />
-                <primitive object={meshMat} attach="material" />
-              </mesh>
-              <lineSegments>
-                <primitive object={ghostEdges} attach="geometry" />
-                <primitive object={lineMat} attach="material" />
+    <>
+      <group position={[x, y, z]}>
+        {isDelete ? (
+          <mesh scale={1.01} raycast={noRaycast}>
+            <primitive object={getCachedFullBox(activeType)} attach="geometry" />
+            <primitive object={deleteMaterial} attach="material" />
+          </mesh>
+        ) : (
+          <group scale={scale}>
+            {!showFoldOutCube && (
+              <>
+                <mesh>
+                  <primitive object={ghostGeometry} attach="geometry" />
+                  <primitive object={meshMat} attach="material" />
+                </mesh>
+                <lineSegments>
+                  <primitive object={ghostEdges} attach="geometry" />
+                  <primitive object={lineMat} attach="material" />
+                </lineSegments>
+              </>
+            )}
+            {fullPipeEdges && (
+              <lineSegments scale={1.04} renderOrder={999}>
+                <primitive object={fullPipeEdges} attach="geometry" />
+                <primitive object={depthPipeOutlineMaterial} attach="material" />
               </lineSegments>
-            </>
-          )}
-          {fullPipeEdges && (
-            <lineSegments scale={1.04} renderOrder={999}>
-              <primitive object={fullPipeEdges} attach="geometry" />
-              <primitive object={depthPipeOutlineMaterial} attach="material" />
-            </lineSegments>
-          )}
-          {showFoldOutCube && (
-            <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
-          )}
-        </group>
+            )}
+            {showFoldOutCube && (
+              <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
+            )}
+          </group>
+        )}
+      </group>
+      {!isDelete && (
+        <GroundShadowAbsolute
+          pos={shadowPos}
+          blockType={activeType}
+          valid={!isInvalid}
+        />
       )}
-    </group>
+    </>
   );
 }
 

--- a/gui/src/components/GroundShadowAbsolute.test.tsx
+++ b/gui/src/components/GroundShadowAbsolute.test.tsx
@@ -1,0 +1,100 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import { describe, expect, it } from "vitest";
+import {
+  INVALID_LINE_COLOR,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+} from "../utils/groundShadow";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+describe("<GroundShadowAbsolute>", () => {
+  it("renders nothing when on the ground (z=0)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 0 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing when below ground (defensive)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: -1 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders a group + mesh + line for an elevated cube", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 3, y: 6, z: 2 }} blockType="XZZ" valid />,
+    );
+    const groups = r.scene.findAllByType("Group");
+    expect(groups).toHaveLength(1);
+    const group = groups[0];
+    // World-space group at (cx, 0, cz) = (3.5, 0, -6.5)
+    expect(group.instance.position.x).toBeCloseTo(3.5);
+    expect(group.instance.position.y).toBeCloseTo(0);
+    expect(group.instance.position.z).toBeCloseTo(-6.5);
+    // Mesh + line live inside the group
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(1);
+    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+  });
+
+  it("rotates mesh -PI/2 around X (lays plane flat) and lifts by Y_OFFSET", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="XZZ" valid />,
+    );
+    const mesh = r.scene.findByType("Mesh");
+    expect(mesh.instance.rotation.x).toBeCloseTo(-Math.PI / 2);
+    expect(mesh.instance.position.y).toBeCloseTo(Y_OFFSET);
+  });
+
+  it("scales line to (1, lineLen, 1) so the unit-vertical geom spans block bottom", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 5 }} blockType="XZZ" valid />,
+    );
+    const line = r.scene.findByType("Line");
+    expect(line.instance.scale.x).toBe(1);
+    expect(line.instance.scale.y).toBeCloseTo(5 - Y_OFFSET);
+    expect(line.instance.scale.z).toBe(1);
+  });
+
+  it("uses valid colors and full opacity at z=1 (no fade)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 1 }} blockType="XZZ" valid />,
+    );
+    const mesh = r.scene.findByType("Mesh");
+    const line = r.scene.findByType("Line");
+    // R3F mounts the inline material as instance.material; cast to read color
+    const meshMat = mesh.instance.material as { color: { getHex: () => number }; opacity: number };
+    const lineMat = line.instance.material as { color: { getHex: () => number }; opacity: number };
+    expect(meshMat.color.getHex()).toBe(VALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(VALID_LINE_COLOR);
+    expect(meshMat.opacity).toBeCloseTo(VALID_MESH_OPACITY);
+  });
+
+  it("uses invalid red colors and full (non-faded) opacity when valid=false", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 30 }} blockType="XZZ" valid={false} />,
+    );
+    const mesh = r.scene.findByType("Mesh");
+    const line = r.scene.findByType("Line");
+    const meshMat = mesh.instance.material as { color: { getHex: () => number }; opacity: number };
+    const lineMat = line.instance.material as { color: { getHex: () => number }; opacity: number };
+    expect(meshMat.color.getHex()).toBe(INVALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(INVALID_LINE_COLOR);
+    // Invalid skips elevation falloff: full base opacity even at z=30
+    expect(meshMat.opacity).toBe(INVALID_MESH_OPACITY);
+  });
+
+  it("respects pipe footprint dims (X-open pipe centers at offset 1, 0.5)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="OZX" valid />,
+    );
+    const group = r.scene.findByType("Group");
+    expect(group.instance.position.x).toBeCloseTo(1);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+});

--- a/gui/src/components/GroundShadowAbsolute.test.tsx
+++ b/gui/src/components/GroundShadowAbsolute.test.tsx
@@ -1,4 +1,5 @@
 import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
 import { describe, expect, it } from "vitest";
 import {
   INVALID_LINE_COLOR,
@@ -10,6 +11,13 @@ import {
   Y_OFFSET,
 } from "../utils/groundShadow";
 import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+function meshMaterial(node: { instance: unknown }): THREE.MeshBasicMaterial {
+  return (node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial;
+}
+function lineMaterial(node: { instance: unknown }): THREE.LineBasicMaterial {
+  return (node.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+}
 
 describe("<GroundShadowAbsolute>", () => {
   it("renders nothing when on the ground (z=0)", async () => {
@@ -39,7 +47,7 @@ describe("<GroundShadowAbsolute>", () => {
     expect(group.instance.position.z).toBeCloseTo(-6.5);
     // Mesh + line live inside the group
     expect(r.scene.findAllByType("Mesh")).toHaveLength(1);
-    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(1);
   });
 
   it("rotates mesh -PI/2 around X (lays plane flat) and lifts by Y_OFFSET", async () => {
@@ -55,7 +63,7 @@ describe("<GroundShadowAbsolute>", () => {
     const r = await ReactThreeTestRenderer.create(
       <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 5 }} blockType="XZZ" valid />,
     );
-    const line = r.scene.findByType("Line");
+    const line = r.scene.findByType("LineSegments");
     expect(line.instance.scale.x).toBe(1);
     expect(line.instance.scale.y).toBeCloseTo(5 - Y_OFFSET);
     expect(line.instance.scale.z).toBe(1);
@@ -65,11 +73,8 @@ describe("<GroundShadowAbsolute>", () => {
     const r = await ReactThreeTestRenderer.create(
       <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 1 }} blockType="XZZ" valid />,
     );
-    const mesh = r.scene.findByType("Mesh");
-    const line = r.scene.findByType("Line");
-    // R3F mounts the inline material as instance.material; cast to read color
-    const meshMat = mesh.instance.material as { color: { getHex: () => number }; opacity: number };
-    const lineMat = line.instance.material as { color: { getHex: () => number }; opacity: number };
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
     expect(meshMat.color.getHex()).toBe(VALID_SHADOW_COLOR);
     expect(lineMat.color.getHex()).toBe(VALID_LINE_COLOR);
     expect(meshMat.opacity).toBeCloseTo(VALID_MESH_OPACITY);
@@ -79,10 +84,8 @@ describe("<GroundShadowAbsolute>", () => {
     const r = await ReactThreeTestRenderer.create(
       <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 30 }} blockType="XZZ" valid={false} />,
     );
-    const mesh = r.scene.findByType("Mesh");
-    const line = r.scene.findByType("Line");
-    const meshMat = mesh.instance.material as { color: { getHex: () => number }; opacity: number };
-    const lineMat = line.instance.material as { color: { getHex: () => number }; opacity: number };
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
     expect(meshMat.color.getHex()).toBe(INVALID_SHADOW_COLOR);
     expect(lineMat.color.getHex()).toBe(INVALID_LINE_COLOR);
     // Invalid skips elevation falloff: full base opacity even at z=30

--- a/gui/src/components/GroundShadowAbsolute.tsx
+++ b/gui/src/components/GroundShadowAbsolute.tsx
@@ -76,7 +76,7 @@ export function GroundShadowAbsolute({
           side={THREE.DoubleSide}
         />
       </mesh>
-      <line
+      <lineSegments
         position={[0, Y_OFFSET, 0]}
         scale={[1, v.lineLen, 1]}
         geometry={lineGeom}
@@ -88,7 +88,7 @@ export function GroundShadowAbsolute({
           opacity={v.lineOpacity}
           depthWrite={false}
         />
-      </line>
+      </lineSegments>
     </group>
   );
 }

--- a/gui/src/components/GroundShadowAbsolute.tsx
+++ b/gui/src/components/GroundShadowAbsolute.tsx
@@ -1,0 +1,94 @@
+import * as THREE from "three";
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+import { shadowVisuals, shouldRenderShadow, Y_OFFSET } from "../utils/groundShadow";
+
+// PERF NOTE: Per-instance materials (inline JSX) chosen for simplicity and
+// per-elevation opacity. Worst case ~800 materials in flight at MAX_SHADOWS=200
+// across 4 call sites — fine at typical scale. If perf becomes a problem at
+// extreme selection sizes, swap for InstancedMesh + per-instance opacity
+// vertex attribute. See TODOS.md (perf-shadows).
+
+const noRaycast = () => {};
+
+const planeCache = new Map<string, THREE.PlaneGeometry>();
+function getPlane(sx: number, sy: number): THREE.PlaneGeometry {
+  const key = `${sx}x${sy}`;
+  let g = planeCache.get(key);
+  if (!g) {
+    g = new THREE.PlaneGeometry(sx, sy);
+    planeCache.set(key, g);
+  }
+  return g;
+}
+
+const lineGeom = new THREE.BufferGeometry().setFromPoints([
+  new THREE.Vector3(0, 0, 0),
+  new THREE.Vector3(0, 1, 0),
+]);
+
+/**
+ * Ground-projected shadow + vertical anchor line for an elevated block.
+ *
+ * WORLD-SPACE COMPONENT — the `Absolute` suffix is a contract.
+ *
+ * This component positions itself in WORLD coordinates derived from `pos`.
+ * Do NOT render it inside a positioned `<group>` wrapper — the positions will
+ * compound and the shadow will end up at the wrong cell on the ground.
+ *
+ * Correct (rendered as a sibling of the positioned ghost):
+ *   return <>
+ *     <group position={[x, y, z]}><mesh>...</mesh></group>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />
+ *   </>;
+ *
+ * Wrong (nested — positions compound, shadow ends up offset by [x, y, z]):
+ *   return <group position={[x, y, z]}>
+ *     <mesh>...</mesh>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />   // <-- bug
+ *   </group>;
+ */
+export function GroundShadowAbsolute({
+  pos,
+  blockType,
+  valid,
+}: {
+  pos: Position3D;
+  blockType: BlockType;
+  valid: boolean;
+}) {
+  if (!shouldRenderShadow(pos)) return null;
+  const [sx, sy] = blockTqecSize(blockType);
+  const v = shadowVisuals(pos, blockType, valid);
+
+  return (
+    <group position={[v.cx, 0, v.cz]}>
+      <mesh
+        position={[0, Y_OFFSET, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        geometry={getPlane(sx, sy)}
+        raycast={noRaycast}
+      >
+        <meshBasicMaterial
+          color={v.meshColor}
+          transparent
+          opacity={v.meshOpacity}
+          depthWrite={false}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      <line
+        position={[0, Y_OFFSET, 0]}
+        scale={[1, v.lineLen, 1]}
+        geometry={lineGeom}
+        raycast={noRaycast}
+      >
+        <lineBasicMaterial
+          color={v.lineColor}
+          transparent
+          opacity={v.lineOpacity}
+          depthWrite={false}
+        />
+      </line>
+    </group>
+  );
+}

--- a/gui/src/components/PasteGhost.test.tsx
+++ b/gui/src/components/PasteGhost.test.tsx
@@ -1,4 +1,5 @@
 import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useBlockStore } from "../stores/blockStore";
 import type { Block, BlockType, Position3D } from "../types";
@@ -39,7 +40,7 @@ beforeEach(() => {
 });
 
 function setPaste(opts: {
-  clipboard?: Map<string, Block>;
+  clipboard?: Map<string, Block> | null;
   hoveredGridPos?: Position3D | null;
   blocks?: Map<string, Block>;
 }) {
@@ -93,9 +94,10 @@ describe("<PasteGhost>", () => {
       hoveredGridPos: { x: 0, y: 0, z: 0 },
     });
     const r = await ReactThreeTestRenderer.create(<PasteGhost />);
-    // 2 ghost meshes; no Lines because no GroundShadowAbsolute fires at z=0.
+    // 2 ghost meshes; ghost edges (LineSegments) for each = 2 LineSegments.
+    // No shadows because z=0.
     expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
-    expect(r.scene.findAllByType("Line")).toHaveLength(0);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
   });
 
   it("renders shadow + projection line for elevated paste-ghost block", async () => {
@@ -104,9 +106,9 @@ describe("<PasteGhost>", () => {
       hoveredGridPos: { x: 0, y: 0, z: 0 },
     });
     const r = await ReactThreeTestRenderer.create(<PasteGhost />);
-    // 1 ghost mesh + 1 shadow mesh = 2; 1 projection line
+    // 1 ghost mesh + 1 shadow mesh = 2; ghost edges + shadow line = 2 LineSegments.
     expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
-    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
   });
 
   it("turns shadow red when paste collides with existing block", async () => {
@@ -116,11 +118,13 @@ describe("<PasteGhost>", () => {
       blocks: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]), // collision
     });
     const r = await ReactThreeTestRenderer.create(<PasteGhost />);
-    const line = r.scene.findByType("Line");
-    const lineColor = (
-      line.instance.material as { color: { getHex: () => number } }
-    ).color.getHex();
-    expect(lineColor).toBe(0xff0000);
+    // Both ghost edges and shadow line should be red on collision.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
   });
 
   it("Y-cube paste at z=0 with pipe above gets a lifted shadow", async () => {
@@ -132,7 +136,8 @@ describe("<PasteGhost>", () => {
       blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
     });
     const r = await ReactThreeTestRenderer.create(<PasteGhost />);
-    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+    // ghost edges + shadow line = 2 LineSegments (shadow renders thanks to yBlockZOffset).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
   });
 
   it("caps clipboard at 200 entries (MAX_PASTE_SHADOWS)", async () => {
@@ -146,8 +151,9 @@ describe("<PasteGhost>", () => {
       hoveredGridPos: { x: 0, y: 0, z: 0 },
     });
     const r = await ReactThreeTestRenderer.create(<PasteGhost />);
-    // 200 paste-ghost meshes + 200 shadow meshes = 400 total
+    // 200 paste-ghost meshes + 200 shadow meshes = 400 total.
+    // 200 ghost edges + 200 shadow lines = 400 LineSegments.
     expect(r.scene.findAllByType("Mesh")).toHaveLength(400);
-    expect(r.scene.findAllByType("Line")).toHaveLength(200);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(400);
   });
 });

--- a/gui/src/components/PasteGhost.test.tsx
+++ b/gui/src/components/PasteGhost.test.tsx
@@ -1,0 +1,153 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { PasteGhost } from "./PasteGhost";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+function setPaste(opts: {
+  clipboard?: Map<string, Block>;
+  hoveredGridPos?: Position3D | null;
+  blocks?: Map<string, Block>;
+}) {
+  useBlockStore.setState(
+    {
+      armedTool: "paste",
+      mode: "edit",
+      clipboard: opts.clipboard ?? null,
+      hoveredGridPos: opts.hoveredGridPos ?? null,
+      blocks: opts.blocks ?? new Map(),
+    },
+    false,
+  );
+}
+
+describe("<PasteGhost>", () => {
+  it("renders nothing when armedTool is not paste", async () => {
+    useBlockStore.setState(
+      {
+        armedTool: "cube",
+        clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+        hoveredGridPos: { x: 3, y: 0, z: 0 },
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing with empty/null clipboard", async () => {
+    setPaste({ clipboard: null, hoveredGridPos: { x: 0, y: 0, z: 0 } });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing without a hovered grid pos", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+      hoveredGridPos: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders one paste-ghost per clipboard entry at z=0 (no shadows)", async () => {
+    setPaste({
+      clipboard: new Map([
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["3,0,0", mk({ x: 3, y: 0, z: 0 })],
+      ]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 2 ghost meshes; no Lines because no GroundShadowAbsolute fires at z=0.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("Line")).toHaveLength(0);
+  });
+
+  it("renders shadow + projection line for elevated paste-ghost block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 1 ghost mesh + 1 shadow mesh = 2; 1 projection line
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+  });
+
+  it("turns shadow red when paste collides with existing block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]), // collision
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    const line = r.scene.findByType("Line");
+    const lineColor = (
+      line.instance.material as { color: { getHex: () => number } }
+    ).color.getHex();
+    expect(lineColor).toBe(0xff0000);
+  });
+
+  it("Y-cube paste at z=0 with pipe above gets a lifted shadow", async () => {
+    // Clipboard contains a Y-cube at z=0; paste destination has a pipe at z=1
+    // directly above. yBlockZOffset returns 0.5 -> shadow renders.
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.findAllByType("Line")).toHaveLength(1);
+  });
+
+  it("caps clipboard at 200 entries (MAX_PASTE_SHADOWS)", async () => {
+    // Build a clipboard with 250 elevated blocks
+    const big = new Map<string, Block>();
+    for (let i = 0; i < 250; i++) {
+      big.set(`${i * 3},0,3`, mk({ x: i * 3, y: 0, z: 3 }));
+    }
+    setPaste({
+      clipboard: big,
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 200 paste-ghost meshes + 200 shadow meshes = 400 total
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(400);
+    expect(r.scene.findAllByType("Line")).toHaveLength(200);
+  });
+});

--- a/gui/src/components/PasteGhost.tsx
+++ b/gui/src/components/PasteGhost.tsx
@@ -4,6 +4,9 @@ import { useBlockStore } from "../stores/blockStore";
 import { tqecToThree, yBlockZOffset, isValidPos } from "../types";
 import type { Block, Position3D } from "../types";
 import { getCachedGeometry, getCachedEdges } from "./BlockInstances";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+const MAX_PASTE_SHADOWS = 200;
 
 const noRaycast = () => {};
 
@@ -57,7 +60,7 @@ export function PasteGhost() {
 
   const entries = useMemo(() => {
     if (!clipboard) return null;
-    return Array.from(clipboard.values());
+    return Array.from(clipboard.values()).slice(0, MAX_PASTE_SHADOWS);
   }, [clipboard]);
 
   if (mode !== "edit" || armedTool !== "paste" || !hoveredGridPos || !entries) {
@@ -103,17 +106,23 @@ function PasteGhostBlock({
   const [x, y, z] = tqecToThree(worldPos, block.type, zo);
   const meshMat = collides ? invalidMaterial : pasteMaterial;
   const lineMat = collides ? invalidLineMaterial : pasteLineMaterial;
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // shadow + projection line align with what the user sees.
+  const shadowPos = { ...worldPos, z: worldPos.z + zo };
 
   return (
-    <group position={[x, y, z]}>
-      <mesh raycast={noRaycast}>
-        <primitive object={geometry} attach="geometry" />
-        <primitive object={meshMat} attach="material" />
-      </mesh>
-      <lineSegments raycast={noRaycast}>
-        <primitive object={edges} attach="geometry" />
-        <primitive object={lineMat} attach="material" />
-      </lineSegments>
-    </group>
+    <>
+      <group position={[x, y, z]}>
+        <mesh raycast={noRaycast}>
+          <primitive object={geometry} attach="geometry" />
+          <primitive object={meshMat} attach="material" />
+        </mesh>
+        <lineSegments raycast={noRaycast}>
+          <primitive object={edges} attach="geometry" />
+          <primitive object={lineMat} attach="material" />
+        </lineSegments>
+      </group>
+      <GroundShadowAbsolute pos={shadowPos} blockType={block.type} valid={!collides} />
+    </>
   );
 }

--- a/gui/src/utils/groundShadow.test.ts
+++ b/gui/src/utils/groundShadow.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  ELEVATION_FALLOFF_FLOOR,
+  GROUND_EPSILON,
+  INVALID_LINE_COLOR,
+  INVALID_LINE_OPACITY,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_LINE_OPACITY,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+  elevationFactor,
+  shadowVisuals,
+  shouldRenderShadow,
+} from "./groundShadow";
+
+describe("shouldRenderShadow", () => {
+  it.each<[number, boolean, string]>([
+    [0, false, "exactly on ground"],
+    [GROUND_EPSILON, false, "exactly at GROUND_EPSILON"],
+    [0.001, true, "just above epsilon"],
+    [1, true, "z=1 cube above ground"],
+    [30, true, "very tall block"],
+    [-1, false, "below ground (defensive)"],
+    [-0.5, false, "Y-cube below ground (defensive)"],
+  ])("z=%s -> %s (%s)", (z, expected) => {
+    expect(shouldRenderShadow({ x: 0, y: 0, z })).toBe(expected);
+  });
+});
+
+describe("elevationFactor", () => {
+  it("returns 1 at z=0 (no fade below z=1)", () => {
+    expect(elevationFactor(0)).toBe(1);
+  });
+
+  it("returns 1 at z=1 (full opacity baseline)", () => {
+    expect(elevationFactor(1)).toBe(1);
+  });
+
+  it("decreases monotonically between z=1 and z=30", () => {
+    let prev = elevationFactor(1);
+    for (let z = 2; z <= 30; z++) {
+      const cur = elevationFactor(z);
+      expect(cur).toBeLessThanOrEqual(prev);
+      prev = cur;
+    }
+  });
+
+  it("hits the floor at high z and stays there", () => {
+    // Pure formula at z=30 = 1/3.32 = 0.301, just above floor.
+    // Floor engages around z=30.17. Test slightly past that point.
+    expect(elevationFactor(31)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(50)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(100)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("floors at ELEVATION_FALLOFF_FLOOR even at z=10000", () => {
+    expect(elevationFactor(10000)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("z=8 ~ 0.61 (sanity-check the curve)", () => {
+    expect(elevationFactor(8)).toBeCloseTo(0.6410, 3);
+  });
+
+  it("z=16 ~ 0.45", () => {
+    expect(elevationFactor(16)).toBeCloseTo(0.4545, 3);
+  });
+});
+
+describe("shadowVisuals", () => {
+  describe("footprint sizing", () => {
+    it("centers a 1x1 cube at (pos.x + 0.5, -(pos.y + 0.5))", () => {
+      const v = shadowVisuals({ x: 3, y: 6, z: 2 }, "XZZ", true);
+      expect(v.cx).toBe(3.5);
+      expect(v.cz).toBe(-6.5);
+    });
+
+    it("uses 2x1 footprint for X-open pipe (OZX): cx offset 1, cz offset 0.5", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "OZX", true);
+      // OZX is [2, 1, 1] in TQEC -> ground footprint sx=2, sy=1
+      expect(v.cx).toBe(1);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x2 footprint for Y-open pipe (ZOX): cx offset 0.5, cz offset 1", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZOX", true);
+      // ZOX is [1, 2, 1] in TQEC -> ground footprint sx=1, sy=2
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-1);
+    });
+
+    it("uses 1x1 footprint for Z-open pipe (ZXO)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZXO", true);
+      // ZXO is [1, 1, 2] in TQEC -> ground footprint sx=1, sy=1 (z is open axis)
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x1 footprint for Y half-cube (sz=0.5 ignored for ground)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+  });
+
+  describe("lineLen", () => {
+    it("uses pos.z (block bottom), not pos.z + sz (block top)", () => {
+      // Y half-cube at z=2: top is at 2.5, but lineLen must use 2.
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.lineLen).toBeCloseTo(2 - Y_OFFSET, 6);
+    });
+
+    it("computes correctly for a tall block", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.lineLen).toBeCloseTo(8 - Y_OFFSET, 6);
+    });
+  });
+
+  describe("opacity & elevation falloff", () => {
+    it("applies falloff to valid mesh+line opacity", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * elevationFactor(8), 6);
+      expect(v.lineOpacity).toBeCloseTo(VALID_LINE_OPACITY * elevationFactor(8), 6);
+    });
+
+    it("does NOT apply falloff when valid=false (full strength)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 30 }, "XZZ", false);
+      expect(v.meshOpacity).toBe(INVALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(INVALID_LINE_OPACITY);
+    });
+
+    it("at z=1, valid mesh opacity == VALID_MESH_OPACITY (no fade)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 1 }, "XZZ", true);
+      expect(v.meshOpacity).toBe(VALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(VALID_LINE_OPACITY);
+    });
+
+    it("at high z, valid mesh opacity hits floor (30% of base)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 50 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * ELEVATION_FALLOFF_FLOOR, 6);
+    });
+  });
+
+  describe("colors", () => {
+    it("uses #000/#000 for valid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", true);
+      expect(v.meshColor).toBe(VALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(VALID_LINE_COLOR);
+    });
+
+    it("uses #ff5555/#ff0000 for invalid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", false);
+      expect(v.meshColor).toBe(INVALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(INVALID_LINE_COLOR);
+    });
+  });
+});

--- a/gui/src/utils/groundShadow.ts
+++ b/gui/src/utils/groundShadow.ts
@@ -1,0 +1,77 @@
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+
+export const GROUND_EPSILON = 1e-4;
+export const Y_OFFSET = 0.01;
+export const ELEVATION_FALLOFF_FLOOR = 0.30;
+
+// Match DragGhost's red palette for invalid:
+//   shadow color #ff5555 (DragGhost mesh, gui/src/components/DragGhost.tsx:23)
+//   line   color #ff0000 (DragGhost edges, gui/src/components/DragGhost.tsx:30)
+export const VALID_MESH_OPACITY = 0.28;
+export const INVALID_MESH_OPACITY = 0.30;
+export const VALID_LINE_OPACITY = 0.22;
+export const INVALID_LINE_OPACITY = 0.28;
+
+export const VALID_SHADOW_COLOR = 0x000000;
+export const INVALID_SHADOW_COLOR = 0xff5555;
+export const VALID_LINE_COLOR = 0x000000;
+export const INVALID_LINE_COLOR = 0xff0000;
+
+/** True when the block is sufficiently above the ground to deserve a shadow. */
+export function shouldRenderShadow(pos: Position3D): boolean {
+  return pos.z > GROUND_EPSILON;
+}
+
+/**
+ * Elevation falloff factor. Asymptotic, floored at ELEVATION_FALLOFF_FLOOR
+ * so the shadow always remains visible even on very tall TQEC graphs.
+ *  z=1  -> 1.00   (full)
+ *  z=8  -> 0.64
+ *  z=16 -> 0.45
+ *  z=30 -> 0.30   (floor)
+ */
+export function elevationFactor(z: number): number {
+  const raw = 1 / (1 + Math.max(0, z - 1) * 0.08);
+  return Math.max(raw, ELEVATION_FALLOFF_FLOOR);
+}
+
+export interface ShadowVisuals {
+  cx: number;
+  cz: number;
+  lineLen: number;
+  meshOpacity: number;
+  lineOpacity: number;
+  meshColor: number;
+  lineColor: number;
+}
+
+/**
+ * Derive everything a GroundShadowAbsolute needs to render from inputs.
+ *
+ * Coordinate convention: TQEC pos.z is the block's bottom in three.js Y
+ * (since tqecToThree maps TQEC Z -> three.js Y and adds sz/2 from the base).
+ * The shadow's ground-plane center is offset by sx/2, sy/2 from pos in the
+ * XZ plane (with TQEC Y negated to match three.js -Z).
+ *
+ * NOTE: caller is responsible for the shouldRenderShadow gate; this fn
+ * computes visuals unconditionally so tests can exercise the math at z=0.
+ */
+export function shadowVisuals(
+  pos: Position3D,
+  blockType: BlockType,
+  valid: boolean,
+): ShadowVisuals {
+  const [sx, sy] = blockTqecSize(blockType);
+  // Valid shadows fade with elevation; invalid stays full strength so the
+  // conflict signal remains legible at any height.
+  const fade = valid ? elevationFactor(pos.z) : 1;
+  return {
+    cx: pos.x + sx / 2,
+    cz: -(pos.y + sy / 2),
+    lineLen: pos.z - Y_OFFSET,
+    meshOpacity: (valid ? VALID_MESH_OPACITY : INVALID_MESH_OPACITY) * fade,
+    lineOpacity: (valid ? VALID_LINE_OPACITY : INVALID_LINE_OPACITY) * fade,
+    meshColor: valid ? VALID_SHADOW_COLOR : INVALID_SHADOW_COLOR,
+    lineColor: valid ? VALID_LINE_COLOR : INVALID_LINE_COLOR,
+  };
+}

--- a/gui/vitest.config.ts
+++ b/gui/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });


### PR DESCRIPTION
## Summary

When you drag (or just have selected) blocks at z>0, it's hard to see exactly where they sit on the X/Y grid. This PR adds a flat ground shadow + thin vertical projection line under every elevated translucent ghost — selection drag, selection at-rest, single-block placement preview, and multi-block paste preview — so the landing cell is always visible.

## Visual treatment

- Dark semi-transparent quad on the ground at y≈0
- Thin vertical line from block bottom to shadow center
- **Valid:** dark/black with elevation falloff (asymptotic, floored at 30% so very tall stacks still show a visible shadow)
- **Invalid:** red (`#ff5555` mesh, `#ff0000` line — matches DragGhost convention), no falloff so the conflict signal stays legible at any height
- Y-cubes that are visually lifted by an above pipe (`yBlockZOffset` +0.5) get the lift baked into the shadow position too

## Architecture

- `gui/src/utils/groundShadow.ts` — pure helpers (`shouldRenderShadow`, `elevationFactor`, `shadowVisuals`)
- `gui/src/components/GroundShadowAbsolute.tsx` — world-space rendering shell (must be a sibling of positioned ghost wrappers, never nested — JSDoc spells out the contract)
- `gui/src/components/DragShadow.tsx` — selection iteration, capped at 200, drag-shifted vs at-rest modes
- `GhostBlock.tsx` and `PasteGhost.tsx` — render `<GroundShadowAbsolute>` alongside their existing ghosts; `PasteGhost` now also caps at 200 entries (pre-existing risk amplified by adding shadows)
- `App.tsx` — mount `<DragShadow />` in the Canvas

## Tests

62 new tests across 5 files, all passing. Includes pure-logic unit tests (`groundShadow.test.ts`), R3F render-shell tests for the new components, and backfill coverage for `GhostBlock` + `PasteGhost` (previously untested). Net suite: 346 → 365 tests on merged code. Adds `@react-three/test-renderer@^9.1.0` as a devDep and extends `vitest.config.ts` to collect `*.test.tsx`.

## Reviewed by

Plan went through `/plan-design-review` (6/10 → 9/10) and `/plan-eng-review` (clean) plus a Codex outside-voice pass. Three high-severity findings from Codex (vitest config glob, R3F test-renderer peer-dep validation, `yBlockZOffset` gap) were applied during planning and shipped here.

## Test plan

- [x] All 365 Vitest tests pass on merged code
- [x] `npx tsc --noEmit` clean
- [x] No new ESLint warnings
- [ ] Manual: drag elevated selection sideways, confirm shadow follows the dragged X/Y
- [ ] Manual: select an elevated stack at rest, confirm shadow + projection line appear
- [ ] Manual: hover placement tool over a cell at z=2, confirm placement ghost has a shadow
- [ ] Manual: paste an elevated multi-block clipboard, confirm shadows on each elevated block
- [ ] Manual: drag a Y-cube placed under a pipe (visually lifted) — shadow + line should reach the rendered block bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)