### PR TITLE
feat: share scenes via URL hash

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -52,6 +52,15 @@ import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 import { downloadPng } from "./utils/photoExport";
 import { downloadDae } from "./utils/daeExport";
+import {
+  applySnapshot,
+  type SceneSnapshotV1,
+} from "./utils/sceneSnapshot";
+import {
+  decodeSnapshotFromHash,
+  parseSceneHashParam,
+} from "./utils/sceneShare";
+import { SharedSceneBanner } from "./components/SharedSceneBanner";
 import { isEditableTarget } from "./utils/editableFocus";
 import {
   ISO_INITIAL_ZOOM,
@@ -497,6 +506,8 @@ export default function App() {
   const [helpOpen, setHelpOpen] = useState(
     () => typeof localStorage !== 'undefined' && !localStorage.getItem('piperDraw.seenIntro'),
   );
+  const [sharedSceneBanner, setSharedSceneBanner] =
+    useState<{ previousSnapshot: SceneSnapshotV1 } | null>(null);
   const threeStateRef = useRef<ThreeState | null>(null);
   const photoRequest = useBlockStore((s) => s.photoRequest);
   const flowsPanelOpen = useBlockStore((s) => s.flowsPanelOpen);
@@ -896,36 +907,69 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(AUTOSAVE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          useBlockStore.getState().hydrateBlocks(new Map<string, Block>(parsed));
+    function readAutosaveSnapshot(): SceneSnapshotV1 {
+      const snapshot: SceneSnapshotV1 = { v: 1, blocks: [], portMeta: [], portPositions: [] };
+      try {
+        const raw = localStorage.getItem(AUTOSAVE_KEY);
+        if (raw) {
+          const parsed: unknown = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            snapshot.blocks = parsed as SceneSnapshotV1["blocks"];
+          }
         }
+      } catch {
+        localStorage.removeItem(AUTOSAVE_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_KEY);
-    }
-    try {
-      const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
-      if (rawMeta) {
-        const parsed = JSON.parse(rawMeta) as {
-          portMeta?: Array<[string, { label: string; io: "in" | "out" }]>;
-          portPositions?: string[];
-        };
-        const store = useBlockStore.getState();
-        if (parsed.portMeta) {
-          useBlockStore.setState({ portMeta: new Map(parsed.portMeta) });
+      try {
+        const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
+        if (rawMeta) {
+          const parsed = JSON.parse(rawMeta) as {
+            portMeta?: SceneSnapshotV1["portMeta"];
+            portPositions?: string[];
+          };
+          if (parsed.portMeta) snapshot.portMeta = parsed.portMeta;
+          if (parsed.portPositions) snapshot.portPositions = parsed.portPositions;
         }
-        if (parsed.portPositions) {
-          useBlockStore.setState({ portPositions: new Set(parsed.portPositions) });
-        }
-        store.ensurePortLabels();
+      } catch {
+        localStorage.removeItem(AUTOSAVE_META_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_META_KEY);
+      return snapshot;
     }
+
+    function clearShareHash() {
+      if (typeof window === "undefined") return;
+      if (parseSceneHashParam(window.location.hash)) {
+        history.replaceState(null, "", window.location.pathname + window.location.search);
+      }
+    }
+
+    const sharedHash = parseSceneHashParam(window.location.hash);
+    if (!sharedHash) {
+      applySnapshot(readAutosaveSnapshot(), "hydrate");
+      return;
+    }
+
+    const autosaveSnapshot = readAutosaveSnapshot();
+    let cancelled = false;
+    void (async () => {
+      const shared = await decodeSnapshotFromHash(window.location.hash);
+      if (cancelled) return;
+      if (shared) {
+        applySnapshot(shared, "hydrate");
+        clearShareHash();
+        const hadAutosave =
+          autosaveSnapshot.blocks.length > 0 || autosaveSnapshot.portPositions.length > 0;
+        if (hadAutosave) {
+          setSharedSceneBanner({ previousSnapshot: autosaveSnapshot });
+        }
+      } else {
+        applySnapshot(autosaveSnapshot, "hydrate");
+        clearShareHash();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -1013,6 +1057,16 @@ export default function App() {
         onOpenKeybindEditor={setKeybindEditorMode}
       />
       <ValidationToast toolbarRef={toolbarRef} controlsRef={controlsRef} />
+      {sharedSceneBanner && (
+        <SharedSceneBanner
+          previousSnapshot={sharedSceneBanner.previousSnapshot}
+          onRestore={(snapshot) => {
+            applySnapshot(snapshot, "load");
+            setSharedSceneBanner(null);
+          }}
+          onDismiss={() => setSharedSceneBanner(null)}
+        />
+      )}
       <button
         onClick={() => setHelpOpen(true)}
         onPointerDown={(e) => e.stopPropagation()}

--- a/gui/src/components/SharedSceneBanner.tsx
+++ b/gui/src/components/SharedSceneBanner.tsx
@@ -1,0 +1,70 @@
+import type { SceneSnapshotV1 } from "../utils/sceneSnapshot";
+
+export function SharedSceneBanner({
+  previousSnapshot,
+  onRestore,
+  onDismiss,
+}: {
+  previousSnapshot: SceneSnapshotV1;
+  onRestore: (snapshot: SceneSnapshotV1) => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        top: 12,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1100,
+        background: "#fff8d6",
+        border: "1px solid #d8c46a",
+        borderRadius: 6,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+        padding: "8px 12px",
+        fontFamily: "sans-serif",
+        fontSize: 13,
+        color: "#5b4a00",
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <span>Loaded a shared scene. Your previous work is still saved.</span>
+      <button
+        onClick={() => onRestore(previousSnapshot)}
+        style={{
+          fontSize: 12,
+          padding: "4px 10px",
+          border: "1px solid #b89a30",
+          borderRadius: 4,
+          background: "#fff",
+          cursor: "pointer",
+          color: "#5b4a00",
+        }}
+      >
+        Restore previous
+      </button>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+        style={{
+          fontSize: 14,
+          width: 22,
+          height: 22,
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          color: "#7a6300",
+          padding: 0,
+          lineHeight: 1,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -6,6 +6,12 @@ import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPo
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
+import {
+  buildShareUrl,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+} from "../utils/sceneShare";
+import { captureSnapshot } from "../utils/sceneSnapshot";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
 import { evalCoordExpr } from "../utils/parseCoordExpr";
 import { usePreviewImages } from "./PreviewRenderer";
@@ -1108,7 +1114,15 @@ function FileMenu({
   const [templates, setTemplates] = useState<TemplateEntry[] | null>(null);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [loadingFile, setLoadingFile] = useState<string | null>(null);
+  const [shareStatus, setShareStatus] = useState<"idle" | "copied" | "too-long" | "error">("idle");
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const compressionSupported = isCompressionStreamSupported();
+
+  // ~6 KB total URL — Twitter/X and most chat clients are well above this,
+  // but very long URLs choke older SMS, some embeds, and the URL bar in
+  // older browsers. Past this we surface the .dae export instead.
+  const SHARE_URL_MAX_LEN = 6144;
 
   useEffect(() => {
     if (!open) return;
@@ -1157,6 +1171,52 @@ function FileMenu({
     cursor: disabled ? "default" : "pointer",
     whiteSpace: "nowrap",
   });
+
+  const onShare = async () => {
+    if (!compressionSupported || blocksEmpty) return;
+    if (shareTimeoutRef.current !== null) {
+      clearTimeout(shareTimeoutRef.current);
+      shareTimeoutRef.current = null;
+    }
+    try {
+      const snapshot = captureSnapshot();
+      const encoded = await encodeSnapshotToHashParam(snapshot);
+      const url = buildShareUrl(encoded);
+      if (url.length > SHARE_URL_MAX_LEN) {
+        setShareStatus("too-long");
+      } else {
+        await navigator.clipboard.writeText(url);
+        setShareStatus("copied");
+      }
+    } catch {
+      setShareStatus("error");
+    }
+    shareTimeoutRef.current = setTimeout(() => {
+      setShareStatus("idle");
+      setOpen(false);
+      shareTimeoutRef.current = null;
+    }, 1600);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (shareTimeoutRef.current !== null) clearTimeout(shareTimeoutRef.current);
+    };
+  }, []);
+
+  let shareLabel = "Share link";
+  let shareTitle = "Copy a link that loads this exact scene";
+  if (!compressionSupported) {
+    shareTitle = "Share link is unsupported in this browser (needs CompressionStream)";
+  } else if (shareStatus === "copied") {
+    shareLabel = "Link copied!";
+  } else if (shareStatus === "too-long") {
+    shareLabel = "Too large — use Export";
+    shareTitle = "Scene is too big for a URL; use Export to send a .dae file instead";
+  } else if (shareStatus === "error") {
+    shareLabel = "Could not copy";
+  }
+  const shareDisabled = blocksEmpty || !compressionSupported;
 
   return (
     <div ref={wrapRef} style={{ position: "relative" }}>
@@ -1214,6 +1274,16 @@ function FileMenu({
             style={item(blocksEmpty)}
           >
             Export
+          </button>
+          <button
+            onClick={() => {
+              void onShare();
+            }}
+            disabled={shareDisabled}
+            title={shareTitle}
+            style={item(shareDisabled)}
+          >
+            {shareLabel}
           </button>
           <button
             onClick={() => {

--- a/gui/src/utils/sceneShare.test.ts
+++ b/gui/src/utils/sceneShare.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { Block } from "../types";
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import {
+  buildShareUrl,
+  decodeSnapshotFromHash,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+  parseSceneHashParam,
+} from "./sceneShare";
+
+function snapshot(
+  blocks: Array<[string, Block]> = [],
+  portMeta: SceneSnapshotV1["portMeta"] = [],
+  portPositions: string[] = [],
+): SceneSnapshotV1 {
+  return { v: 1, blocks, portMeta, portPositions };
+}
+
+describe("parseSceneHashParam", () => {
+  it("extracts the scene parameter from various hash forms", () => {
+    expect(parseSceneHashParam("#scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("?scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#foo=1&scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#scene=abc&foo=1")).toBe("abc");
+    expect(parseSceneHashParam("https://x.test/app#scene=abc")).toBe("abc");
+  });
+
+  it("returns null when no scene param is present", () => {
+    expect(parseSceneHashParam("")).toBe(null);
+    expect(parseSceneHashParam("#")).toBe(null);
+    expect(parseSceneHashParam("#otherkey=value")).toBe(null);
+    expect(parseSceneHashParam("scenefoo=bar")).toBe(null);
+  });
+});
+
+describe("buildShareUrl", () => {
+  it("appends the encoded payload to the supplied base", () => {
+    expect(buildShareUrl("xyz", "https://app.test/")).toBe(
+      "https://app.test/#scene=xyz",
+    );
+  });
+});
+
+const compressionAvailable = isCompressionStreamSupported();
+const skipIfNoCompression = compressionAvailable ? describe : describe.skip;
+
+skipIfNoCompression("encode/decode round-trip", () => {
+  it("round-trips an empty scene", async () => {
+    const original = snapshot();
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a small scene with port meta and ranks", async () => {
+    const blocks: Array<[string, Block]> = [
+      ["0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" }],
+      ["3,0,0", { pos: { x: 3, y: 0, z: 0 }, type: "OZX" }],
+      ["6,0,0", { pos: { x: 6, y: 0, z: 0 }, type: "ZXZ" }],
+    ];
+    const original = snapshot(
+      blocks,
+      [
+        ["0,0,0", { label: "P1", io: "in", rank: 0 }],
+        ["6,0,0", { label: "P2", io: "out", rank: 1 }],
+      ],
+      ["0,0,0", "6,0,0"],
+    );
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a 200-block scene and produces base64url-safe output", async () => {
+    const blocks: Array<[string, Block]> = [];
+    for (let i = 0; i < 200; i++) {
+      const x = (i % 20) * 3;
+      const z = Math.floor(i / 20) * 3;
+      blocks.push([`${x},0,${z}`, { pos: { x, y: 0, z }, type: "XZZ" }]);
+    }
+    const original = snapshot(blocks);
+    const encoded = await encodeSnapshotToHashParam(original);
+    expect(/^[A-Za-z0-9_-]+$/.test(encoded)).toBe(true);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("returns null for a malformed base64 payload", async () => {
+    expect(await decodeSnapshotFromHash("#scene=!!!not-base64")).toBe(null);
+  });
+
+  it("returns null when valid base64 is not deflate-compressed", async () => {
+    expect(await decodeSnapshotFromHash("#scene=aGVsbG8")).toBe(null);
+  });
+
+  it("returns null when the decoded JSON has the wrong shape", async () => {
+    const wrongShape = await encodeSnapshotToHashParam({
+      v: 1,
+      blocks: "not-an-array" as unknown as never,
+      portMeta: [],
+      portPositions: [],
+    } as SceneSnapshotV1);
+    expect(await decodeSnapshotFromHash(`#scene=${wrongShape}`)).toBe(null);
+  });
+
+  it("returns null when there is no scene param", async () => {
+    expect(await decodeSnapshotFromHash("#nothing-here")).toBe(null);
+  });
+});

--- a/gui/src/utils/sceneShare.ts
+++ b/gui/src/utils/sceneShare.ts
@@ -1,0 +1,99 @@
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import { isSceneSnapshotV1 } from "./sceneSnapshot";
+
+export const SCENE_HASH_KEY = "scene";
+
+const COMPRESSION_FORMAT = "deflate-raw" as const;
+
+export function isCompressionStreamSupported(): boolean {
+  return (
+    typeof CompressionStream !== "undefined" &&
+    typeof DecompressionStream !== "undefined"
+  );
+}
+
+async function runStream(
+  input: Uint8Array,
+  transform: GenericTransformStream,
+): Promise<Uint8Array> {
+  const writer = transform.writable.getWriter();
+  // Swallow writer-side rejections so they don't become unhandled. The
+  // canonical error surface is the readable side, which the caller awaits.
+  writer.write(input).catch(() => {});
+  writer.close().catch(() => {});
+  const buf = await new Response(transform.readable).arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+async function compress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new CompressionStream(COMPRESSION_FORMAT));
+}
+
+async function decompress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new DecompressionStream(COMPRESSION_FORMAT));
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  // Chunk to keep apply() argument count safe across engines.
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+  const padded = s.replaceAll("-", "+").replaceAll("_", "/");
+  const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const binary = atob(padded + pad);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export async function encodeSnapshotToHashParam(
+  snapshot: SceneSnapshotV1,
+): Promise<string> {
+  const json = JSON.stringify(snapshot);
+  const compressed = await compress(new TextEncoder().encode(json));
+  return bytesToBase64Url(compressed);
+}
+
+/**
+ * Accepts any of: "#scene=xyz", "scene=xyz", "?scene=xyz", "&scene=xyz",
+ * or a full URL containing "scene=xyz". Returns the value, or null if
+ * no `scene` parameter is present.
+ */
+export function parseSceneHashParam(hashOrUrl: string): string | null {
+  const re = /(?:^|[#?&])scene=([^&]*)/;
+  const match = re.exec(hashOrUrl);
+  if (!match || !match[1]) return null;
+  return match[1];
+}
+
+export async function decodeSnapshotFromHash(
+  hashOrUrl: string,
+): Promise<SceneSnapshotV1 | null> {
+  const param = parseSceneHashParam(hashOrUrl);
+  if (!param) return null;
+  try {
+    const bytes = base64UrlToBytes(param);
+    const decompressed = await decompress(bytes);
+    const json = new TextDecoder().decode(decompressed);
+    const parsed: unknown = JSON.parse(json);
+    if (!isSceneSnapshotV1(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function buildShareUrl(hashParam: string, base?: string): string {
+  const b =
+    base ??
+    (typeof window !== "undefined"
+      ? window.location.origin + window.location.pathname + window.location.search
+      : "");
+  return `${b}#${SCENE_HASH_KEY}=${hashParam}`;
+}

--- a/gui/src/utils/sceneSnapshot.ts
+++ b/gui/src/utils/sceneSnapshot.ts
@@ -1,0 +1,69 @@
+import type { Block, PortMeta } from "../types";
+import { useBlockStore } from "../stores/blockStore";
+
+export const SCENE_SCHEMA_VERSION = 1;
+
+export interface SceneSnapshotV1 {
+  v: 1;
+  blocks: Array<[string, Block]>;
+  portMeta: Array<[string, PortMeta]>;
+  portPositions: string[];
+}
+
+export function captureSnapshot(): SceneSnapshotV1 {
+  const s = useBlockStore.getState();
+  return {
+    v: 1,
+    blocks: Array.from(s.blocks.entries()),
+    portMeta: Array.from(s.portMeta.entries()),
+    portPositions: Array.from(s.portPositions),
+  };
+}
+
+export function snapshotIsEmpty(snapshot: SceneSnapshotV1): boolean {
+  return snapshot.blocks.length === 0;
+}
+
+export function isSceneSnapshotV1(value: unknown): value is SceneSnapshotV1 {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<SceneSnapshotV1>;
+  if (v.v !== 1) return false;
+  if (!Array.isArray(v.blocks) || !Array.isArray(v.portMeta) || !Array.isArray(v.portPositions)) {
+    return false;
+  }
+  for (const entry of v.blocks) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const block = entry[1] as Partial<Block> | undefined;
+    if (!block || typeof block !== "object") return false;
+    if (typeof block.type !== "string") return false;
+    if (!block.pos || typeof block.pos !== "object") return false;
+    const { x, y, z } = block.pos;
+    if (typeof x !== "number" || typeof y !== "number" || typeof z !== "number") return false;
+  }
+  for (const entry of v.portMeta) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const meta = entry[1] as Partial<PortMeta> | undefined;
+    if (!meta || typeof meta.label !== "string") return false;
+    if (meta.io !== "in" && meta.io !== "out") return false;
+  }
+  for (const p of v.portPositions) {
+    if (typeof p !== "string") return false;
+  }
+  return true;
+}
+
+export type ApplyMode = "load" | "hydrate";
+
+export function applySnapshot(snapshot: SceneSnapshotV1, mode: ApplyMode = "hydrate"): void {
+  const store = useBlockStore.getState();
+  const blocks = new Map<string, Block>(snapshot.blocks);
+  if (mode === "load") store.loadBlocks(blocks);
+  else store.hydrateBlocks(blocks);
+  useBlockStore.setState({
+    portMeta: new Map(snapshot.portMeta),
+    portPositions: new Set(snapshot.portPositions),
+  });
+  useBlockStore.getState().ensurePortLabels();
+}


### PR DESCRIPTION
## Summary
- Adds a "Share link" button to the File menu that copies a URL with the compressed scene in the hash fragment — paste anywhere, recipient opens it and the scene loads automatically.
- Hash is cleared via `history.replaceState` on load; if the recipient had local autosave content, a banner appears with a "Restore previous" button so nothing gets silently clobbered.
- Compression uses the browser-native `CompressionStream` API (zero new deps); malformed share URLs fall through silently to the existing autosave hydration path.

## Test plan
- [x] `npm run build`, `npm run lint`, `npm run test` (375 pass, 10 new in `sceneShare.test.ts`)
- [x] Manual headed-browser QA: share-and-paste round-trip, banner Restore, malformed-hash fallthrough — all behave correctly

🧙 Built with [WOZCODE](https://wozcode.com)