### PR TITLE
feat: free-build color-swap pipes (full + half-swap variants)

### DIFF
--- a/.github/workflows/fly-deploy-dev.yml
+++ b/.github/workflows/fly-deploy-dev.yml
@@ -1,0 +1,35 @@
+name: Dev Deploy
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency: deploy-dev-group
+    steps:
+      - uses: actions/checkout@v6
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only --config fly.dev.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+
+  smoke-test:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe dev for HTTP 200
+        run: |
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" https://piper-draw-dev.fly.dev/)
+            if [ "$code" = "200" ]; then
+              echo "OK: got 200"
+              exit 0
+            fi
+            echo "attempt $i: got $code, retrying in 10s..."
+            sleep 10
+          done
+          echo "FAIL: dev never returned 200"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 ## Branching strategy
 
 - **`dev`** is the integration branch. All pull requests should target `dev`.
-- **`main`** is the stable/release branch. Changes are merged from `dev` into `main` for releases.
+  Merges to `dev` auto-deploy to <https://piper-draw-dev.walruscomputing.com>.
+- **`main`** is the stable/release branch. Changes are merged from `dev` into
+  `main` for releases. Merges to `main` auto-deploy to
+  <https://piper-draw.walruscomputing.com>.
 
 ## How to contribute
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: build the Vite/React frontend
 FROM node:22-slim AS frontend
+ARG VITE_UMAMI_WEBSITE_ID
+ENV VITE_UMAMI_WEBSITE_ID=${VITE_UMAMI_WEBSITE_ID}
 WORKDIR /app/gui
 COPY gui/package.json gui/package-lock.json ./
 RUN npm ci

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,0 +1,21 @@
+# Fly.io config for the piper-draw dev release (deploys from the `dev` branch).
+# Mirrors fly.toml; only `app` differs.
+
+app = "piper-draw-dev"
+primary_region = "ams"
+
+[build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "0d67b9da-dff1-45c2-844d-06b45ff00ff8"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,8 @@ app = "piper-draw"
 primary_region = "ams"
 
 [build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "c9fe90a4-6296-4b2d-b0bc-6b272b01786c"
 
 [http_service]
   internal_port = 8000

--- a/gui/index.html
+++ b/gui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Piper Draw</title>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="c9fe90a4-6296-4b2d-b0bc-6b272b01786c"></script>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="%VITE_UMAMI_WEBSITE_ID%"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@react-three/test-renderer": "^9.1.0",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1408,6 +1409,18 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-three/test-renderer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@react-three/test-renderer/-/test-renderer-9.1.0.tgz",
+      "integrity": "sha512-bLjG+cdpVW69wG1W3TuziHrHvA1JQbLesYddY94QMaFF8yzpgwovWK8hGaHWBET1dvsCPIOWVNYHbKAbRj2xSg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-three/fiber": ">=9.0.0",
+        "react": "^19.0.0",
+        "three": ">=0.156"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@react-three/test-renderer": "^9.1.0",
     "@types/three": "^0.184.0",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.1.2",

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -38,7 +38,7 @@ import { BuildModeHints } from "./components/BuildModeHints";
 import { EditModeHints } from "./components/EditModeHints";
 import { KeybindEditor, type KeybindEditorTab } from "./components/KeybindEditor";
 import { HelpPanel } from "./components/HelpPanel";
-import { useBlockStore } from "./stores/blockStore";
+import { useBlockStore, sceneHasFreeBuildBlocks } from "./stores/blockStore";
 import {
   useKeybindStore,
   actionForKey,
@@ -550,6 +550,13 @@ export default function App() {
             break;
           case "s":
             e.preventDefault();
+            // Block export when scene contains free-build pieces — TQEC ops
+            // shouldn't silently strip them. UI's File → Export is also
+            // disabled with a tooltip; this guards the keyboard shortcut.
+            if (sceneHasFreeBuildBlocks(store)) {
+              console.warn("[export] DAE export blocked: scene contains Free Build pieces. Remove them or use Undo.");
+              return;
+            }
             void downloadDae(store.blocks);
             return;
         }

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -26,9 +26,11 @@ import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
 import { SelectModePointer, type ThreeState } from "./components/SelectModePointer";
 import { DragGhost } from "./components/DragGhost";
+import { DragShadow } from "./components/DragShadow";
 import { NavControlsModifier } from "./components/NavControlsModifier";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
 import { FlowsPanel } from "./components/FlowsPanel";
+import { FreeBuildPipeVariantsPanel } from "./components/FreeBuildPipeVariantsPanel";
 import { ZXPanel } from "./components/ZXPanel";
 import { PortLabels3D } from "./components/PortLabels3D";
 import { FoldOutCubeOverlay } from "./components/FoldOutCubeOverlay";
@@ -51,6 +53,15 @@ import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 import { downloadPng } from "./utils/photoExport";
 import { downloadDae } from "./utils/daeExport";
+import {
+  applySnapshot,
+  type SceneSnapshotV1,
+} from "./utils/sceneSnapshot";
+import {
+  decodeSnapshotFromHash,
+  parseSceneHashParam,
+} from "./utils/sceneShare";
+import { SharedSceneBanner } from "./components/SharedSceneBanner";
 import { isEditableTarget } from "./utils/editableFocus";
 import {
   ISO_INITIAL_ZOOM,
@@ -496,6 +507,8 @@ export default function App() {
   const [helpOpen, setHelpOpen] = useState(
     () => typeof localStorage !== 'undefined' && !localStorage.getItem('piperDraw.seenIntro'),
   );
+  const [sharedSceneBanner, setSharedSceneBanner] =
+    useState<{ previousSnapshot: SceneSnapshotV1 } | null>(null);
   const threeStateRef = useRef<ThreeState | null>(null);
   const photoRequest = useBlockStore((s) => s.photoRequest);
   const flowsPanelOpen = useBlockStore((s) => s.flowsPanelOpen);
@@ -902,36 +915,69 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(AUTOSAVE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          useBlockStore.getState().hydrateBlocks(new Map<string, Block>(parsed));
+    function readAutosaveSnapshot(): SceneSnapshotV1 {
+      const snapshot: SceneSnapshotV1 = { v: 1, blocks: [], portMeta: [], portPositions: [] };
+      try {
+        const raw = localStorage.getItem(AUTOSAVE_KEY);
+        if (raw) {
+          const parsed: unknown = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            snapshot.blocks = parsed as SceneSnapshotV1["blocks"];
+          }
         }
+      } catch {
+        localStorage.removeItem(AUTOSAVE_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_KEY);
-    }
-    try {
-      const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
-      if (rawMeta) {
-        const parsed = JSON.parse(rawMeta) as {
-          portMeta?: Array<[string, { label: string; io: "in" | "out" }]>;
-          portPositions?: string[];
-        };
-        const store = useBlockStore.getState();
-        if (parsed.portMeta) {
-          useBlockStore.setState({ portMeta: new Map(parsed.portMeta) });
+      try {
+        const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
+        if (rawMeta) {
+          const parsed = JSON.parse(rawMeta) as {
+            portMeta?: SceneSnapshotV1["portMeta"];
+            portPositions?: string[];
+          };
+          if (parsed.portMeta) snapshot.portMeta = parsed.portMeta;
+          if (parsed.portPositions) snapshot.portPositions = parsed.portPositions;
         }
-        if (parsed.portPositions) {
-          useBlockStore.setState({ portPositions: new Set(parsed.portPositions) });
-        }
-        store.ensurePortLabels();
+      } catch {
+        localStorage.removeItem(AUTOSAVE_META_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_META_KEY);
+      return snapshot;
     }
+
+    function clearShareHash() {
+      if (typeof window === "undefined") return;
+      if (parseSceneHashParam(window.location.hash)) {
+        history.replaceState(null, "", window.location.pathname + window.location.search);
+      }
+    }
+
+    const sharedHash = parseSceneHashParam(window.location.hash);
+    if (!sharedHash) {
+      applySnapshot(readAutosaveSnapshot(), "hydrate");
+      return;
+    }
+
+    const autosaveSnapshot = readAutosaveSnapshot();
+    let cancelled = false;
+    void (async () => {
+      const shared = await decodeSnapshotFromHash(window.location.hash);
+      if (cancelled) return;
+      if (shared) {
+        applySnapshot(shared, "hydrate");
+        clearShareHash();
+        const hadAutosave =
+          autosaveSnapshot.blocks.length > 0 || autosaveSnapshot.portPositions.length > 0;
+        if (hadAutosave) {
+          setSharedSceneBanner({ previousSnapshot: autosaveSnapshot });
+        }
+      } else {
+        applySnapshot(autosaveSnapshot, "hydrate");
+        clearShareHash();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -1019,6 +1065,16 @@ export default function App() {
         onOpenKeybindEditor={setKeybindEditorMode}
       />
       <ValidationToast toolbarRef={toolbarRef} controlsRef={controlsRef} />
+      {sharedSceneBanner && (
+        <SharedSceneBanner
+          previousSnapshot={sharedSceneBanner.previousSnapshot}
+          onRestore={(snapshot) => {
+            applySnapshot(snapshot, "load");
+            setSharedSceneBanner(null);
+          }}
+          onDismiss={() => setSharedSceneBanner(null)}
+        />
+      )}
       <button
         onClick={() => setHelpOpen(true)}
         onPointerDown={(e) => e.stopPropagation()}
@@ -1060,6 +1116,7 @@ export default function App() {
       )}
       <FlowsPanel controlsRef={controlsRef} toolbarRef={toolbarRef} />
       <ZXPanel controlsRef={controlsRef} toolbarRef={toolbarRef} />
+      <FreeBuildPipeVariantsPanel />
       {showHints && <EditModeHints onCustomize={() => setKeybindEditorMode("edit")} />}
       {showHints && <BuildModeHints onCustomize={() => setKeybindEditorMode("build")} />}
       {keybindEditorMode && (
@@ -1079,6 +1136,7 @@ export default function App() {
         {!photoRequest && <LocatePulseHighlight />}
         {!photoRequest && !flowVizMode && <SelectionHighlights />}
         {!photoRequest && !flowVizMode && <DragGhost />}
+        {!photoRequest && !flowVizMode && <DragShadow />}
         {!photoRequest && !flowVizMode && <BuildCursor />}
         {!photoRequest && !flowVizMode && <OpenPipeGhosts />}
       {!photoRequest && (flowsPanelOpen || zxPanelOpen || flowVizMode) && <PortLabels3D />}

--- a/gui/src/components/BlockInstances.logic.test.ts
+++ b/gui/src/components/BlockInstances.logic.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { Vector3 } from "three";
+import {
+  decidePlaceModeClick,
+  decidePlaceModeHover,
+  resolveFBSpecFromFace,
+  resolvePipeTypeFromFace,
+  type PlaceModeState,
+} from "./BlockInstances.logic";
+import {
+  buildSpatialIndex,
+  FB_PRESETS,
+  isFreeBuildPipeSpec,
+  posKey,
+} from "../types";
+import type { Block, BlockType, CubeType, FBPreset, PipeVariant, Position3D } from "../types";
+import type { ArmedTool } from "../stores/blockStore";
+
+const FB_FREE_PIPE: FBPreset = FB_PRESETS[0];
+
+function block(pos: Position3D, type: BlockType): Block {
+  return { pos, type };
+}
+
+function makeState(opts: {
+  armedTool: ArmedTool;
+  cubeType?: CubeType | "Y";
+  pipeVariant?: PipeVariant | null;
+  fbPreset?: FBPreset | null;
+  freeBuild?: boolean;
+  blocks?: Block[];
+}): PlaceModeState {
+  const blockMap = new Map<string, Block>();
+  for (const b of opts.blocks ?? []) blockMap.set(posKey(b.pos), b);
+  return {
+    armedTool: opts.armedTool,
+    cubeType: opts.cubeType ?? "XZZ",
+    pipeVariant: opts.pipeVariant ?? null,
+    fbPreset: opts.fbPreset ?? null,
+    freeBuild: opts.freeBuild ?? false,
+    blocks: blockMap,
+    spatialIndex: buildSpatialIndex(blockMap),
+  };
+}
+
+describe("decidePlaceModeHover — armedTool === 'cube'", () => {
+  it("returns cube-replace ghost when cubeType differs from hovered.type", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(intent.pos).toEqual({ x: 0, y: 0, z: 0 });
+    expect(intent.type).toBe("XZZ");
+    expect(intent.invalid).toBe(false);
+    expect(intent.replace).toBe(true);
+  });
+
+  it("clears ghost when cubeType === hovered.type (face-based fallback fails on cube-pipe-slot mismatch)", () => {
+    // adj = (1,0,0) is a pipe slot, not a valid cube position, so face-based clears.
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("clear");
+  });
+
+});
+
+describe("decidePlaceModeHover — armedTool === 'pipe' + fbPreset (FB snap regression)", () => {
+  it("never enters cube-replace; returns FB pipe ghost in adj slot regardless of cubeType", () => {
+    // Before the fix this case rendered a CUBE ghost at the cube position.
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ", // different from hovered.type — would have triggered cube-replace
+      fbPreset: FB_FREE_PIPE,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(isFreeBuildPipeSpec(intent.type)).toBe(true);
+    expect(intent.pos).toEqual({ x: 1, y: 0, z: 0 });
+    expect(intent.invalid).toBe(false);
+  });
+
+  it("places FB pipe in adj slot for every face direction tested (cube hover)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_FREE_PIPE,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const cases: { normal: Vector3; expected: Position3D }[] = [
+      { normal: new Vector3(1, 0, 0), expected: { x: 1, y: 0, z: 0 } },
+      { normal: new Vector3(-1, 0, 0), expected: { x: -2, y: 0, z: 0 } },
+      { normal: new Vector3(0, 1, 0), expected: { x: 0, y: 0, z: 1 } },
+      { normal: new Vector3(0, 0, 1), expected: { x: 0, y: -2, z: 0 } },
+    ];
+    for (const { normal, expected } of cases) {
+      const intent = decidePlaceModeHover(state, cube, normal);
+      expect(intent.kind).toBe("ghost");
+      if (intent.kind !== "ghost") continue;
+      expect(intent.pos).toEqual(expected);
+      expect(isFreeBuildPipeSpec(intent.type)).toBe(true);
+    }
+  });
+
+  it("clears when face resolution fails (no faceNormal)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_FREE_PIPE,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, null);
+    expect(intent.kind).toBe("clear");
+  });
+});
+
+describe("decidePlaceModeHover — armedTool === 'pipe' + pipeVariant (TQEC)", () => {
+  it("returns TQEC pipe ghost in adj slot", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(intent.pos).toEqual({ x: 1, y: 0, z: 0 });
+    // X-open ZX pipe at this slot is "OZX"
+    expect(intent.type).toBe("OZX");
+  });
+
+  it("adj slot matches the FB-equivalent path (parity)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const tqecState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const fbState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_FREE_PIPE,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    for (const normal of [
+      new Vector3(1, 0, 0),
+      new Vector3(-1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, 0, 1),
+    ]) {
+      const tqec = decidePlaceModeHover(tqecState, cube, normal);
+      const fb = decidePlaceModeHover(fbState, cube, normal);
+      expect(tqec.kind).toBe("ghost");
+      expect(fb.kind).toBe("ghost");
+      if (tqec.kind !== "ghost" || fb.kind !== "ghost") continue;
+      expect(fb.pos).toEqual(tqec.pos);
+    }
+  });
+});
+
+describe("decidePlaceModeClick", () => {
+  it("returns place-at hovered.pos when cube tool replaces a different-type cube", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const action = decidePlaceModeClick(state, cube, new Vector3(1, 0, 0));
+    expect(action).toEqual({ kind: "place-at", pos: cube.pos });
+  });
+
+  it("FB-armed click on a different-type cube places at adj pipe slot, not at cube pos (REGRESSION)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_FREE_PIPE,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const action = decidePlaceModeClick(state, cube, new Vector3(1, 0, 0));
+    expect(action).toEqual({ kind: "place-at", pos: { x: 1, y: 0, z: 0 } });
+  });
+
+  it("returns noop when no face normal and no cube-replace path applies", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_FREE_PIPE,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const action = decidePlaceModeClick(state, cube, null);
+    expect(action).toEqual({ kind: "noop" });
+  });
+
+  it("FB-click adj position equals TQEC-click adj position for the same hover (parity)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const tqecState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const fbState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_FREE_PIPE,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    for (const normal of [
+      new Vector3(1, 0, 0),
+      new Vector3(-1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, 0, 1),
+    ]) {
+      const tqec = decidePlaceModeClick(tqecState, cube, normal);
+      const fb = decidePlaceModeClick(fbState, cube, normal);
+      expect(tqec.kind).toBe("place-at");
+      expect(fb.kind).toBe("place-at");
+      if (tqec.kind !== "place-at" || fb.kind !== "place-at") continue;
+      expect(fb.pos).toEqual(tqec.pos);
+    }
+  });
+});
+
+// Sanity: the resolution helpers are re-exported from the logic module so
+// other components (OpenPipeGhosts) can import from one place. Cover the
+// re-exports so the surface is stable.
+describe("resolution helpers (sanity)", () => {
+  it("resolveFBSpecFromFace returns a valid pipe slot", () => {
+    const r = resolveFBSpecFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), FB_FREE_PIPE);
+    expect(r).not.toBeNull();
+    expect(r!.adj).toEqual({ x: 1, y: 0, z: 0 });
+    expect(r!.spec.openAxis).toBe(0);
+  });
+
+  it("resolvePipeTypeFromFace agrees with FB on adj slot", () => {
+    const tqec = resolvePipeTypeFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), "ZX");
+    expect(tqec).toBe("OZX");
+  });
+});

--- a/gui/src/components/BlockInstances.logic.ts
+++ b/gui/src/components/BlockInstances.logic.ts
@@ -1,0 +1,224 @@
+import * as THREE from "three";
+import type {
+  Block,
+  BlockType,
+  CubeType,
+  FBPreset,
+  FreeBuildPipeSpec,
+  PipeVariant,
+  Position3D,
+  SpatialIndex,
+} from "../types";
+import {
+  getAdjacentPos,
+  hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
+  hasYCubePipeAxisConflict,
+  isPipeType,
+  isValidPipePos,
+  isValidPos,
+  pipeAxisFromPos,
+  posKey,
+  resolvePipeType,
+  VARIANT_AXIS_MAP,
+} from "../types";
+import type { ArmedTool } from "../stores/blockStore";
+
+// FB-aware face-resolution helpers. Pure: no React, no zustand.
+
+export function resolvePipeTypeFromFace(
+  srcPos: Position3D,
+  srcType: BlockType,
+  normal: THREE.Vector3,
+  variant: PipeVariant,
+): BlockType | null {
+  for (const candidateType of VARIANT_AXIS_MAP[variant]) {
+    const probe = getAdjacentPos(srcPos, srcType, normal, candidateType);
+    if (!isValidPipePos(probe)) continue;
+    const resolved = resolvePipeType(variant, probe);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+export function resolveFBSpecFromFace(
+  srcPos: Position3D,
+  srcType: BlockType,
+  normal: THREE.Vector3,
+  preset: FBPreset,
+): { adj: Position3D; spec: FreeBuildPipeSpec } | null {
+  for (const ax of [0, 1, 2] as const) {
+    const candidate: FreeBuildPipeSpec = { ...preset.spec, openAxis: ax };
+    const adj = getAdjacentPos(srcPos, srcType, normal, candidate);
+    if (!isValidPipePos(adj)) continue;
+    const tqecAxis = pipeAxisFromPos(adj);
+    if (tqecAxis === null) continue;
+    return { adj, spec: { ...preset.spec, openAxis: tqecAxis } };
+  }
+  return null;
+}
+
+// Snapshot the handlers project from the store before calling the decision
+// functions. Keeping the surface explicit means the logic is unit-testable
+// without instantiating a real store, and it documents exactly which fields
+// drive place-mode behaviour.
+export type PlaceModeState = {
+  armedTool: ArmedTool;
+  cubeType: CubeType | "Y";
+  pipeVariant: PipeVariant | null;
+  fbPreset: FBPreset | null;
+  freeBuild: boolean;
+  blocks: Map<string, Block>;
+  spatialIndex: SpatialIndex;
+};
+
+export type HoverIntent =
+  | {
+      kind: "ghost";
+      pos: Position3D;
+      type: BlockType;
+      invalid: boolean;
+      reason?: string;
+      replace: boolean;
+    }
+  | { kind: "clear" };
+
+export type ClickAction =
+  | { kind: "place-at"; pos: Position3D }
+  | { kind: "noop" };
+
+type Verdict =
+  | { kind: "ok"; replace: boolean }
+  | { kind: "invalid"; reason?: string; replace: boolean }
+  | { kind: "hidden" };
+
+function classifyTarget(
+  state: PlaceModeState,
+  pos: Position3D,
+  type: BlockType,
+  existingKey: string | undefined,
+): Verdict {
+  const existing = existingKey ? state.blocks.get(existingKey) : undefined;
+  const replace = !!(existing && existing.type !== type);
+  if (hasBlockOverlap(pos, type, state.blocks, state.spatialIndex, existingKey)) {
+    return { kind: "invalid", replace };
+  }
+  if (existing && existing.type === type) {
+    return { kind: "hidden" };
+  }
+  if (!state.freeBuild) {
+    if (isPipeType(type) && hasPipeColorConflict(type, pos, state.blocks)) {
+      return { kind: "invalid", reason: "Pipe colors don't match the adjacent cube", replace };
+    }
+    if (
+      !isPipeType(type) &&
+      type !== "Y" &&
+      hasCubeColorConflict(type as CubeType, pos, state.blocks)
+    ) {
+      return { kind: "invalid", reason: "Cube colors don't match the adjacent pipe", replace };
+    }
+    if (hasYCubePipeAxisConflict(type, pos, state.blocks)) {
+      return {
+        kind: "invalid",
+        reason: "Y cube cannot be next to an X-open or Y-open pipe",
+        replace,
+      };
+    }
+  }
+  return { kind: "ok", replace };
+}
+
+function resolveFaceDestination(
+  state: PlaceModeState,
+  hovered: Block,
+  normal: THREE.Vector3,
+): { dst: BlockType; adj: Position3D } | null {
+  if (state.fbPreset) {
+    const r = resolveFBSpecFromFace(hovered.pos, hovered.type, normal, state.fbPreset);
+    if (!r) return null;
+    return { dst: r.spec, adj: r.adj };
+  }
+  if (state.pipeVariant) {
+    const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, normal, state.pipeVariant);
+    if (!resolved) return null;
+    const adj = getAdjacentPos(hovered.pos, hovered.type, normal, resolved);
+    return { dst: resolved, adj };
+  }
+  // Cube tool: place adjacent cube of the chosen cubeType.
+  const dst: BlockType = state.cubeType;
+  const adj = getAdjacentPos(hovered.pos, hovered.type, normal, dst);
+  return { dst, adj };
+}
+
+export function decidePlaceModeHover(
+  state: PlaceModeState,
+  hovered: Block,
+  faceNormal: THREE.Vector3 | null,
+): HoverIntent {
+  // Cube-replace runs only when the cube tool is armed. The gate makes
+  // FB-armed and TQEC-pipe-armed paths fall through to face-based placement
+  // regardless of cubeType's value.
+  if (state.armedTool === "cube") {
+    const replaceType = state.cubeType;
+    if (isValidPos(hovered.pos, replaceType) && replaceType !== hovered.type) {
+      const verdict = classifyTarget(state, hovered.pos, replaceType, posKey(hovered.pos));
+      if (verdict.kind === "ok") {
+        return {
+          kind: "ghost",
+          pos: hovered.pos,
+          type: replaceType,
+          invalid: false,
+          replace: verdict.replace,
+        };
+      }
+      if (verdict.kind === "invalid") {
+        return {
+          kind: "ghost",
+          pos: hovered.pos,
+          type: replaceType,
+          invalid: true,
+          reason: verdict.reason,
+          replace: verdict.replace,
+        };
+      }
+      // hidden falls through to face-based placement.
+    }
+  }
+
+  if (!faceNormal) return { kind: "clear" };
+  const resolved = resolveFaceDestination(state, hovered, faceNormal);
+  if (!resolved) return { kind: "clear" };
+  const { dst, adj } = resolved;
+  if (!isValidPos(adj, dst)) return { kind: "clear" };
+  const adjKey = posKey(adj);
+  const existingKey = state.blocks.has(adjKey) ? adjKey : undefined;
+  const verdict = classifyTarget(state, adj, dst, existingKey);
+  if (verdict.kind === "hidden") return { kind: "clear" };
+  return {
+    kind: "ghost",
+    pos: adj,
+    type: dst,
+    invalid: verdict.kind === "invalid",
+    reason: verdict.kind === "invalid" ? verdict.reason : undefined,
+    replace: verdict.replace,
+  };
+}
+
+export function decidePlaceModeClick(
+  state: PlaceModeState,
+  clicked: Block,
+  faceNormal: THREE.Vector3 | null,
+): ClickAction {
+  if (state.armedTool === "cube") {
+    const replaceType = state.cubeType;
+    if (isValidPos(clicked.pos, replaceType) && replaceType !== clicked.type) {
+      return { kind: "place-at", pos: clicked.pos };
+    }
+  }
+
+  if (!faceNormal) return { kind: "noop" };
+  const resolved = resolveFaceDestination(state, clicked, faceNormal);
+  if (!resolved) return { kind: "noop" };
+  return { kind: "place-at", pos: resolved.adj };
+}

--- a/gui/src/components/BlockInstances.logic.ts
+++ b/gui/src/components/BlockInstances.logic.ts
@@ -15,6 +15,7 @@ import {
   hasCubeColorConflict,
   hasPipeColorConflict,
   hasYCubePipeAxisConflict,
+  isFreeBuildPipeSpec,
   isPipeType,
   isValidPipePos,
   isValidPos,
@@ -113,6 +114,7 @@ function classifyTarget(
     }
     if (
       !isPipeType(type) &&
+      !isFreeBuildPipeSpec(type) &&
       type !== "Y" &&
       hasCubeColorConflict(type as CubeType, pos, state.blocks)
     ) {

--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -8,23 +8,30 @@ import {
   createBlockGeometry,
   createBlockEdges,
   blockThreeSize,
-  hasBlockOverlap,
-  hasCubeColorConflict,
-  hasPipeColorConflict,
-  hasYCubePipeAxisConflict,
-  isValidPipePos,
-  isValidPos,
   isPipeType,
   isFreeBuildPipeSpec,
-  pipeAxisFromPos,
-  resolvePipeType,
-  getAdjacentPos,
-  posKey,
   blockTypeCacheKey,
-  VARIANT_AXIS_MAP,
+  posKey,
 } from "../types";
-import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant, FBPreset, FreeBuildPipeSpec } from "../types";
+import type { Block, BlockType, FaceMask } from "../types";
+import {
+  decidePlaceModeClick,
+  decidePlaceModeHover,
+  type PlaceModeState,
+} from "./BlockInstances.logic";
 import { posInActiveSlice } from "../utils/isoView";
+
+function snapshotPlaceMode(store: ReturnType<typeof useBlockStore.getState>): PlaceModeState {
+  return {
+    armedTool: store.armedTool,
+    cubeType: store.cubeType,
+    pipeVariant: store.pipeVariant,
+    fbPreset: store.fbPreset,
+    freeBuild: store.freeBuild,
+    blocks: store.blocks,
+    spatialIndex: store.spatialIndex,
+  };
+}
 
 const DIMMED_OPACITY = 0.18;
 const DIMMED_EDGE_OPACITY = 0.25;
@@ -45,45 +52,6 @@ const dimmedEdgeLineMaterial = new THREE.LineBasicMaterial({
   opacity: DIMMED_EDGE_OPACITY,
   depthWrite: false,
 });
-
-// eslint-disable-next-line react-refresh/only-export-components
-export function resolvePipeTypeFromFace(
-  srcPos: Position3D,
-  srcType: BlockType,
-  normal: THREE.Vector3,
-  variant: PipeVariant,
-): BlockType | null {
-  for (const candidateType of VARIANT_AXIS_MAP[variant]) {
-    const probe = getAdjacentPos(srcPos, srcType, normal, candidateType);
-    if (!isValidPipePos(probe)) continue;
-    const resolved = resolvePipeType(variant, probe);
-    if (resolved) return resolved;
-  }
-  return null;
-}
-
-// FB analogue of resolvePipeTypeFromFace. Iterates candidate open-axis values
-// to find a face-adjacent slot that lands on a valid pipe position, then sets
-// the spec's openAxis to match the slot's TQEC axis. Mirrors the placement
-// invariant in addBlock — the preset's template openAxis is overridden by
-// pipeAxisFromPos at placement time.
-// eslint-disable-next-line react-refresh/only-export-components
-export function resolveFBSpecFromFace(
-  srcPos: Position3D,
-  srcType: BlockType,
-  normal: THREE.Vector3,
-  preset: FBPreset,
-): { adj: Position3D; spec: FreeBuildPipeSpec } | null {
-  for (const ax of [0, 1, 2] as const) {
-    const candidate: FreeBuildPipeSpec = { ...preset.spec, openAxis: ax };
-    const adj = getAdjacentPos(srcPos, srcType, normal, candidate);
-    if (!isValidPipePos(adj)) continue;
-    const tqecAxis = pipeAxisFromPos(adj);
-    if (tqecAxis === null) continue;
-    return { adj, spec: { ...preset.spec, openAxis: tqecAxis } };
-  }
-  return null;
-}
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function getCachedGeometry(blockType: BlockType, hiddenFaces: FaceMask): THREE.BufferGeometry {
@@ -267,71 +235,13 @@ function TypedInstances({
       // either removes the cube or does nothing (and sets a warning).
       store.setHoveredGridPos(null);
     } else {
-      // Place mode: check if we can replace the hovered block itself
-      const hovered = b[e.instanceId];
-      let replaceType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
-        const resolved = resolvePipeType(store.pipeVariant, hovered.pos);
-        if (resolved) replaceType = resolved;
-      }
-      if (isValidPos(hovered.pos, replaceType) && replaceType !== hovered.type) {
-        const hovKey = posKey(hovered.pos);
-        if (hasBlockOverlap(hovered.pos, replaceType, store.blocks, store.spatialIndex, hovKey)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, undefined, true);
-        } else if (!store.freeBuild && isPipeType(replaceType) && hasPipeColorConflict(replaceType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Pipe colors don't match the adjacent cube", true);
-        } else if (!store.freeBuild && !isPipeType(replaceType) && replaceType !== "Y" && hasCubeColorConflict(replaceType as CubeType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Cube colors don't match the adjacent pipe", true);
-        } else if (!store.freeBuild && hasYCubePipeAxisConflict(replaceType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Y cube cannot be next to an X-open or Y-open pipe", true);
-        } else {
-          store.setHoveredGridPos(hovered.pos, replaceType, false, undefined, true);
-        }
-        return;
-      }
-
-      if (!e.face) return;
-
-      // Determine the destination block type for adjacent placement
-      let dstType: BlockType = store.cubeType;
-      if (store.fbPreset) {
-        const r = resolveFBSpecFromFace(hovered.pos, hovered.type, e.face.normal, store.fbPreset);
-        if (!r) {
-          store.setHoveredGridPos(null);
-          return;
-        }
-        dstType = r.spec;
-      } else if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, e.face.normal, store.pipeVariant);
-        if (!resolved) {
-          store.setHoveredGridPos(null);
-          return;
-        }
-        dstType = resolved;
-      }
-
-      const adj = getAdjacentPos(hovered.pos, hovered.type, e.face.normal, dstType);
-
-      if (!isValidPos(adj, dstType)) {
+      // Place mode: pure decision logic lives in BlockInstances.logic.ts so
+      // the cube-replace gate and FB/TQEC pipe paths are unit-testable.
+      const intent = decidePlaceModeHover(snapshotPlaceMode(store), b[e.instanceId], e.face?.normal ?? null);
+      if (intent.kind === "clear") {
         store.setHoveredGridPos(null);
-        return;
-      }
-      const adjKey = posKey(adj);
-      const existingKey = store.blocks.has(adjKey) ? adjKey : undefined;
-      const adjReplace = !!(existingKey && store.blocks.get(existingKey)!.type !== dstType);
-      if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex, existingKey)) {
-        store.setHoveredGridPos(adj, dstType, true, undefined, adjReplace);
-      } else if (existingKey && store.blocks.get(existingKey)!.type === dstType) {
-        // Same type — no replacement needed, hide ghost
-        store.setHoveredGridPos(null);
-      } else if (!store.freeBuild && isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube", adjReplace);
-      } else if (!store.freeBuild && !isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Cube colors don't match the adjacent pipe", adjReplace);
-      } else if (!store.freeBuild && hasYCubePipeAxisConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Y cube cannot be next to an X-open or Y-open pipe", adjReplace);
       } else {
-        store.setHoveredGridPos(adj, dstType, false, undefined, adjReplace);
+        store.setHoveredGridPos(intent.pos, intent.type, intent.invalid, intent.reason, intent.replace);
       }
     }
   };
@@ -366,42 +276,14 @@ function TypedInstances({
       store.commitPaste();
       return;
     }
-    {
-      // Port-conversion tool: click on a cube to remove it (leaving a port
-      // if a pipe was attached). Never falls through to pipe-placement.
-      if (armed === "port") {
-        store.convertBlockToPort(b[e.instanceId].pos);
-        return;
-      }
-      // Place mode: try replacing the clicked block if the selected type
-      // is valid at the clicked block's position
-      const clicked = b[e.instanceId];
-      let replaceType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
-        const resolved = resolvePipeType(store.pipeVariant, clicked.pos);
-        if (resolved) replaceType = resolved;
-      }
-      if (isValidPos(clicked.pos, replaceType) && replaceType !== clicked.type) {
-        store.addBlock(clicked.pos);
-        return;
-      }
-
-      if (!e.face) return;
-
-      let dstType: BlockType = store.cubeType;
-      if (store.fbPreset) {
-        const r = resolveFBSpecFromFace(clicked.pos, clicked.type, e.face.normal, store.fbPreset);
-        if (!r) return;
-        dstType = r.spec;
-      } else if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(clicked.pos, clicked.type, e.face.normal, store.pipeVariant);
-        if (!resolved) return;
-        dstType = resolved;
-      }
-
-      const adj = getAdjacentPos(clicked.pos, clicked.type, e.face.normal, dstType);
-      store.addBlock(adj);
+    // Port-conversion tool: click on a cube to remove it (leaving a port
+    // if a pipe was attached). Never falls through to pipe-placement.
+    if (armed === "port") {
+      store.convertBlockToPort(b[e.instanceId].pos);
+      return;
     }
+    const action = decidePlaceModeClick(snapshotPlaceMode(store), b[e.instanceId], e.face?.normal ?? null);
+    if (action.kind === "place-at") store.addBlock(action.pos);
   };
 
   if (blocks.length === 0) return null;

--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -16,13 +16,14 @@ import {
   isValidPos,
   isPipeType,
   isFreeBuildPipeSpec,
+  pipeAxisFromPos,
   resolvePipeType,
   getAdjacentPos,
   posKey,
   blockTypeCacheKey,
   VARIANT_AXIS_MAP,
 } from "../types";
-import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant } from "../types";
+import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant, FBPreset, FreeBuildPipeSpec } from "../types";
 import { posInActiveSlice } from "../utils/isoView";
 
 const DIMMED_OPACITY = 0.18;
@@ -57,6 +58,29 @@ export function resolvePipeTypeFromFace(
     if (!isValidPipePos(probe)) continue;
     const resolved = resolvePipeType(variant, probe);
     if (resolved) return resolved;
+  }
+  return null;
+}
+
+// FB analogue of resolvePipeTypeFromFace. Iterates candidate open-axis values
+// to find a face-adjacent slot that lands on a valid pipe position, then sets
+// the spec's openAxis to match the slot's TQEC axis. Mirrors the placement
+// invariant in addBlock — the preset's template openAxis is overridden by
+// pipeAxisFromPos at placement time.
+// eslint-disable-next-line react-refresh/only-export-components
+export function resolveFBSpecFromFace(
+  srcPos: Position3D,
+  srcType: BlockType,
+  normal: THREE.Vector3,
+  preset: FBPreset,
+): { adj: Position3D; spec: FreeBuildPipeSpec } | null {
+  for (const ax of [0, 1, 2] as const) {
+    const candidate: FreeBuildPipeSpec = { ...preset.spec, openAxis: ax };
+    const adj = getAdjacentPos(srcPos, srcType, normal, candidate);
+    if (!isValidPipePos(adj)) continue;
+    const tqecAxis = pipeAxisFromPos(adj);
+    if (tqecAxis === null) continue;
+    return { adj, spec: { ...preset.spec, openAxis: tqecAxis } };
   }
   return null;
 }
@@ -270,7 +294,14 @@ function TypedInstances({
 
       // Determine the destination block type for adjacent placement
       let dstType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
+      if (store.fbPreset) {
+        const r = resolveFBSpecFromFace(hovered.pos, hovered.type, e.face.normal, store.fbPreset);
+        if (!r) {
+          store.setHoveredGridPos(null);
+          return;
+        }
+        dstType = r.spec;
+      } else if (store.pipeVariant) {
         const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, e.face.normal, store.pipeVariant);
         if (!resolved) {
           store.setHoveredGridPos(null);
@@ -358,7 +389,11 @@ function TypedInstances({
       if (!e.face) return;
 
       let dstType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
+      if (store.fbPreset) {
+        const r = resolveFBSpecFromFace(clicked.pos, clicked.type, e.face.normal, store.fbPreset);
+        if (!r) return;
+        dstType = r.spec;
+      } else if (store.pipeVariant) {
         const resolved = resolvePipeTypeFromFace(clicked.pos, clicked.type, e.face.normal, store.pipeVariant);
         if (!resolved) return;
         dstType = resolved;

--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -234,6 +234,16 @@ function TypedInstances({
       // Port-conversion tool: no ghost preview on existing blocks — the click
       // either removes the cube or does nothing (and sets a warning).
       store.setHoveredGridPos(null);
+    } else if (
+      store.mode === "edit" &&
+      armed === "pipe" &&
+      store.fbPreset &&
+      isFreeBuildPipeSpec(b[e.instanceId].type)
+    ) {
+      // Mirrors the click branch below: hovering an existing FB pipe with an
+      // FB preset armed will select it on click, not place adjacent — so
+      // suppress the place-adjacent ghost.
+      store.setHoveredGridPos(null);
     } else {
       // Place mode: pure decision logic lives in BlockInstances.logic.ts so
       // the cube-replace gate and FB/TQEC pipe paths are unit-testable.
@@ -268,6 +278,15 @@ function TypedInstances({
     }
     const armed = store.armedTool;
     if (armed === "pointer") {
+      store.selectBlock(b[e.instanceId].pos, e.nativeEvent.shiftKey);
+      return;
+    }
+    // Free Build: clicking an existing FB pipe focuses it (opens the variants
+    // picker, enables Backspace-to-delete) instead of trying to place an
+    // adjacent pipe. Chain-extension still works via the port ghosts at open
+    // endpoints. Without this, the user has no way to select an FB pipe while
+    // an FB preset is armed (armedTool === "pipe").
+    if (armed === "pipe" && store.fbPreset && isFreeBuildPipeSpec(b[e.instanceId].type)) {
       store.selectBlock(b[e.instanceId].pos, e.nativeEvent.shiftKey);
       return;
     }

--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -15,9 +15,11 @@ import {
   isValidPipePos,
   isValidPos,
   isPipeType,
+  isFreeBuildPipeSpec,
   resolvePipeType,
   getAdjacentPos,
   posKey,
+  blockTypeCacheKey,
   VARIANT_AXIS_MAP,
 } from "../types";
 import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant } from "../types";
@@ -33,7 +35,7 @@ const MIN_CAPACITY = 64;
  * geometry never changes. Bounded at ~19 types × 64 masks = ~1216 entries max.
  */
 const geometryCache = new Map<string, THREE.BufferGeometry>();
-const fullBoxCache = new Map<BlockType, THREE.BoxGeometry>();
+const fullBoxCache = new Map<string, THREE.BoxGeometry>();
 const edgesCache = new Map<string, THREE.BufferGeometry>();
 const edgeLineMaterial = new THREE.LineBasicMaterial({ color: "#000000" });
 const dimmedEdgeLineMaterial = new THREE.LineBasicMaterial({
@@ -61,7 +63,7 @@ export function resolvePipeTypeFromFace(
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function getCachedGeometry(blockType: BlockType, hiddenFaces: FaceMask): THREE.BufferGeometry {
-  const key = `${blockType}:${hiddenFaces}`;
+  const key = `${blockTypeCacheKey(blockType)}:${hiddenFaces}`;
   let geo = geometryCache.get(key);
   if (!geo) {
     geo = createBlockGeometry(blockType, hiddenFaces);
@@ -72,7 +74,7 @@ export function getCachedGeometry(blockType: BlockType, hiddenFaces: FaceMask): 
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function getCachedEdges(blockType: BlockType, hiddenFaces: FaceMask): THREE.BufferGeometry {
-  const key = `${blockType}:${hiddenFaces}`;
+  const key = `${blockTypeCacheKey(blockType)}:${hiddenFaces}`;
   let geo = edgesCache.get(key);
   if (!geo) {
     geo = createBlockEdges(blockType, hiddenFaces);
@@ -83,10 +85,11 @@ export function getCachedEdges(blockType: BlockType, hiddenFaces: FaceMask): THR
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function getCachedFullBox(blockType: BlockType): THREE.BoxGeometry {
-  let geo = fullBoxCache.get(blockType);
+  const key = blockTypeCacheKey(blockType);
+  let geo = fullBoxCache.get(key);
   if (!geo) {
     geo = new THREE.BoxGeometry(...blockThreeSize(blockType));
-    fullBoxCache.set(blockType, geo);
+    fullBoxCache.set(key, geo);
   }
   return geo;
 }
@@ -116,7 +119,7 @@ function TypedInstances({
   while (maxCount < blocks.length) maxCount *= 2;
   if (maxCount !== capacity) setCapacity(maxCount);
 
-  const pipe = isPipeType(cubeType);
+  const pipe = isPipeType(cubeType) || isFreeBuildPipeSpec(cubeType);
   const geometry = getCachedGeometry(cubeType, hiddenFaces);
   const fullBoxGeometry = pipe ? getCachedFullBox(cubeType) : null;
   const material = useMemo(
@@ -404,7 +407,7 @@ export function BlockInstances() {
       const dimmed =
         flowVizMode ||
         (viewMode.kind === "iso" && !posInActiveSlice(viewMode, block.pos));
-      const key = `${block.type}:${hf}:${dimmed ? 1 : 0}`;
+      const key = `${blockTypeCacheKey(block.type)}:${hf}:${dimmed ? 1 : 0}`;
       const existing = map.get(key);
       if (existing) {
         existing.blocks.push(block);

--- a/gui/src/components/DragShadow.test.tsx
+++ b/gui/src/components/DragShadow.test.tsx
@@ -1,0 +1,162 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block } from "../types";
+import { DragShadow, MAX_SHADOWS } from "./DragShadow";
+
+function meshColor(node: { instance: unknown }): number {
+  return ((node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial).color.getHex();
+}
+
+function mk(pos: { x: number; y: number; z: number }, type: Block["type"] = "XZZ"): Block {
+  return { pos, type };
+}
+
+function setup(opts: {
+  blocks?: Array<[string, Block]>;
+  selected?: string[];
+  dragDelta?: { x: number; y: number; z: number } | null;
+  dragValid?: boolean;
+}) {
+  useBlockStore.setState(
+    {
+      blocks: new Map(opts.blocks ?? []),
+      selectedKeys: new Set(opts.selected ?? []),
+      dragDelta: opts.dragDelta ?? null,
+      dragValid: opts.dragValid ?? true,
+      isDraggingSelection: opts.dragDelta != null,
+    },
+    false,
+  );
+}
+
+beforeEach(() => {
+  // Hard reset all fields DragShadow reads, plus closely-related drag state.
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      selectedKeys: new Set(),
+      dragDelta: null,
+      dragValid: true,
+      isDraggingSelection: false,
+    },
+    false,
+  );
+});
+
+describe("<DragShadow>", () => {
+  it("renders nothing with empty selection", async () => {
+    setup({});
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("renders one shadow per elevated selected block at rest, none for z=0 blocks", async () => {
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["0,0,3", mk({ x: 0, y: 0, z: 3 })],
+        ["3,0,3", mk({ x: 3, y: 0, z: 3 })],
+      ],
+      selected: ["0,0,0", "0,0,3", "3,0,3"],
+      dragDelta: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // Two elevated blocks -> two GroundShadowAbsolute groups.
+    expect(r.scene.findAllByType("Group")).toHaveLength(2);
+  });
+
+  it("renders nothing if all selected blocks are on the ground", async () => {
+    setup({
+      blocks: [["0,0,0", mk({ x: 0, y: 0, z: 0 })]],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("uses shifted positions when dragDelta is non-zero", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 6, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const group = r.scene.findByType("Group");
+    // Shifted block at (6, 0, 3) -> ground center cx = 6.5, cz = -0.5
+    expect(group.instance.position.x).toBeCloseTo(6.5);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+
+  it("treats {0,0,0} dragDelta as at-rest mode (no shift, neutral validity)", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 0, y: 0, z: 0 },
+      dragValid: false, // would turn red if drag mode kicked in
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // At-rest -> always-valid -> black mesh, not red
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0x000000);
+  });
+
+  it("renders red shadows when dragValid=false during a real drag", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 3, y: 0, z: 0 },
+      dragValid: false,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0xff5555);
+  });
+
+  it("caps at MAX_SHADOWS for huge selections", async () => {
+    const blocks: Array<[string, Block]> = [];
+    const selected: string[] = [];
+    // Build 250 elevated blocks, all selected
+    for (let i = 0; i < 250; i++) {
+      const key = `${i * 3},0,3`;
+      blocks.push([key, mk({ x: i * 3, y: 0, z: 3 })]);
+      selected.push(key);
+    }
+    setup({ blocks, selected });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(MAX_SHADOWS);
+  });
+
+  it("applies yBlockZOffset to at-rest Y-cube under a pipe (visually lifted)", async () => {
+    // Y-cube at logical z=0 with a pipe at z=1 above it -> visually lifted by 0.5
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")], // Z-open pipe above
+      ],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // With the lift, the Y-cube's effective z is 0.5 -> shadow appears.
+    expect(r.scene.findAllByType("Group")).toHaveLength(1);
+    const line = r.scene.findByType("LineSegments");
+    // Line len = 0.5 - Y_OFFSET ≈ 0.49
+    expect(line.instance.scale.y).toBeCloseTo(0.49, 2);
+  });
+
+  it("does NOT apply yBlockZOffset during drag (mirrors DragGhost behavior)", async () => {
+    // Y-cube being dragged from z=0 to z=3. During drag we use shifted logical
+    // pos (z=3), no lift even if a pipe sits at z=4 in the destination.
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["3,0,4", mk({ x: 3, y: 0, z: 4 }, "ZXO")], // pipe at destination top
+      ],
+      selected: ["0,0,0"],
+      dragDelta: { x: 3, y: 0, z: 3 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const line = r.scene.findByType("LineSegments");
+    // Pure shifted z=3, line len = 3 - Y_OFFSET ≈ 2.99
+    expect(line.instance.scale.y).toBeCloseTo(2.99, 2);
+  });
+});

--- a/gui/src/components/DragShadow.tsx
+++ b/gui/src/components/DragShadow.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import { useBlockStore } from "../stores/blockStore";
+import { yBlockZOffset } from "../types";
+import type { Block, Position3D } from "../types";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+export const MAX_SHADOWS = 200;
+
+export function DragShadow() {
+  const dragDelta = useBlockStore((s) => s.dragDelta);
+  const dragValid = useBlockStore((s) => s.dragValid);
+  const selectedKeys = useBlockStore((s) => s.selectedKeys);
+  const blocks = useBlockStore((s) => s.blocks);
+
+  // Stable list keyed on selectedKeys/blocks (same pattern as DragGhost) so
+  // rAF-driven dragDelta/dragValid only re-render leaves.
+  const shadows = useMemo(() => {
+    const result: Array<{ key: string; block: Block }> = [];
+    for (const key of selectedKeys) {
+      const block = blocks.get(key);
+      if (!block) continue;
+      result.push({ key, block });
+      if (result.length >= MAX_SHADOWS) break;
+    }
+    return result;
+  }, [selectedKeys, blocks]);
+
+  if (shadows.length === 0) return null;
+
+  // {0,0,0} delta = at-rest mode (treated as null). Drag commits a non-zero
+  // delta the moment the pointer crosses the drag threshold.
+  const liveDelta =
+    dragDelta && (dragDelta.x !== 0 || dragDelta.y !== 0 || dragDelta.z !== 0)
+      ? dragDelta
+      : null;
+  const valid = liveDelta ? dragValid : true;
+
+  return (
+    <>
+      {shadows.map(({ key, block }) => {
+        let pos: Position3D;
+        if (liveDelta) {
+          // Drag mode: shifted logical position, no Y-cube lift (matches
+          // DragGhost which renders the dragged ghost at the logical destination).
+          pos = {
+            x: block.pos.x + liveDelta.x,
+            y: block.pos.y + liveDelta.y,
+            z: block.pos.z + liveDelta.z,
+          };
+        } else {
+          // At-rest mode: committed block is rendered by BlockInstances with
+          // yBlockZOffset applied to Y-cubes that have a pipe above. Mirror
+          // that lift here so the shadow reflects what the user actually SEES,
+          // not the bare logical z.
+          const lift = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+          pos = { ...block.pos, z: block.pos.z + lift };
+        }
+        return (
+          <GroundShadowAbsolute
+            key={key}
+            pos={pos}
+            blockType={block.type}
+            valid={valid}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/gui/src/components/FlowsPanel.tsx
+++ b/gui/src/components/FlowsPanel.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useBlockStore } from "../stores/blockStore";
 import { computeFlows, type FlowsResult } from "../utils/flows";
-import { getAllPortPositions, type Position3D } from "../types";
+import { blockTypeCacheKey, getAllPortPositions, type BlockType, type Position3D } from "../types";
 import { isInSpanGF2, pauliToSymplectic } from "../utils/stabilizerSpan";
 import { useFloatingPanel } from "../hooks/useFloatingPanel";
 import { ResizeGrip } from "../hooks/ResizeGrip";
@@ -38,11 +38,11 @@ const PAULI_COLOR: Record<string, string> = {
 };
 
 function signature(
-  blocks: Map<string, { pos: Position3D; type: string }>,
+  blocks: Map<string, { pos: Position3D; type: BlockType }>,
   portMeta: Map<string, { label: string; io: "in" | "out" }>,
 ): string {
   const b: string[] = [];
-  for (const [k, v] of blocks) b.push(`${k}:${v.type}`);
+  for (const [k, v] of blocks) b.push(`${k}:${blockTypeCacheKey(v.type)}`);
   b.sort();
   const m: string[] = [];
   for (const [k, v] of portMeta) m.push(`${k}=${v.label}/${v.io}`);

--- a/gui/src/components/FlowsPanel.tsx
+++ b/gui/src/components/FlowsPanel.tsx
@@ -221,19 +221,52 @@ export function FlowsPanel({
     if (stale && flowVizMode) setFlowVizMode(false);
   }, [stale, flowVizMode, setFlowVizMode]);
 
+  // Order port labels by user-defined rank (PortMeta.rank). Labels without a
+  // rank fall back to the server's order. This drives the column order in the
+  // generator and membership tables, i.e. the qubit-register position when
+  // the diagram is interpreted as a circuit.
+  const labelRank = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const meta of portMeta.values()) {
+      if (meta.rank !== undefined) m.set(meta.label, meta.rank);
+    }
+    return m;
+  }, [portMeta]);
+  const sortByRank = useCallback(
+    (labels: string[]): string[] => {
+      const indexed = labels.map((l, i) => ({ l, i }));
+      indexed.sort((a, b) => {
+        const ra = labelRank.get(a.l) ?? Number.POSITIVE_INFINITY;
+        const rb = labelRank.get(b.l) ?? Number.POSITIVE_INFINITY;
+        if (ra !== rb) return ra - rb;
+        return a.i - b.i;
+      });
+      return indexed.map(({ l }) => l);
+    },
+    [labelRank],
+  );
+  const orderedInputs = useMemo(
+    () => (result?.ok ? sortByRank(result.inputs) : []),
+    [result, sortByRank],
+  );
+  const orderedOutputs = useMemo(
+    () => (result?.ok ? sortByRank(result.outputs) : []),
+    [result, sortByRank],
+  );
+
   const generatorSpan = useMemo(() => {
     if (!result || !result.ok) return null;
-    const labels = [...result.inputs, ...result.outputs];
+    const labels = [...orderedInputs, ...orderedOutputs];
     const vecs = result.flows.map((flow) => {
       const pauliStr = labels
         .map((l, i) =>
-          i < result.inputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
+          i < orderedInputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
         )
         .join("");
       return pauliToSymplectic(pauliStr);
     });
-    return { labels, vecs, inputCount: result.inputs.length };
-  }, [result]);
+    return { labels, vecs, inputCount: orderedInputs.length };
+  }, [result, orderedInputs, orderedOutputs]);
 
   const addQuery = useCallback(() => {
     if (!generatorSpan) return;
@@ -475,7 +508,7 @@ export function FlowsPanel({
               <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                 <thead>
                   <tr>
-                    {result.inputs.map((label) => (
+                    {orderedInputs.map((label) => (
                       <th
                         key={`in-${label}`}
                         style={{
@@ -489,7 +522,7 @@ export function FlowsPanel({
                       </th>
                     ))}
                     <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>→</th>
-                    {result.outputs.map((label) => (
+                    {orderedOutputs.map((label) => (
                       <th
                         key={`out-${label}`}
                         style={{
@@ -521,7 +554,7 @@ export function FlowsPanel({
                           outline: isActive ? "2px solid #4a9eff" : undefined,
                         }}
                       >
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <td
                             key={`in-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -530,7 +563,7 @@ export function FlowsPanel({
                           </td>
                         ))}
                         <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <td
                             key={`out-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -610,7 +643,7 @@ export function FlowsPanel({
                   <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                     <thead>
                       <tr>
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <th
                             key={`qin-${label}`}
                             style={{
@@ -626,7 +659,7 @@ export function FlowsPanel({
                         <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>
                           →
                         </th>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <th
                             key={`qout-${label}`}
                             style={{
@@ -648,7 +681,7 @@ export function FlowsPanel({
                         const inSpan = isQueryInSpan(q);
                         return (
                           <tr key={q.id}>
-                            {result.inputs.map((label) => (
+                            {orderedInputs.map((label) => (
                               <td
                                 key={`qin-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}
@@ -660,7 +693,7 @@ export function FlowsPanel({
                               </td>
                             ))}
                             <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                            {result.outputs.map((label) => (
+                            {orderedOutputs.map((label) => (
                               <td
                                 key={`qout-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}

--- a/gui/src/components/FoldOutCubeOverlay.tsx
+++ b/gui/src/components/FoldOutCubeOverlay.tsx
@@ -29,6 +29,7 @@ export function FoldOutCubeOverlay() {
       hf: number;
     }> = [];
     for (const block of blocks.values()) {
+      if (typeof block.type !== "string") continue;  // skip FB blocks (objects)
       if (!(CUBE_TYPES as readonly string[]).includes(block.type)) continue;
       const k = posKey(block.pos);
       if (undeterminedCubes.has(k)) continue;

--- a/gui/src/components/FreeBuildPipeVariantsPanel.tsx
+++ b/gui/src/components/FreeBuildPipeVariantsPanel.tsx
@@ -8,6 +8,7 @@ import {
   faceAboveBasis,
   faceBelowBasis,
   isFreeBuildPipeSpec,
+  validFBPipeVariantsXZZXAxis,
 } from "../types";
 import type { FaceConfig } from "../types";
 import { useFloatingPanel } from "../hooks/useFloatingPanel";
@@ -113,8 +114,54 @@ export function FreeBuildPipeVariantsPanel() {
 
   const variants = useMemo(() => enumerateVariants(), []);
 
+  const partitioned = useMemo(() => {
+    if (!block) return null;
+    const valid = validFBPipeVariantsXZZXAxis(block, blocks);
+    if (!valid) return null;
+    const validKeys = new Set(valid.map((v) => v.join("|")));
+    const validList: typeof variants = [];
+    const invalidList: typeof variants = [];
+    for (const v of variants) {
+      if (validKeys.has(v.join("|"))) validList.push(v);
+      else invalidList.push(v);
+    }
+    return { validList, invalidList };
+  }, [block, blocks, variants]);
+
   if (!open || !block || !isFreeBuildPipeSpec(block.type)) return null;
   const currentFaces = block.type.faces;
+
+  const renderCell = (faces: [FaceConfig, FaceConfig, FaceConfig, FaceConfig]) => {
+    const isCurrent = facesEqual(faces, currentFaces);
+    const key = faces.join("|");
+    return (
+      <button
+        key={key}
+        type="button"
+        onClick={() => setFBPipeFaces(block.pos, faces)}
+        title={faces.join(" ")}
+        style={{
+          padding: 4,
+          background: isCurrent ? "#e8f1ff" : "#fafafa",
+          border: `1px solid ${isCurrent ? "#4a9eff" : "#e0e0e0"}`,
+          borderRadius: 4,
+          cursor: "pointer",
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <VariantSprite faces={faces} />
+      </button>
+    );
+  };
+
+  const sectionHeaderStyle = {
+    gridColumn: "1 / -1",
+    color: "#666",
+    fontSize: 11,
+    fontWeight: 600,
+    padding: "4px 2px 2px",
+  } as const;
 
   return (
     <div
@@ -173,28 +220,25 @@ export function FreeBuildPipeVariantsPanel() {
           gap: 6,
         }}
       >
-        {variants.map((faces, idx) => {
-          const isCurrent = facesEqual(faces, currentFaces);
-          return (
-            <button
-              key={idx}
-              type="button"
-              onClick={() => setFBPipeFaces(block.pos, faces)}
-              title={faces.join(" ")}
+        {partitioned ? (
+          <>
+            <div style={sectionHeaderStyle}>Valid for XZZ–XZZ in X</div>
+            {partitioned.validList.map(renderCell)}
+            <div
               style={{
-                padding: 4,
-                background: isCurrent ? "#e8f1ff" : "#fafafa",
-                border: `1px solid ${isCurrent ? "#4a9eff" : "#e0e0e0"}`,
-                borderRadius: 4,
-                cursor: "pointer",
-                display: "flex",
-                justifyContent: "center",
+                ...sectionHeaderStyle,
+                borderTop: "1px solid #eee",
+                marginTop: 6,
+                paddingTop: 8,
               }}
             >
-              <VariantSprite faces={faces} />
-            </button>
-          );
-        })}
+              Other variants (not valid for XZZ–XZZ in X)
+            </div>
+            {partitioned.invalidList.map(renderCell)}
+          </>
+        ) : (
+          variants.map(renderCell)
+        )}
       </div>
 
       <ResizeGrip {...resizeGripProps} />

--- a/gui/src/components/FreeBuildPipeVariantsPanel.tsx
+++ b/gui/src/components/FreeBuildPipeVariantsPanel.tsx
@@ -8,7 +8,7 @@ import {
   faceAboveBasis,
   faceBelowBasis,
   isFreeBuildPipeSpec,
-  validFBPipeVariantsXZZXAxis,
+  validFBPipeVariantsForCubePair,
 } from "../types";
 import type { FaceConfig } from "../types";
 import { useFloatingPanel } from "../hooks/useFloatingPanel";
@@ -116,16 +116,18 @@ export function FreeBuildPipeVariantsPanel() {
 
   const partitioned = useMemo(() => {
     if (!block) return null;
-    const valid = validFBPipeVariantsXZZXAxis(block, blocks);
-    if (!valid) return null;
-    const validKeys = new Set(valid.map((v) => v.join("|")));
+    const result = validFBPipeVariantsForCubePair(block, blocks);
+    if (!result) return null;
+    const axisName = ["X", "Y", "Z"][result.openAxis];
+    const label = `${result.negType}–${result.posType} in ${axisName}`;
+    const validKeys = new Set(result.faces.map((v) => v.join("|")));
     const validList: typeof variants = [];
     const invalidList: typeof variants = [];
     for (const v of variants) {
       if (validKeys.has(v.join("|"))) validList.push(v);
       else invalidList.push(v);
     }
-    return { validList, invalidList };
+    return { validList, invalidList, label };
   }, [block, blocks, variants]);
 
   if (!open || !block || !isFreeBuildPipeSpec(block.type)) return null;
@@ -222,7 +224,7 @@ export function FreeBuildPipeVariantsPanel() {
       >
         {partitioned ? (
           <>
-            <div style={sectionHeaderStyle}>Valid for XZZ–XZZ in X</div>
+            <div style={sectionHeaderStyle}>Valid for {partitioned.label}</div>
             {partitioned.validList.map(renderCell)}
             <div
               style={{
@@ -232,7 +234,7 @@ export function FreeBuildPipeVariantsPanel() {
                 paddingTop: 8,
               }}
             >
-              Other variants (not valid for XZZ–XZZ in X)
+              Other variants (not valid for {partitioned.label})
             </div>
             {partitioned.invalidList.map(renderCell)}
           </>

--- a/gui/src/components/FreeBuildPipeVariantsPanel.tsx
+++ b/gui/src/components/FreeBuildPipeVariantsPanel.tsx
@@ -1,0 +1,203 @@
+import { useMemo } from "react";
+import { useBlockStore } from "../stores/blockStore";
+import {
+  FACE_CONFIGS,
+  X_HEX,
+  Y_DEFECT_HEX,
+  Z_HEX,
+  faceAboveBasis,
+  faceBelowBasis,
+  isFreeBuildPipeSpec,
+} from "../types";
+import type { FaceConfig } from "../types";
+import { useFloatingPanel } from "../hooks/useFloatingPanel";
+import { ResizeGrip } from "../hooks/ResizeGrip";
+
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MIN_HEIGHT = 260;
+
+const COLOR_FOR: Record<"X" | "Z", string> = { X: X_HEX, Z: Z_HEX };
+
+const CELL_W = 56;
+const CELL_H = 36;
+// Face order matches FreeBuildPipeSpec.faces: [+ca0, −ca0, +ca1, −ca1].
+const FACE_LABELS = ["+a", "−a", "+b", "−b"] as const;
+
+function VariantSprite({ faces, size = 1 }: { faces: readonly FaceConfig[]; size?: number }) {
+  // 4 walls × (below, above) strips. Layout: vertical stack of 4 rows, each
+  // row is two halves (left = below, right = above). A magenta divider sits
+  // between the halves on swapping faces (XZ/ZX), echoing the Y-defect ring.
+  const rowH = (CELL_H * size) / 4;
+  const halfW = (CELL_W * size) / 2;
+  return (
+    <svg
+      width={CELL_W * size}
+      height={CELL_H * size}
+      viewBox={`0 0 ${CELL_W * size} ${CELL_H * size}`}
+      shapeRendering="crispEdges"
+    >
+      {faces.map((fc, i) => {
+        const y = i * rowH;
+        const below = COLOR_FOR[faceBelowBasis(fc)];
+        const above = COLOR_FOR[faceAboveBasis(fc)];
+        const swap = fc === "XZ" || fc === "ZX";
+        return (
+          <g key={i}>
+            <rect x={0} y={y} width={halfW} height={rowH} fill={below} />
+            <rect x={halfW} y={y} width={halfW} height={rowH} fill={above} />
+            {swap && (
+              <line
+                x1={halfW}
+                y1={y}
+                x2={halfW}
+                y2={y + rowH}
+                stroke={Y_DEFECT_HEX}
+                strokeWidth={2}
+              />
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function facesEqual(
+  a: readonly FaceConfig[],
+  b: readonly FaceConfig[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** Enumerate every (face0, face1, face2, face3) ∈ FACE_CONFIGS⁴. */
+function enumerateVariants(): Array<[FaceConfig, FaceConfig, FaceConfig, FaceConfig]> {
+  const out: Array<[FaceConfig, FaceConfig, FaceConfig, FaceConfig]> = [];
+  for (const f0 of FACE_CONFIGS) {
+    for (const f1 of FACE_CONFIGS) {
+      for (const f2 of FACE_CONFIGS) {
+        for (const f3 of FACE_CONFIGS) {
+          out.push([f0, f1, f2, f3]);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+export function FreeBuildPipeVariantsPanel() {
+  const fbPos = useBlockStore((s) => s.fbVariantsPos);
+  const blocks = useBlockStore((s) => s.blocks);
+  const setFBVariantsPos = useBlockStore((s) => s.setFBVariantsPos);
+  const setFBPipeFaces = useBlockStore((s) => s.setFBPipeFaces);
+
+  const block = fbPos ? blocks.get(fbPos) : null;
+  const open = !!(block && isFreeBuildPipeSpec(block.type));
+
+  const {
+    containerStyle,
+    dragHandleProps,
+    resizeGripProps,
+  } = useFloatingPanel({
+    id: "fb-variants",
+    defaultGeometry: {
+      x: typeof window !== "undefined" ? window.innerWidth - 360 : 10,
+      y: 70,
+      width: 340,
+      height: 460,
+    },
+    minWidth: PANEL_MIN_WIDTH,
+    minHeight: PANEL_MIN_HEIGHT,
+  });
+
+  const variants = useMemo(() => enumerateVariants(), []);
+
+  if (!open || !block || !isFreeBuildPipeSpec(block.type)) return null;
+  const currentFaces = block.type.faces;
+
+  return (
+    <div
+      style={{
+        ...containerStyle,
+        zIndex: 50,
+        background: "#fff",
+        borderRadius: 10,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "sans-serif",
+        fontSize: 12,
+        color: "#222",
+        overflow: "hidden",
+      }}
+    >
+      <header
+        {...dragHandleProps}
+        style={{
+          ...dragHandleProps.style,
+          padding: "10px 12px",
+          borderBottom: "1px solid #eee",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: 13 }}>Free Pipe variants</span>
+        <button
+          onClick={() => setFBVariantsPos(null)}
+          aria-label="Close FB variants panel"
+          style={{ background: "none", border: "none", fontSize: 16, cursor: "pointer", color: "#666", padding: "0 4px" }}
+        >
+          ✕
+        </button>
+      </header>
+
+      <div style={{ padding: "8px 12px", borderBottom: "1px solid #eee", display: "flex", alignItems: "center", gap: 12 }}>
+        <span style={{ color: "#666" }}>Current</span>
+        <VariantSprite faces={currentFaces} size={1.2} />
+        <span style={{ color: "#888", fontFamily: "monospace" }}>{currentFaces.join(" ")}</span>
+      </div>
+
+      <div style={{ padding: "8px 12px", color: "#666", fontSize: 11, borderBottom: "1px solid #eee" }}>
+        Rows top→bottom: {FACE_LABELS.join(", ")}. Left half = below defect, right half = above.
+      </div>
+
+      <div
+        style={{
+          padding: 8,
+          flex: 1,
+          overflowY: "auto",
+          display: "grid",
+          gridTemplateColumns: `repeat(auto-fill, minmax(${CELL_W + 12}px, 1fr))`,
+          gap: 6,
+        }}
+      >
+        {variants.map((faces, idx) => {
+          const isCurrent = facesEqual(faces, currentFaces);
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => setFBPipeFaces(block.pos, faces)}
+              title={faces.join(" ")}
+              style={{
+                padding: 4,
+                background: isCurrent ? "#e8f1ff" : "#fafafa",
+                border: `1px solid ${isCurrent ? "#4a9eff" : "#e0e0e0"}`,
+                borderRadius: 4,
+                cursor: "pointer",
+                display: "flex",
+                justifyContent: "center",
+              }}
+            >
+              <VariantSprite faces={faces} />
+            </button>
+          );
+        })}
+      </div>
+
+      <ResizeGrip {...resizeGripProps} />
+    </div>
+  );
+}

--- a/gui/src/components/GhostBlock.test.tsx
+++ b/gui/src/components/GhostBlock.test.tsx
@@ -1,0 +1,173 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { GhostBlock } from "./GhostBlock";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+describe("<GhostBlock>", () => {
+  it("renders nothing when hoveredGridPos is null", async () => {
+    useBlockStore.setState({ hoveredGridPos: null }, false);
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in build mode", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, mode: "build" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is pointer", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "pointer" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is paste", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "paste" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders cube ghost only (no shadow) at ground level", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 0 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // The ghost itself is one positioned group + inner scaled group; no second
+    // GroundShadowAbsolute group because z=0 -> shouldRenderShadow false.
+    const groups = r.scene.findAllByType("Group");
+    // 1 outer positioned group + 1 inner scaled group = 2 (no shadow group)
+    expect(groups.length).toBe(2);
+  });
+
+  it("renders cube ghost + GroundShadowAbsolute at z=2", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    const groups = r.scene.findAllByType("Group");
+    // ghost outer + ghost inner-scaled + GroundShadowAbsolute world-positioned group = 3
+    expect(groups.length).toBe(3);
+    // 2 LineSegments: ghost-block edges (existing) + shadow projection line (new).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("Y-cube placement preview at z=0 with pipe above gets a lifted shadow", async () => {
+    // A Z-open pipe sits at z=1 directly above the hovered Y placement at z=0.
+    // yBlockZOffset returns 0.5 → effective z = 0.5 → shadow renders.
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 0 },
+        armedTool: "cube",
+        cubeType: "Y",
+        blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Without the yBlockZOffset adjustment, no shadow would render (logical z=0).
+    // With it, effective z=0.5 → shadow + line appear. 2 LineSegments total:
+    // ghost-block edges + shadow projection line.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("port placement preview at z=2 renders port ghost + GroundShadow", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "port" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Port ghost positioned group + GroundShadowAbsolute group = 2
+    const groups = r.scene.findAllByType("Group");
+    expect(groups.length).toBe(2);
+    // port-ghost edges (existing) + shadow line (new) = 2 LineSegments.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("isInvalid hover at z=2 renders red shadow (invalid color)", async () => {
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        hoveredInvalid: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Both the ghost edges and the shadow line render in red for invalid hover.
+    // GhostBlock uses #ff0000 lineMaterial; GroundShadowAbsolute uses #ff0000.
+    // Assert all LineSegments are red.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
+  });
+
+  it("isDelete (xHeld in edit mode) renders delete preview but NO shadow", async () => {
+    // xHeld + edit mode = isDelete. We render the existing block being targeted
+    // for removal in red, but explicitly do NOT add a ground shadow (it's a
+    // "remove this" cue, not a "place here" cue).
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        xHeld: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Delete branch renders only a mesh (no edges). No shadow either.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(0);
+  });
+});

--- a/gui/src/components/GhostBlock.tsx
+++ b/gui/src/components/GhostBlock.tsx
@@ -218,7 +218,7 @@ function GhostBlockInner() {
               </lineSegments>
             )}
             {showFoldOutCube && (
-              <FoldOutCubeFaces blockType={activeType as string} topAxis={foldTopAxis} />
+              <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
             )}
           </group>
         )}

--- a/gui/src/components/GhostBlock.tsx
+++ b/gui/src/components/GhostBlock.tsx
@@ -13,6 +13,7 @@ import { isoTopThreeAxis } from "../utils/isoFoldOut";
 import type { ThreeAxis } from "../utils/isoFoldOut";
 import { getCachedGeometry, getCachedEdges, getCachedFullBox } from "./BlockInstances";
 import { FoldOutCubeFaces } from "./FoldOutCube";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
 
 const noRaycast = () => {};
 
@@ -116,16 +117,19 @@ function GhostBlockInner() {
   if (armedTool === "port" && mode === "edit" && !xHeld) {
     const [x, y, z] = tqecToThree(hoveredGridPos, "XZZ");
     return (
-      <group position={[x, y, z]}>
-        <mesh raycast={noRaycast}>
-          <primitive object={portGhostBox} attach="geometry" />
-          <primitive object={portGhostMaterial} attach="material" />
-        </mesh>
-        <lineSegments raycast={noRaycast}>
-          <primitive object={portGhostEdges} attach="geometry" />
-          <primitive object={validLineMaterial} attach="material" />
-        </lineSegments>
-      </group>
+      <>
+        <group position={[x, y, z]}>
+          <mesh raycast={noRaycast}>
+            <primitive object={portGhostBox} attach="geometry" />
+            <primitive object={portGhostMaterial} attach="material" />
+          </mesh>
+          <lineSegments raycast={noRaycast}>
+            <primitive object={portGhostEdges} attach="geometry" />
+            <primitive object={validLineMaterial} attach="material" />
+          </lineSegments>
+        </group>
+        <GroundShadowAbsolute pos={hoveredGridPos} blockType="XZZ" valid />
+      </>
     );
   }
 
@@ -179,39 +183,54 @@ function GhostBlockInner() {
     (CUBE_TYPES as readonly string[]).includes(activeType);
   const foldTopAxis: ThreeAxis = viewMode.kind === "iso" ? isoTopThreeAxis(viewMode.axis) : 0;
 
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // a Y-cube placement preview lifted by an above pipe still gets a shadow
+  // whose projection line reaches the rendered block bottom. No shadow for
+  // delete previews — that's a "remove this" cue, not a "place here" cue.
+  const shadowPos = { ...hoveredGridPos, z: hoveredGridPos.z + zo };
+
   return (
-    <group position={[x, y, z]}>
-      {isDelete ? (
-        <mesh scale={1.01} raycast={noRaycast}>
-          <primitive object={getCachedFullBox(activeType)} attach="geometry" />
-          <primitive object={deleteMaterial} attach="material" />
-        </mesh>
-      ) : (
-        <group scale={scale}>
-          {!showFoldOutCube && (
-            <>
-              <mesh>
-                <primitive object={ghostGeometry} attach="geometry" />
-                <primitive object={meshMat} attach="material" />
-              </mesh>
-              <lineSegments>
-                <primitive object={ghostEdges} attach="geometry" />
-                <primitive object={lineMat} attach="material" />
+    <>
+      <group position={[x, y, z]}>
+        {isDelete ? (
+          <mesh scale={1.01} raycast={noRaycast}>
+            <primitive object={getCachedFullBox(activeType)} attach="geometry" />
+            <primitive object={deleteMaterial} attach="material" />
+          </mesh>
+        ) : (
+          <group scale={scale}>
+            {!showFoldOutCube && (
+              <>
+                <mesh>
+                  <primitive object={ghostGeometry} attach="geometry" />
+                  <primitive object={meshMat} attach="material" />
+                </mesh>
+                <lineSegments>
+                  <primitive object={ghostEdges} attach="geometry" />
+                  <primitive object={lineMat} attach="material" />
+                </lineSegments>
+              </>
+            )}
+            {fullPipeEdges && (
+              <lineSegments scale={1.04} renderOrder={999}>
+                <primitive object={fullPipeEdges} attach="geometry" />
+                <primitive object={depthPipeOutlineMaterial} attach="material" />
               </lineSegments>
-            </>
-          )}
-          {fullPipeEdges && (
-            <lineSegments scale={1.04} renderOrder={999}>
-              <primitive object={fullPipeEdges} attach="geometry" />
-              <primitive object={depthPipeOutlineMaterial} attach="material" />
-            </lineSegments>
-          )}
-          {showFoldOutCube && (
-            <FoldOutCubeFaces blockType={activeType as string} topAxis={foldTopAxis} />
-          )}
-        </group>
+            )}
+            {showFoldOutCube && (
+              <FoldOutCubeFaces blockType={activeType as string} topAxis={foldTopAxis} />
+            )}
+          </group>
+        )}
+      </group>
+      {!isDelete && (
+        <GroundShadowAbsolute
+          pos={shadowPos}
+          blockType={activeType}
+          valid={!isInvalid}
+        />
       )}
-    </group>
+    </>
   );
 }
 

--- a/gui/src/components/GhostBlock.tsx
+++ b/gui/src/components/GhostBlock.tsx
@@ -175,6 +175,7 @@ function GhostBlockInner() {
     !isDelete &&
     !isInvalid &&
     viewMode.kind === "iso" &&
+    typeof activeType === "string" &&
     (CUBE_TYPES as readonly string[]).includes(activeType);
   const foldTopAxis: ThreeAxis = viewMode.kind === "iso" ? isoTopThreeAxis(viewMode.axis) : 0;
 
@@ -206,7 +207,7 @@ function GhostBlockInner() {
             </lineSegments>
           )}
           {showFoldOutCube && (
-            <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
+            <FoldOutCubeFaces blockType={activeType as string} topAxis={foldTopAxis} />
           )}
         </group>
       )}

--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -10,6 +10,7 @@ import {
   hasCubeColorConflict,
   hasPipeColorConflict,
   hasYCubePipeAxisConflict,
+  isFreeBuildPipeSpec,
   isValidPos,
   isPipeType,
   pipeAxisFromPos,
@@ -131,7 +132,7 @@ export function GridPlane() {
       setHoveredGridPos(null);
     } else if (!store.freeBuild && isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube", isReplace);
-    } else if (!store.freeBuild && !isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
+    } else if (!store.freeBuild && !isPipeType(blockType) && !isFreeBuildPipeSpec(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Cube colors don't match the adjacent pipe", isReplace);
     } else if (!store.freeBuild && hasYCubePipeAxisConflict(blockType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Y cube cannot be next to an X-open or Y-open pipe", isReplace);

--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -12,11 +12,12 @@ import {
   hasYCubePipeAxisConflict,
   isValidPos,
   isPipeType,
+  pipeAxisFromPos,
   resolvePipeType,
   posKey,
   axisIndex,
 } from "../types";
-import type { CubeType, Position3D, ViewMode } from "../types";
+import type { BlockType, CubeType, FreeBuildPipeSpec, Position3D, ViewMode } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
 import { snapIsoPos, isoGridMeshTransform } from "../utils/isoView";
 
@@ -90,12 +91,16 @@ export function GridPlane() {
       }
       return;
     }
-    const forPipe = store.pipeVariant !== null;
+    const forPipe = store.pipeVariant !== null || store.fbPreset !== null;
     const pos = snapForViewMode(viewMode, e.point, forPipe);
 
     // Determine actual block type for this position
-    let blockType = store.cubeType;
-    if (store.pipeVariant) {
+    let blockType: BlockType = store.cubeType;
+    if (store.fbPreset) {
+      const tqecAxis = pipeAxisFromPos(pos);
+      if (tqecAxis === null) { setHoveredGridPos(pos, undefined, true); return; }
+      blockType = { ...store.fbPreset.spec, openAxis: tqecAxis } as FreeBuildPipeSpec;
+    } else if (store.pipeVariant) {
       const resolved = resolvePipeType(store.pipeVariant, pos);
       if (!resolved) { setHoveredGridPos(pos, undefined, true); return; }
       blockType = resolved;
@@ -143,7 +148,7 @@ export function GridPlane() {
       store.addPortAt(pos);
       return;
     }
-    const forPipe = store.pipeVariant !== null;
+    const forPipe = store.pipeVariant !== null || store.fbPreset !== null;
     const pos = snapForViewMode(viewMode, e.point, forPipe);
     addBlock(pos);
   };

--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -19,6 +19,7 @@ import {
 } from "../types";
 import type { BlockType, CubeType, FreeBuildPipeSpec, Position3D, ViewMode } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
+import { shouldPassThroughGridPlane } from "../utils/gridPlanePassthrough";
 import { snapIsoPos, isoGridMeshTransform } from "../utils/isoView";
 
 const PLANE_SIZE = 1000;
@@ -62,6 +63,21 @@ export function GridPlane() {
   });
 
   const handlePointerMove = (e: ThreeEvent<PointerEvent>) => {
+    // Pass-through (pointer/paste only): when a block/port is also under the
+    // cursor, return early without stopProp so the block's onPointerMove sets
+    // hoveredGridPos. Done before any setHoveredGridPos call so we don't write
+    // the plane cell and let the block immediately overwrite it (one-frame
+    // flash on stacked hits).
+    if (mode === "edit") {
+      const s = useBlockStore.getState();
+      if (
+        !s.xHeld &&
+        (s.armedTool === "pointer" || s.armedTool === "paste") &&
+        shouldPassThroughGridPlane(e.intersections, meshRef.current)
+      ) {
+        return;
+      }
+    }
     e.stopPropagation();
     if (mode !== "edit") { setHoveredGridPos(null); return; }
 
@@ -125,17 +141,31 @@ export function GridPlane() {
   };
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {
-    e.stopPropagation();
-    if (e.delta > 2) return; // ignore drags
-    if (mode !== "edit") return;
+    if (e.delta > 2) { e.stopPropagation(); return; } // ignore drags
+    if (mode !== "edit") { e.stopPropagation(); return; }
 
     const store = useBlockStore.getState();
     // X-held delete on empty grid is a no-op.
-    if (store.xHeld) return;
+    if (store.xHeld) { e.stopPropagation(); return; }
+
     if (store.armedTool === "pointer") {
+      // Pass-through: when the click ray also hits a block or port ghost
+      // further along, let that handler own the event so sub-ground blocks
+      // (TQEC z<0) can be selected from above.
+      //
+      // NOTE: this couples deselect-on-empty-click policy to GridPlane. Any
+      // future clickable scene mesh must either opt out of raycast (the
+      // raycast={noRaycast} convention used by decoratives) or call
+      // e.stopPropagation() in its own onClick. Otherwise deselection would
+      // silently stop working through that mesh.
+      if (shouldPassThroughGridPlane(e.intersections, meshRef.current)) return;
+      e.stopPropagation();
       store.clearSelection();
       return;
     }
+    // Paste / port / placement: the plane is the intended target, so we
+    // always consume the click here.
+    e.stopPropagation();
     // Paste tool: commit the clipboard at the snapped hover cell, then
     // return to pointer (commitPaste sets armedTool="pointer").
     if (store.armedTool === "paste") {

--- a/gui/src/components/GroundShadowAbsolute.test.tsx
+++ b/gui/src/components/GroundShadowAbsolute.test.tsx
@@ -1,0 +1,103 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+import {
+  INVALID_LINE_COLOR,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+} from "../utils/groundShadow";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+function meshMaterial(node: { instance: unknown }): THREE.MeshBasicMaterial {
+  return (node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial;
+}
+function lineMaterial(node: { instance: unknown }): THREE.LineBasicMaterial {
+  return (node.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+}
+
+describe("<GroundShadowAbsolute>", () => {
+  it("renders nothing when on the ground (z=0)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 0 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing when below ground (defensive)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: -1 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders a group + mesh + line for an elevated cube", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 3, y: 6, z: 2 }} blockType="XZZ" valid />,
+    );
+    const groups = r.scene.findAllByType("Group");
+    expect(groups).toHaveLength(1);
+    const group = groups[0];
+    // World-space group at (cx, 0, cz) = (3.5, 0, -6.5)
+    expect(group.instance.position.x).toBeCloseTo(3.5);
+    expect(group.instance.position.y).toBeCloseTo(0);
+    expect(group.instance.position.z).toBeCloseTo(-6.5);
+    // Mesh + line live inside the group
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(1);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(1);
+  });
+
+  it("rotates mesh -PI/2 around X (lays plane flat) and lifts by Y_OFFSET", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="XZZ" valid />,
+    );
+    const mesh = r.scene.findByType("Mesh");
+    expect(mesh.instance.rotation.x).toBeCloseTo(-Math.PI / 2);
+    expect(mesh.instance.position.y).toBeCloseTo(Y_OFFSET);
+  });
+
+  it("scales line to (1, lineLen, 1) so the unit-vertical geom spans block bottom", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 5 }} blockType="XZZ" valid />,
+    );
+    const line = r.scene.findByType("LineSegments");
+    expect(line.instance.scale.x).toBe(1);
+    expect(line.instance.scale.y).toBeCloseTo(5 - Y_OFFSET);
+    expect(line.instance.scale.z).toBe(1);
+  });
+
+  it("uses valid colors and full opacity at z=1 (no fade)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 1 }} blockType="XZZ" valid />,
+    );
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
+    expect(meshMat.color.getHex()).toBe(VALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(VALID_LINE_COLOR);
+    expect(meshMat.opacity).toBeCloseTo(VALID_MESH_OPACITY);
+  });
+
+  it("uses invalid red colors and full (non-faded) opacity when valid=false", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 30 }} blockType="XZZ" valid={false} />,
+    );
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
+    expect(meshMat.color.getHex()).toBe(INVALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(INVALID_LINE_COLOR);
+    // Invalid skips elevation falloff: full base opacity even at z=30
+    expect(meshMat.opacity).toBe(INVALID_MESH_OPACITY);
+  });
+
+  it("respects pipe footprint dims (X-open pipe centers at offset 1, 0.5)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="OZX" valid />,
+    );
+    const group = r.scene.findByType("Group");
+    expect(group.instance.position.x).toBeCloseTo(1);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+});

--- a/gui/src/components/GroundShadowAbsolute.tsx
+++ b/gui/src/components/GroundShadowAbsolute.tsx
@@ -1,0 +1,94 @@
+import * as THREE from "three";
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+import { shadowVisuals, shouldRenderShadow, Y_OFFSET } from "../utils/groundShadow";
+
+// PERF NOTE: Per-instance materials (inline JSX) chosen for simplicity and
+// per-elevation opacity. Worst case ~800 materials in flight at MAX_SHADOWS=200
+// across 4 call sites — fine at typical scale. If perf becomes a problem at
+// extreme selection sizes, swap for InstancedMesh + per-instance opacity
+// vertex attribute. See TODOS.md (perf-shadows).
+
+const noRaycast = () => {};
+
+const planeCache = new Map<string, THREE.PlaneGeometry>();
+function getPlane(sx: number, sy: number): THREE.PlaneGeometry {
+  const key = `${sx}x${sy}`;
+  let g = planeCache.get(key);
+  if (!g) {
+    g = new THREE.PlaneGeometry(sx, sy);
+    planeCache.set(key, g);
+  }
+  return g;
+}
+
+const lineGeom = new THREE.BufferGeometry().setFromPoints([
+  new THREE.Vector3(0, 0, 0),
+  new THREE.Vector3(0, 1, 0),
+]);
+
+/**
+ * Ground-projected shadow + vertical anchor line for an elevated block.
+ *
+ * WORLD-SPACE COMPONENT — the `Absolute` suffix is a contract.
+ *
+ * This component positions itself in WORLD coordinates derived from `pos`.
+ * Do NOT render it inside a positioned `<group>` wrapper — the positions will
+ * compound and the shadow will end up at the wrong cell on the ground.
+ *
+ * Correct (rendered as a sibling of the positioned ghost):
+ *   return <>
+ *     <group position={[x, y, z]}><mesh>...</mesh></group>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />
+ *   </>;
+ *
+ * Wrong (nested — positions compound, shadow ends up offset by [x, y, z]):
+ *   return <group position={[x, y, z]}>
+ *     <mesh>...</mesh>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />   // <-- bug
+ *   </group>;
+ */
+export function GroundShadowAbsolute({
+  pos,
+  blockType,
+  valid,
+}: {
+  pos: Position3D;
+  blockType: BlockType;
+  valid: boolean;
+}) {
+  if (!shouldRenderShadow(pos)) return null;
+  const [sx, sy] = blockTqecSize(blockType);
+  const v = shadowVisuals(pos, blockType, valid);
+
+  return (
+    <group position={[v.cx, 0, v.cz]}>
+      <mesh
+        position={[0, Y_OFFSET, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        geometry={getPlane(sx, sy)}
+        raycast={noRaycast}
+      >
+        <meshBasicMaterial
+          color={v.meshColor}
+          transparent
+          opacity={v.meshOpacity}
+          depthWrite={false}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      <lineSegments
+        position={[0, Y_OFFSET, 0]}
+        scale={[1, v.lineLen, 1]}
+        geometry={lineGeom}
+        raycast={noRaycast}
+      >
+        <lineBasicMaterial
+          color={v.lineColor}
+          transparent
+          opacity={v.lineOpacity}
+          depthWrite={false}
+        />
+      </lineSegments>
+    </group>
+  );
+}

--- a/gui/src/components/OpenPipeGhosts.tsx
+++ b/gui/src/components/OpenPipeGhosts.tsx
@@ -15,7 +15,7 @@ import {
   getAdjacentPos,
   getAllPortPositions,
 } from "../types";
-import { resolvePipeTypeFromFace } from "./BlockInstances";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "./BlockInstances";
 import type { Position3D, BlockType, CubeType } from "../types";
 
 // Sentinel cube type for sizing/face-normal calculations on a port (which has
@@ -78,17 +78,28 @@ function InteractiveGhost({ pos, threePos }: { pos: Position3D; threePos: [numbe
       return;
     }
 
-    if (store.armedTool === "pipe" && store.pipeVariant) {
+    if (store.armedTool === "pipe" && (store.pipeVariant || store.fbPreset)) {
       // Pipe placement adjacent to a port: use the hovered face normal to compute
       // which adjacent pipe slot to target, mirroring BlockInstances' face logic.
       if (!e.face) {
         store.setHoveredGridPos(null);
         return;
       }
-      const resolved = resolvePipeTypeFromFace(pos, PORT_SENTINEL_TYPE, e.face.normal, store.pipeVariant);
-      if (!resolved) {
-        store.setHoveredGridPos(null);
-        return;
+      let resolved: BlockType;
+      if (store.fbPreset) {
+        const r = resolveFBSpecFromFace(pos, PORT_SENTINEL_TYPE, e.face.normal, store.fbPreset);
+        if (!r) {
+          store.setHoveredGridPos(null);
+          return;
+        }
+        resolved = r.spec;
+      } else {
+        const r = resolvePipeTypeFromFace(pos, PORT_SENTINEL_TYPE, e.face.normal, store.pipeVariant!);
+        if (!r) {
+          store.setHoveredGridPos(null);
+          return;
+        }
+        resolved = r;
       }
       const adj = getAdjacentPos(pos, PORT_SENTINEL_TYPE, e.face.normal, resolved);
       const adjKey = posKey(adj);
@@ -135,10 +146,18 @@ function InteractiveGhost({ pos, threePos }: { pos: Position3D; threePos: [numbe
     }
     // Port tool: clicking a port is a no-op (it's already a port).
     if (store.armedTool === "port") return;
-    if (store.armedTool === "pipe" && store.pipeVariant) {
+    if (store.armedTool === "pipe" && (store.pipeVariant || store.fbPreset)) {
       if (!e.face) return;
-      const resolved = resolvePipeTypeFromFace(pos, PORT_SENTINEL_TYPE, e.face.normal, store.pipeVariant);
-      if (!resolved) return;
+      let resolved: BlockType;
+      if (store.fbPreset) {
+        const r = resolveFBSpecFromFace(pos, PORT_SENTINEL_TYPE, e.face.normal, store.fbPreset);
+        if (!r) return;
+        resolved = r.spec;
+      } else {
+        const r = resolvePipeTypeFromFace(pos, PORT_SENTINEL_TYPE, e.face.normal, store.pipeVariant!);
+        if (!r) return;
+        resolved = r;
+      }
       const adj = getAdjacentPos(pos, PORT_SENTINEL_TYPE, e.face.normal, resolved);
       store.addBlock(adj);
       return;

--- a/gui/src/components/OpenPipeGhosts.tsx
+++ b/gui/src/components/OpenPipeGhosts.tsx
@@ -15,7 +15,7 @@ import {
   getAdjacentPos,
   getAllPortPositions,
 } from "../types";
-import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "./BlockInstances";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "./BlockInstances.logic";
 import type { Position3D, BlockType, CubeType } from "../types";
 
 // Sentinel cube type for sizing/face-normal calculations on a port (which has

--- a/gui/src/components/PasteGhost.test.tsx
+++ b/gui/src/components/PasteGhost.test.tsx
@@ -1,0 +1,159 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { PasteGhost } from "./PasteGhost";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+function setPaste(opts: {
+  clipboard?: Map<string, Block> | null;
+  hoveredGridPos?: Position3D | null;
+  blocks?: Map<string, Block>;
+}) {
+  useBlockStore.setState(
+    {
+      armedTool: "paste",
+      mode: "edit",
+      clipboard: opts.clipboard ?? null,
+      hoveredGridPos: opts.hoveredGridPos ?? null,
+      blocks: opts.blocks ?? new Map(),
+    },
+    false,
+  );
+}
+
+describe("<PasteGhost>", () => {
+  it("renders nothing when armedTool is not paste", async () => {
+    useBlockStore.setState(
+      {
+        armedTool: "cube",
+        clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+        hoveredGridPos: { x: 3, y: 0, z: 0 },
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing with empty/null clipboard", async () => {
+    setPaste({ clipboard: null, hoveredGridPos: { x: 0, y: 0, z: 0 } });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing without a hovered grid pos", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+      hoveredGridPos: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders one paste-ghost per clipboard entry at z=0 (no shadows)", async () => {
+    setPaste({
+      clipboard: new Map([
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["3,0,0", mk({ x: 3, y: 0, z: 0 })],
+      ]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 2 ghost meshes; ghost edges (LineSegments) for each = 2 LineSegments.
+    // No shadows because z=0.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("renders shadow + projection line for elevated paste-ghost block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 1 ghost mesh + 1 shadow mesh = 2; ghost edges + shadow line = 2 LineSegments.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("turns shadow red when paste collides with existing block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]), // collision
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // Both ghost edges and shadow line should be red on collision.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
+  });
+
+  it("Y-cube paste at z=0 with pipe above gets a lifted shadow", async () => {
+    // Clipboard contains a Y-cube at z=0; paste destination has a pipe at z=1
+    // directly above. yBlockZOffset returns 0.5 -> shadow renders.
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // ghost edges + shadow line = 2 LineSegments (shadow renders thanks to yBlockZOffset).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("caps clipboard at 200 entries (MAX_PASTE_SHADOWS)", async () => {
+    // Build a clipboard with 250 elevated blocks
+    const big = new Map<string, Block>();
+    for (let i = 0; i < 250; i++) {
+      big.set(`${i * 3},0,3`, mk({ x: i * 3, y: 0, z: 3 }));
+    }
+    setPaste({
+      clipboard: big,
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 200 paste-ghost meshes + 200 shadow meshes = 400 total.
+    // 200 ghost edges + 200 shadow lines = 400 LineSegments.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(400);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(400);
+  });
+});

--- a/gui/src/components/PasteGhost.tsx
+++ b/gui/src/components/PasteGhost.tsx
@@ -4,6 +4,9 @@ import { useBlockStore } from "../stores/blockStore";
 import { tqecToThree, yBlockZOffset, isValidPos } from "../types";
 import type { Block, Position3D } from "../types";
 import { getCachedGeometry, getCachedEdges } from "./BlockInstances";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+const MAX_PASTE_SHADOWS = 200;
 
 const noRaycast = () => {};
 
@@ -57,7 +60,7 @@ export function PasteGhost() {
 
   const entries = useMemo(() => {
     if (!clipboard) return null;
-    return Array.from(clipboard.values());
+    return Array.from(clipboard.values()).slice(0, MAX_PASTE_SHADOWS);
   }, [clipboard]);
 
   if (mode !== "edit" || armedTool !== "paste" || !hoveredGridPos || !entries) {
@@ -103,17 +106,23 @@ function PasteGhostBlock({
   const [x, y, z] = tqecToThree(worldPos, block.type, zo);
   const meshMat = collides ? invalidMaterial : pasteMaterial;
   const lineMat = collides ? invalidLineMaterial : pasteLineMaterial;
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // shadow + projection line align with what the user sees.
+  const shadowPos = { ...worldPos, z: worldPos.z + zo };
 
   return (
-    <group position={[x, y, z]}>
-      <mesh raycast={noRaycast}>
-        <primitive object={geometry} attach="geometry" />
-        <primitive object={meshMat} attach="material" />
-      </mesh>
-      <lineSegments raycast={noRaycast}>
-        <primitive object={edges} attach="geometry" />
-        <primitive object={lineMat} attach="material" />
-      </lineSegments>
-    </group>
+    <>
+      <group position={[x, y, z]}>
+        <mesh raycast={noRaycast}>
+          <primitive object={geometry} attach="geometry" />
+          <primitive object={meshMat} attach="material" />
+        </mesh>
+        <lineSegments raycast={noRaycast}>
+          <primitive object={edges} attach="geometry" />
+          <primitive object={lineMat} attach="material" />
+        </lineSegments>
+      </group>
+      <GroundShadowAbsolute pos={shadowPos} blockType={block.type} valid={!collides} />
+    </>
   );
 }

--- a/gui/src/components/PortsTable.tsx
+++ b/gui/src/components/PortsTable.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
 import { useLocateStore } from "../stores/locateStore";
-import { getAllPortPositions, posKey, tqecToThree, type Position3D } from "../types";
+import { getOrderedPortPositions, posKey, tqecToThree, type Position3D } from "../types";
 import { animateCamera } from "../utils/cameraAnim";
 
 function PortLabelInput({
@@ -72,6 +72,19 @@ function LocateIcon() {
   );
 }
 
+function GripIcon() {
+  return (
+    <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+      <circle cx="3" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="11" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="11" r="1.1" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function PortsTable({
   controlsRef,
 }: {
@@ -83,9 +96,13 @@ export function PortsTable({
   const portPositions = useBlockStore((s) => s.portPositions);
   const setPortLabel = useBlockStore((s) => s.setPortLabel);
   const setPortIO = useBlockStore((s) => s.setPortIO);
+  const reorderPort = useBlockStore((s) => s.reorderPort);
+
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
 
   const portList = useMemo(() => {
-    const positions = getAllPortPositions(blocks, portPositions);
+    const positions = getOrderedPortPositions(blocks, portPositions, portMeta);
     return positions.map((pos) => {
       const key = posKey(pos);
       const meta = portMeta.get(key);
@@ -119,56 +136,105 @@ export function PortsTable({
           No open ports. Add open pipes or place port markers.
         </div>
       )}
-      {portList.map(({ pos, key, meta }) => (
-        <div
-          key={key}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            marginBottom: 4,
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => handleLocate(pos)}
-            aria-label="Locate port"
-            title="Locate port"
+      {portList.map(({ pos, key, meta }, index) => {
+        const isDragging = dragIndex === index;
+        const showDropAbove =
+          dragIndex !== null && overIndex === index && index < dragIndex;
+        const showDropBelow =
+          dragIndex !== null && overIndex === index && index > dragIndex;
+        return (
+          <div
+            key={key}
+            onDragOver={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              if (overIndex !== index) setOverIndex(index);
+            }}
+            onDrop={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              if (dragIndex !== index) reorderPort(dragIndex, index);
+              setDragIndex(null);
+              setOverIndex(null);
+            }}
             style={{
-              background: "none",
-              border: "none",
-              padding: 2,
-              cursor: "pointer",
-              color: "#666",
-              display: "inline-flex",
+              display: "flex",
               alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
+              gap: 6,
+              marginBottom: 4,
+              padding: "2px 0",
+              opacity: isDragging ? 0.4 : 1,
+              borderTop: showDropAbove ? "2px solid #4a9eff" : "2px solid transparent",
+              borderBottom: showDropBelow ? "2px solid #4a9eff" : "2px solid transparent",
             }}
           >
-            <LocateIcon />
-          </button>
-          <PortLabelInput
-            pos={pos}
-            label={meta?.label ?? ""}
-            onCommit={setPortLabel}
-          />
-          <select
-            value={meta?.io ?? "in"}
-            onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
-            style={{ fontSize: 12, padding: "2px 4px" }}
-          >
-            <option value="in">in</option>
-            <option value="out">out</option>
-          </select>
-          <span
-            title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
-            style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
-          >
-            {pos.x / 3},{pos.y / 3},{pos.z / 3}
-          </span>
-        </div>
-      ))}
+            <span
+              draggable
+              onDragStart={(e) => {
+                setDragIndex(index);
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", String(index));
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setOverIndex(null);
+              }}
+              aria-label="Drag to reorder"
+              title="Drag to reorder"
+              style={{
+                cursor: "grab",
+                color: "#aaa",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                padding: "0 2px",
+              }}
+            >
+              <GripIcon />
+            </span>
+            <button
+              type="button"
+              onClick={() => handleLocate(pos)}
+              aria-label="Locate port"
+              title="Locate port"
+              style={{
+                background: "none",
+                border: "none",
+                padding: 2,
+                cursor: "pointer",
+                color: "#666",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <LocateIcon />
+            </button>
+            <PortLabelInput
+              pos={pos}
+              label={meta?.label ?? ""}
+              onCommit={setPortLabel}
+            />
+            <select
+              value={meta?.io ?? "in"}
+              onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
+              style={{ fontSize: 12, padding: "2px 4px" }}
+            >
+              <option value="in">in</option>
+              <option value="out">out</option>
+            </select>
+            <span
+              title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
+              style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
+            >
+              {pos.x / 3},{pos.y / 3},{pos.z / 3}
+            </span>
+          </div>
+        );
+      })}
     </section>
   );
 }

--- a/gui/src/components/PreviewRenderer.tsx
+++ b/gui/src/components/PreviewRenderer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import * as THREE from "three";
 import {
   CUBE_TYPES,
+  FB_PRESETS,
   VARIANT_AXIS_MAP,
   createBlockGeometry,
   createBlockEdges,
@@ -9,7 +10,7 @@ import {
   blockThreeSize,
   Y_DEFECT_HEX,
 } from "../types";
-import type { BlockType, PipeVariant, ViewMode } from "../types";
+import type { BlockType, FreeBuildPipeSpec, PipeVariant, ViewMode } from "../types";
 import { useBlockStore } from "../stores/blockStore";
 import {
   FOLD_ANGLE,
@@ -38,6 +39,14 @@ const PREVIEW_TYPES: { key: string; blockType: BlockType | null; isoZBlockType?:
     key: v,
     blockType: VARIANT_AXIS_MAP[v][2] as BlockType,
     isoZBlockType: VARIANT_AXIS_MAP[v][1] as BlockType,
+  })),
+  // Free-build pipe presets — keyed by preset.id ("swap-zx", "swap-xz").
+  // Default openAxis = 2 (Z-open) for persp + iso-x/iso-y; iso-z uses Y-open
+  // so the pipe is visible (Z-open pipes point into the screen in iso-z).
+  ...FB_PRESETS.map((p) => ({
+    key: p.id,
+    blockType: p.spec as BlockType,
+    isoZBlockType: { ...p.spec, openAxis: 1 } as FreeBuildPipeSpec as BlockType,
   })),
 ];
 
@@ -243,13 +252,17 @@ export function usePreviewImages(controlsRef: React.RefObject<any>) {
         }
         continue;
       }
-      const isCube = (CUBE_TYPES as readonly string[]).includes(blockType);
+      // PREVIEW_TYPES never contains FB specs — all blockTypes here are TQEC
+      // strings — but the BlockType union now includes FreeBuildPipeSpec, so
+      // the typeof guard is required for the .includes() and the fold-out
+      // helper which expect string arguments.
+      const isCube = typeof blockType === "string" && (CUBE_TYPES as readonly string[]).includes(blockType);
       const regular = buildRegularEntry(blockType);
       meshesRef.current.set(variantKey(key, "persp"), regular);
 
       if (isCube) {
         for (const v of FOLD_VARIANTS) {
-          meshesRef.current.set(variantKey(key, v), buildFoldOutCubeEntry(blockType, variantTopAxis(v)));
+          meshesRef.current.set(variantKey(key, v), buildFoldOutCubeEntry(blockType as string, variantTopAxis(v)));
         }
       } else {
         const isoZ = isoZBlockType ? buildRegularEntry(isoZBlockType) : regular;

--- a/gui/src/components/SharedSceneBanner.tsx
+++ b/gui/src/components/SharedSceneBanner.tsx
@@ -1,0 +1,70 @@
+import type { SceneSnapshotV1 } from "../utils/sceneSnapshot";
+
+export function SharedSceneBanner({
+  previousSnapshot,
+  onRestore,
+  onDismiss,
+}: {
+  previousSnapshot: SceneSnapshotV1;
+  onRestore: (snapshot: SceneSnapshotV1) => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        top: 12,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1100,
+        background: "#fff8d6",
+        border: "1px solid #d8c46a",
+        borderRadius: 6,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+        padding: "8px 12px",
+        fontFamily: "sans-serif",
+        fontSize: 13,
+        color: "#5b4a00",
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <span>Loaded a shared scene. Your previous work is still saved.</span>
+      <button
+        onClick={() => onRestore(previousSnapshot)}
+        style={{
+          fontSize: 12,
+          padding: "4px 10px",
+          border: "1px solid #b89a30",
+          borderRadius: 4,
+          background: "#fff",
+          cursor: "pointer",
+          color: "#5b4a00",
+        }}
+      >
+        Restore previous
+      </button>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+        style={{
+          fontSize: 14,
+          width: 22,
+          height: 22,
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          color: "#7a6300",
+          padding: 0,
+          lineHeight: 1,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -1,8 +1,8 @@
 import { useEffect, useRef, useState } from "react";
-import { useBlockStore, type BuildStep } from "../stores/blockStore";
+import { useBlockStore, sceneHasFreeBuildBlocks, type BuildStep } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { useKeybindStore, type Mode as KeybindMode, type NavStyle } from "../stores/keybindStore";
-import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
+import { CUBE_TYPES, FB_PRESETS, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
@@ -121,6 +121,8 @@ export function Toolbar({
   const blocksEmpty = useBlockStore((s) => s.blocks.size === 0);
   const freeBuild = useBlockStore((s) => s.freeBuild);
   const toggleFreeBuild = useBlockStore((s) => s.toggleFreeBuild);
+  const fbPreset = useBlockStore((s) => s.fbPreset);
+  const setFBPreset = useBlockStore((s) => s.setFBPreset);
   const selectedCount = useBlockStore((s) => {
     if (s.selectedKeys.size === 0) return 0;
     let count = 0;
@@ -218,6 +220,10 @@ export function Toolbar({
       const k = s.selectedKeys.values().next().value as string;
       const b = s.blocks.get(k);
       if (!b || isPipeType(b.type)) return null;
+      // Skip free-build blocks here — they're pipes and shouldn't reach this
+      // cube-slot info path; the isPipeType guard above doesn't catch them
+      // because FB specs are objects (isPipeType returns false for them).
+      if (typeof b.type !== "string") return null;
       pos = b.pos;
       currentType = b.type;
     } else {
@@ -746,6 +752,40 @@ export function Toolbar({
         </div>
       </div>
 
+      {/* Free Build group — only visible when freeBuild is enabled.
+         Non-TQEC pipes parameterized by Y-defect positions. */}
+      {freeBuild && (
+        <>
+          <div style={{ width: 1, background: "#ddd" }} />
+          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+            <span style={groupLabelStyle}>Free Build</span>
+            <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
+              {FB_PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  onPointerDown={() => {
+                    if (mode !== "edit") return;
+                    setFBPreset(preset);
+                    setPaletteDragging(true);
+                  }}
+                  onClick={() => {
+                    setFBPreset(preset);
+                  }}
+                  title={`Free-build color-swap pipe (${preset.label}) with a Y defect at the midpoint`}
+                  style={blockBtnStyle(
+                    mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
+                    false,
+                  )}
+                >
+                  {preset.label}
+                  <div style={previewWrapStyle}>{previewImg(preset.id)}</div>
+                </button>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
       {/* Position display */}
       <div style={{ width: 1, background: "#ddd" }} />
       <div style={{ display: "flex", flexDirection: "column", justifyContent: "space-between", fontFamily: "monospace", fontSize: "12px", color: "#555", lineHeight: "1.6", minWidth: 90 }}>
@@ -1109,6 +1149,7 @@ function FileMenu({
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [loadingFile, setLoadingFile] = useState<string | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const hasFB = useBlockStore(sceneHasFreeBuildBlocks);
 
   useEffect(() => {
     if (!open) return;
@@ -1210,8 +1251,11 @@ function FileMenu({
               downloadDae(useBlockStore.getState().blocks);
               setOpen(false);
             }}
-            disabled={blocksEmpty}
-            style={item(blocksEmpty)}
+            disabled={blocksEmpty || hasFB}
+            title={hasFB
+              ? "DAE export requires a TQEC-only scene. Remove Free Build pieces (or use Undo) to export."
+              : undefined}
+            style={item(blocksEmpty || hasFB)}
           >
             Export
           </button>
@@ -1329,6 +1373,7 @@ function AnalyzeMenu() {
   const zxPanelOpen = useBlockStore((s) => s.zxPanelOpen);
   const validationStatus = useValidationStore((s) => s.status);
   const runValidation = useValidationStore((s) => s.validate);
+  const hasFB = useBlockStore(sceneHasFreeBuildBlocks);
 
   useEffect(() => {
     if (!open) return;
@@ -1339,7 +1384,10 @@ function AnalyzeMenu() {
     return () => document.removeEventListener("mousedown", onDocClick);
   }, [open]);
 
-  const verifyDisabled = blocksEmpty || validationStatus === "loading";
+  const verifyDisabled = blocksEmpty || validationStatus === "loading" || hasFB;
+  const verifyTitle = hasFB
+    ? "Validation requires a TQEC-only scene. Remove Free Build pieces (or use Undo) to validate."
+    : "Server-side validation via the TQEC library";
   const verifyBorder =
     validationStatus === "valid" ? "#28a745" :
     validationStatus === "invalid" ? "#dc3545" :
@@ -1401,10 +1449,10 @@ function AnalyzeMenu() {
           <button
             onClick={() => { runValidation(); }}
             disabled={verifyDisabled}
-            title="Server-side validation via the TQEC library"
+            title={verifyTitle}
             style={{
               ...btnStyle(false),
-              opacity: blocksEmpty ? 0.4 : 1,
+              opacity: blocksEmpty || hasFB ? 0.4 : 1,
               cursor: verifyDisabled ? "default" : "pointer",
               borderColor: verifyBorder ?? "#ccc",
               background: verifyBackground ?? "#fff",

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -100,6 +100,7 @@ export function Toolbar({
   onOpenKeybindEditor: (mode: KeybindMode) => void;
 }) {
   const [userScale, setUserScale] = useState<number>(loadToolbarUserScale);
+  const [recenterTooltip, setRecenterTooltip] = useState(false);
   useEffect(() => {
     window.localStorage.setItem(TOOLBAR_USER_SCALE_KEY, String(userScale));
   }, [userScale]);
@@ -420,8 +421,6 @@ export function Toolbar({
   const setPerspView = useBlockStore((s) => s.setPerspView);
   const setIsoView = useBlockStore((s) => s.setIsoView);
   const stepSlice = useBlockStore((s) => s.stepSlice);
-  const showYDefects = useBlockStore((s) => s.showYDefects);
-  const toggleShowYDefects = useBlockStore((s) => s.toggleShowYDefects);
 
   const previewImg = (key: string) => {
     const src = previewImages.get(key);
@@ -504,16 +503,6 @@ export function Toolbar({
             </button>
           </div>
         )}
-        <button onClick={onResetCamera} style={btnStyle(false)} title="Recenter the camera on the origin">
-          Origin
-        </button>
-        <button
-          onClick={toggleShowYDefects}
-          style={btnStyle(showYDefects)}
-          title="Highlight Y-type defects (twists) along edges where X and Z faces meet"
-        >
-          Y defects
-        </button>
       </div>
 
       {/* History + Analyze */}
@@ -820,6 +809,60 @@ export function Toolbar({
             }
             return <><span>X: {pos.x / 3}</span><span>Y: {pos.y / 3}</span><span>Z: {pos.z / 3}</span></>;
           })()}
+        </div>
+        <div style={{ position: "relative", alignSelf: "center" }}>
+          <button
+            onClick={onResetCamera}
+            onMouseEnter={() => setRecenterTooltip(true)}
+            onMouseLeave={() => setRecenterTooltip(false)}
+            aria-label="Recenter camera on origin"
+            style={{
+              ...btnStyle(false),
+              display: "inline-flex",
+              alignItems: "center",
+              justifyContent: "center",
+              padding: 0,
+              width: 28,
+              height: 22,
+            }}
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 14 14"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.2"
+              aria-hidden="true"
+            >
+              <circle cx="7" cy="7" r="3.5" />
+              <line x1="7" y1="0.5" x2="7" y2="3" />
+              <line x1="7" y1="11" x2="7" y2="13.5" />
+              <line x1="0.5" y1="7" x2="3" y2="7" />
+              <line x1="11" y1="7" x2="13.5" y2="7" />
+            </svg>
+          </button>
+          {recenterTooltip && (
+            <div
+              role="tooltip"
+              style={{
+                position: "absolute",
+                top: "calc(100% + 4px)",
+                right: 0,
+                background: "rgba(0,0,0,0.85)",
+                color: "#fff",
+                padding: "4px 8px",
+                borderRadius: 4,
+                fontSize: 11,
+                fontFamily: "sans-serif",
+                whiteSpace: "nowrap",
+                pointerEvents: "none",
+                zIndex: 100,
+              }}
+            >
+              Recenter camera on origin (0, 0, 0)
+            </div>
+          )}
         </div>
         <div style={{ textAlign: "center" }}>
           <FpsDisplay spanRef={fpsRef} />
@@ -1585,6 +1628,8 @@ function SettingsMenu({
   const toggleCameraFollowsBuild = useKeybindStore((s) => s.toggleCameraFollowsBuild);
   const axisAbsoluteWasd = useKeybindStore((s) => s.axisAbsoluteWasd);
   const toggleAxisAbsoluteWasd = useKeybindStore((s) => s.toggleAxisAbsoluteWasd);
+  const showYDefects = useBlockStore((s) => s.showYDefects);
+  const toggleShowYDefects = useBlockStore((s) => s.toggleShowYDefects);
 
   useEffect(() => {
     if (!open) return;
@@ -1630,6 +1675,16 @@ function SettingsMenu({
               Ignore color rules
               <div style={{ fontSize: 10, color: "#888", whiteSpace: "nowrap" }}>
                 (“Free Build” — skips color-matching checks)
+              </div>
+            </span>
+          </label>
+
+          <label style={{ display: "flex", alignItems: "flex-start", gap: 6, cursor: "pointer" }}>
+            <input type="checkbox" checked={showYDefects} onChange={toggleShowYDefects} style={{ marginTop: 2 }} />
+            <span>
+              Highlight Y defects
+              <div style={{ fontSize: 10, color: "#888", whiteSpace: "nowrap" }}>
+                (magenta cylinders along edges where X and Z faces meet)
               </div>
             </span>
           </label>

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -747,40 +747,35 @@ export function Toolbar({
         </div>
       </div>
 
-      {/* Free Build group — only visible when freeBuild is enabled.
-         Single generic Free Pipe; the per-face variant is picked from the
-         side panel that opens after placement. */}
-      {freeBuild && (
-        <>
-          <div style={{ width: 1, background: "#ddd" }} />
-          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-            <span style={groupLabelStyle}>Free Build</span>
-            <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
-              {FB_PRESETS.map((preset) => (
-                <button
-                  key={preset.id}
-                  onPointerDown={() => {
-                    if (mode !== "edit") return;
-                    setFBPreset(preset);
-                    setPaletteDragging(true);
-                  }}
-                  onClick={() => {
-                    setFBPreset(preset);
-                  }}
-                  title="Free-build pipe — drop to place, then pick a color/swap variant from the side panel"
-                  style={blockBtnStyle(
-                    mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
-                    false,
-                  )}
-                >
-                  {preset.label}
-                  <div style={previewWrapStyle}>{previewImg(preset.id)}</div>
-                </button>
-              ))}
-            </div>
-          </div>
-        </>
-      )}
+      {/* Free Build group — single generic Free Pipe; the per-face variant
+         is picked from the side panel that opens after placement. */}
+      <div style={{ width: 1, background: "#ddd" }} />
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+        <span style={groupLabelStyle}>Free Build</span>
+        <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
+          {FB_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              onPointerDown={() => {
+                if (mode !== "edit") return;
+                setFBPreset(preset);
+                setPaletteDragging(true);
+              }}
+              onClick={() => {
+                setFBPreset(preset);
+              }}
+              title="Free-build pipe — drop to place, then pick a color/swap variant from the side panel"
+              style={blockBtnStyle(
+                mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
+                false,
+              )}
+            >
+              {preset.label}
+              <div style={previewWrapStyle}>{previewImg(preset.id)}</div>
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Position display */}
       <div style={{ width: 1, background: "#ddd" }} />
@@ -1674,7 +1669,7 @@ function SettingsMenu({
             <span>
               Ignore color rules
               <div style={{ fontSize: 10, color: "#888", whiteSpace: "nowrap" }}>
-                (“Free Build” — skips color-matching checks)
+                (relaxes cube/pipe color-matching checks)
               </div>
             </span>
           </label>

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -771,7 +771,11 @@ export function Toolbar({
                   onClick={() => {
                     setFBPreset(preset);
                   }}
-                  title={`Free-build color-swap pipe (${preset.label}) with a Y defect at the midpoint`}
+                  title={
+                    preset.spec.swapAxes && preset.spec.swapAxes !== "all"
+                      ? `Free-build half color-swap pipe (${preset.label}) — only one wall pair flips at the midpoint`
+                      : `Free-build color-swap pipe (${preset.label}) with a Y defect at the midpoint`
+                  }
                   style={blockBtnStyle(
                     mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
                     false,

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -6,6 +6,12 @@ import { CUBE_TYPES, FB_PRESETS, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pi
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
+import {
+  buildShareUrl,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+} from "../utils/sceneShare";
+import { captureSnapshot } from "../utils/sceneSnapshot";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
 import { evalCoordExpr } from "../utils/parseCoordExpr";
 import { usePreviewImages } from "./PreviewRenderer";
@@ -636,7 +642,7 @@ export function Toolbar({
               onPointerDown={() => {
                 if (mode !== "edit") return;
                 if (selectedCubeSlotInfo != null) return;
-                setCubeType(ct as BlockType);
+                setCubeType(ct);
                 setPaletteDragging(true);
               }}
               onClick={() => {
@@ -648,7 +654,7 @@ export function Toolbar({
                   cycleSelectedType(1, { kind: "cube", type: ct });
                   return;
                 }
-                setCubeType(ct as BlockType);
+                setCubeType(ct);
               }}
               style={blockBtnStyle(
                 (mode === "edit" && armedTool === "cube" && cubeType === ct) ||
@@ -753,7 +759,8 @@ export function Toolbar({
       </div>
 
       {/* Free Build group — only visible when freeBuild is enabled.
-         Non-TQEC pipes parameterized by Y-defect positions. */}
+         Single generic Free Pipe; the per-face variant is picked from the
+         side panel that opens after placement. */}
       {freeBuild && (
         <>
           <div style={{ width: 1, background: "#ddd" }} />
@@ -771,11 +778,7 @@ export function Toolbar({
                   onClick={() => {
                     setFBPreset(preset);
                   }}
-                  title={
-                    preset.spec.swapAxes && preset.spec.swapAxes !== "all"
-                      ? `Free-build half color-swap pipe (${preset.label}) — only one wall pair flips at the midpoint`
-                      : `Free-build color-swap pipe (${preset.label}) with a Y defect at the midpoint`
-                  }
+                  title="Free-build pipe — drop to place, then pick a color/swap variant from the side panel"
                   style={blockBtnStyle(
                     mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
                     false,
@@ -1152,8 +1155,16 @@ function FileMenu({
   const [templates, setTemplates] = useState<TemplateEntry[] | null>(null);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [loadingFile, setLoadingFile] = useState<string | null>(null);
+  const [shareStatus, setShareStatus] = useState<"idle" | "copied" | "too-long" | "error">("idle");
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
   const hasFB = useBlockStore(sceneHasFreeBuildBlocks);
+  const compressionSupported = isCompressionStreamSupported();
+
+  // ~6 KB total URL — Twitter/X and most chat clients are well above this,
+  // but very long URLs choke older SMS, some embeds, and the URL bar in
+  // older browsers. Past this we surface the .dae export instead.
+  const SHARE_URL_MAX_LEN = 6144;
 
   useEffect(() => {
     if (!open) return;
@@ -1202,6 +1213,52 @@ function FileMenu({
     cursor: disabled ? "default" : "pointer",
     whiteSpace: "nowrap",
   });
+
+  const onShare = async () => {
+    if (!compressionSupported || blocksEmpty) return;
+    if (shareTimeoutRef.current !== null) {
+      clearTimeout(shareTimeoutRef.current);
+      shareTimeoutRef.current = null;
+    }
+    try {
+      const snapshot = captureSnapshot();
+      const encoded = await encodeSnapshotToHashParam(snapshot);
+      const url = buildShareUrl(encoded);
+      if (url.length > SHARE_URL_MAX_LEN) {
+        setShareStatus("too-long");
+      } else {
+        await navigator.clipboard.writeText(url);
+        setShareStatus("copied");
+      }
+    } catch {
+      setShareStatus("error");
+    }
+    shareTimeoutRef.current = setTimeout(() => {
+      setShareStatus("idle");
+      setOpen(false);
+      shareTimeoutRef.current = null;
+    }, 1600);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (shareTimeoutRef.current !== null) clearTimeout(shareTimeoutRef.current);
+    };
+  }, []);
+
+  let shareLabel = "Share link";
+  let shareTitle = "Copy a link that loads this exact scene";
+  if (!compressionSupported) {
+    shareTitle = "Share link is unsupported in this browser (needs CompressionStream)";
+  } else if (shareStatus === "copied") {
+    shareLabel = "Link copied!";
+  } else if (shareStatus === "too-long") {
+    shareLabel = "Too large — use Export";
+    shareTitle = "Scene is too big for a URL; use Export to send a .dae file instead";
+  } else if (shareStatus === "error") {
+    shareLabel = "Could not copy";
+  }
+  const shareDisabled = blocksEmpty || !compressionSupported;
 
   return (
     <div ref={wrapRef} style={{ position: "relative" }}>
@@ -1262,6 +1319,16 @@ function FileMenu({
             style={item(blocksEmpty || hasFB)}
           >
             Export
+          </button>
+          <button
+            onClick={() => {
+              void onShare();
+            }}
+            disabled={shareDisabled}
+            title={shareTitle}
+            style={item(shareDisabled)}
+          >
+            {shareLabel}
           </button>
           <button
             onClick={() => {

--- a/gui/src/components/YDefectOverlay.tsx
+++ b/gui/src/components/YDefectOverlay.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
 import {
+  blockTypeCacheKey,
   createYDefectCylinderGroup,
   posKey,
   tqecToThree,
@@ -21,7 +22,7 @@ type CylinderInstance = {
 const templateCache = new Map<string, CylinderInstance[]>();
 
 function getCachedTemplate(blockType: BlockType, hiddenFaces: FaceMask): CylinderInstance[] {
-  const key = `${blockType}:${hiddenFaces}`;
+  const key = `${blockTypeCacheKey(blockType)}:${hiddenFaces}`;
   let arr = templateCache.get(key);
   if (!arr) {
     const group = createYDefectCylinderGroup(blockType, hiddenFaces, yDefectMaterial);

--- a/gui/src/components/ZXPanel.tsx
+++ b/gui/src/components/ZXPanel.tsx
@@ -358,6 +358,7 @@ export function ZXPanel({
     result && result.ok
       ? `${result.vertices.length} spider${result.vertices.length === 1 ? "" : "s"}, ${result.edges.length} edge${result.edges.length === 1 ? "" : "s"}`
       : null;
+  const excludedPipes = result?.excludedFreeBuildPipes ?? 0;
 
   return (
     <div
@@ -506,6 +507,20 @@ export function ZXPanel({
             <span style={{ color: "#666", marginLeft: "auto" }}>{stats}</span>
           )}
         </div>
+
+        {excludedPipes > 0 && (
+          <div
+            style={{
+              color: "#666",
+              fontStyle: "italic",
+              marginBottom: 8,
+              fontSize: 11,
+            }}
+            title="Pipes whose face colors don't match their adjacent cubes are not yet supported by TQEC analysis."
+          >
+            {excludedPipes} free-build pipe{excludedPipes === 1 ? "" : "s"} excluded from analysis (color mismatch with adjacent cubes).
+          </div>
+        )}
 
         {loading && !result && (
           <div style={{ color: "#888", padding: "24px 0", textAlign: "center" }}>

--- a/gui/src/components/ZXPanel.tsx
+++ b/gui/src/components/ZXPanel.tsx
@@ -21,7 +21,8 @@ import {
   type ZXResult,
   type ZXVertex,
 } from "../utils/zx";
-import type { Position3D } from "../types";
+import { blockTypeCacheKey } from "../types";
+import type { BlockType, Position3D } from "../types";
 
 const Z_COLOR = "#5bc466";
 const X_COLOR = "#ff7f7f";
@@ -33,11 +34,11 @@ const MARGIN = 32;
 const SPIDER_RADIUS = 11;
 
 function signature(
-  blocks: Map<string, { pos: Position3D; type: string }>,
+  blocks: Map<string, { pos: Position3D; type: BlockType }>,
   portMeta: Map<string, { label: string; io: "in" | "out" }>,
 ): string {
   const b: string[] = [];
-  for (const [k, v] of blocks) b.push(`${k}:${v.type}`);
+  for (const [k, v] of blocks) b.push(`${k}:${blockTypeCacheKey(v.type)}`);
   b.sort();
   const m: string[] = [];
   for (const [k, v] of portMeta) m.push(`${k}=${v.label}`);

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { useBlockStore } from "./blockStore";
 import type { Block } from "../types";
-import { buildSpatialIndex } from "../types";
+import { buildSpatialIndex, FB_PRESETS } from "../types";
 
 function reset() {
   useBlockStore.setState({
@@ -13,6 +13,7 @@ function reset() {
     mode: "edit",
     cubeType: "XZZ",
     pipeVariant: null,
+    fbPreset: null,
     armedTool: "cube",
     xHeld: false,
     portWarning: null,
@@ -145,9 +146,8 @@ describe("blockStore", () => {
       const fbX = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const fbY = { ...fbX, openAxis: 1 as const };
       const incoming = new Map<string, Block>([
@@ -168,9 +168,8 @@ describe("blockStore", () => {
       const fbX = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const incoming = new Map<string, Block>([
         ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbX }],
@@ -515,9 +514,8 @@ describe("blockStore", () => {
       const fbSpec = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const incoming = new Map<string, Block>([
         ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbSpec }],
@@ -532,9 +530,8 @@ describe("blockStore", () => {
       const fbX = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const fbY = { ...fbX, openAxis: 1 as const };
       const incoming = new Map<string, Block>([
@@ -583,6 +580,31 @@ describe("blockStore", () => {
       useBlockStore.getState().setPlacePort(true);
       useBlockStore.getState().setPlacePort(false);
       expect(useBlockStore.getState().armedTool).toBe("pointer");
+    });
+  });
+
+  // cubeType used to be silently rewritten to a PipeType by setPipeVariant
+  // and left untouched by setFBPreset. That asymmetry caused the FB-pipe
+  // snap-to-cube bug: when cubeType was a real CubeType while an FB preset
+  // was armed, the cube-replace branch in BlockInstances fired against the
+  // hovered cube position. The fix is for cubeType to be owned exclusively
+  // by the cube tool and persist across pipe-mode arming.
+  describe("cubeType ownership", () => {
+    it("setPipeVariant does NOT overwrite cubeType (FB snap regression)", () => {
+      useBlockStore.getState().setCubeType("ZXZ");
+      useBlockStore.getState().setPipeVariant("ZX");
+      expect(useBlockStore.getState().cubeType).toBe("ZXZ");
+      expect(useBlockStore.getState().armedTool).toBe("pipe");
+      expect(useBlockStore.getState().pipeVariant).toBe("ZX");
+    });
+
+    it("setFBPreset does NOT overwrite cubeType", () => {
+      useBlockStore.getState().setCubeType("ZXZ");
+      const freePipe = FB_PRESETS[0];
+      useBlockStore.getState().setFBPreset(freePipe);
+      expect(useBlockStore.getState().cubeType).toBe("ZXZ");
+      expect(useBlockStore.getState().armedTool).toBe("pipe");
+      expect(useBlockStore.getState().fbPreset?.id).toBe(freePipe.id);
     });
   });
 
@@ -1360,6 +1382,62 @@ describe("blockStore", () => {
       useBlockStore.getState().setPortIO({ x: 0, y: 0, z: 3 }, "in");
       useBlockStore.getState().ensurePortLabels();
       expect(useBlockStore.getState().portMeta.get("0,0,3")?.io).toBe("in");
+    });
+  });
+
+  describe("reorderPort", () => {
+    function seedFourPorts() {
+      useBlockStore.setState({
+        blocks: new Map(),
+        portPositions: new Set(["0,0,0", "3,0,0", "6,0,0", "9,0,0"]),
+        portMeta: new Map(),
+      });
+      useBlockStore.getState().ensurePortLabels();
+    }
+
+    function ranksByX(): Record<number, number | undefined> {
+      const out: Record<number, number | undefined> = {};
+      for (const [k, m] of useBlockStore.getState().portMeta) {
+        const x = Number(k.split(",")[0]);
+        out[x] = m.rank;
+      }
+      return out;
+    }
+
+    it("ensurePortLabels assigns sequential ranks 0..N-1 in spatial order", () => {
+      seedFourPorts();
+      // Spatial sort is by x ascending → ranks should match the x order.
+      expect(ranksByX()).toEqual({ 0: 0, 3: 1, 6: 2, 9: 3 });
+    });
+
+    it("moves a port forward and rewrites all ranks to 0..N-1", () => {
+      seedFourPorts();
+      // Move the port at index 3 (x=9) to index 0.
+      useBlockStore.getState().reorderPort(3, 0);
+      expect(ranksByX()).toEqual({ 9: 0, 0: 1, 3: 2, 6: 3 });
+    });
+
+    it("moves a port backward and rewrites all ranks", () => {
+      seedFourPorts();
+      // Move the port at index 0 (x=0) to index 2.
+      useBlockStore.getState().reorderPort(0, 2);
+      expect(ranksByX()).toEqual({ 3: 0, 6: 1, 0: 2, 9: 3 });
+    });
+
+    it("is a no-op when from === to", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(2, 2);
+      // Object identity preserved (set returned `state` unchanged).
+      expect(useBlockStore.getState().portMeta).toBe(before);
+    });
+
+    it("is a no-op when indices are out of range", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(-1, 2);
+      useBlockStore.getState().reorderPort(0, 99);
+      expect(useBlockStore.getState().portMeta).toBe(before);
     });
   });
 

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -139,6 +139,49 @@ describe("blockStore", () => {
       expect(useBlockStore.getState().blocks.size).toBe(0);
     });
 
+    it("cascades attached FB pipes the same way as TQEC pipes", () => {
+      // Without FB-aware attachment counting, the cube would delete cleanly
+      // and leave two orphaned FB pipes floating in the scene.
+      const fbX = {
+        kind: "fb-pipe" as const,
+        openAxis: 0 as const,
+        baseAtStart: "Z" as const,
+        baseAtEnd: "X" as const,
+        defectPositions: [0.5],
+      };
+      const fbY = { ...fbX, openAxis: 1 as const };
+      const incoming = new Map<string, Block>([
+        ["0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" }],
+        ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbX }],
+        ["0,1,0", { pos: { x: 0, y: 1, z: 0 }, type: fbY }],
+      ]);
+      useBlockStore.getState().loadBlocks(incoming);
+      useBlockStore.getState().removeBlock({ x: 0, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.size).toBe(0);
+    });
+
+    it("cleans up an orphaned port marker when an FB pipe is removed", () => {
+      // User-placed port at (0,0,0); FB pipe at (1,0,0) ends at that port.
+      // Removing the pipe should sweep up the port marker since nothing else
+      // anchors it — same behavior we already get for TQEC pipes.
+      // (loadBlocks clears portPositions, so addPortAt has to happen after.)
+      const fbX = {
+        kind: "fb-pipe" as const,
+        openAxis: 0 as const,
+        baseAtStart: "Z" as const,
+        baseAtEnd: "X" as const,
+        defectPositions: [0.5],
+      };
+      const incoming = new Map<string, Block>([
+        ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbX }],
+      ]);
+      useBlockStore.getState().loadBlocks(incoming);
+      useBlockStore.getState().addPortAt({ x: 0, y: 0, z: 0 });
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(true);
+      useBlockStore.getState().removeBlock({ x: 1, y: 0, z: 0 });
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(false);
+    });
+
     it("does not cascade when removing a cube with <2 pipes", () => {
       const incoming = new Map<string, Block>([
         ["0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" }],
@@ -466,6 +509,43 @@ describe("blockStore", () => {
       useBlockStore.getState().convertBlockToPort({ x: 1, y: 0, z: 0 });
       expect(useBlockStore.getState().blocks.size).toBe(1);
       expect(useBlockStore.getState().portWarning).toMatch(/Only cubes/);
+    });
+
+    it("refuses a free-build pipe and sets the same warning", () => {
+      const fbSpec = {
+        kind: "fb-pipe" as const,
+        openAxis: 0 as const,
+        baseAtStart: "Z" as const,
+        baseAtEnd: "X" as const,
+        defectPositions: [0.5],
+      };
+      const incoming = new Map<string, Block>([
+        ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbSpec }],
+      ]);
+      useBlockStore.getState().loadBlocks(incoming);
+      useBlockStore.getState().convertBlockToPort({ x: 1, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.size).toBe(1);
+      expect(useBlockStore.getState().portWarning).toMatch(/Only cubes/);
+    });
+
+    it("refuses a cube with 2+ FB pipes attached (parity with TQEC pipe attachment)", () => {
+      const fbX = {
+        kind: "fb-pipe" as const,
+        openAxis: 0 as const,
+        baseAtStart: "Z" as const,
+        baseAtEnd: "X" as const,
+        defectPositions: [0.5],
+      };
+      const fbY = { ...fbX, openAxis: 1 as const };
+      const incoming = new Map<string, Block>([
+        ["0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" }],
+        ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbX }],
+        ["0,1,0", { pos: { x: 0, y: 1, z: 0 }, type: fbY }],
+      ]);
+      useBlockStore.getState().loadBlocks(incoming);
+      useBlockStore.getState().convertBlockToPort({ x: 0, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.size).toBe(3);
+      expect(useBlockStore.getState().portWarning).toMatch(/2 pipes attached/);
     });
 
     it("is a no-op on an empty position", () => {

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -38,9 +38,11 @@ import {
   countAttachedPipes,
   getAttachedPipeKeys,
   CUBE_TYPES,
+  FACE_CONFIGS,
   PIPE_VARIANTS,
   VARIANT_AXIS_MAP,
   PIPE_TYPE_TO_VARIANT,
+  validFBPipeVariantsXZZXAxis,
   toggleHadamard,
   swapPipeVariant,
   traversedPipeKey,
@@ -846,6 +848,42 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     if (state.selectedKeys.size === 1 && state.selectedPortPositions.size === 0) {
       const pipeKey = state.selectedKeys.values().next().value as string;
       const pipeBlock = state.blocks.get(pipeKey);
+      if (pipeBlock && isFreeBuildPipeSpec(pipeBlock.type)) {
+        if (target !== undefined) return;
+        set((s) => {
+          const fb = pipeBlock.type as FreeBuildPipeSpec;
+          const valid = validFBPipeVariantsXZZXAxis(pipeBlock, s.blocks);
+          const curKey = fb.faces.join("|");
+          let cycle: Array<[FaceConfig, FaceConfig, FaceConfig, FaceConfig]>;
+          if (valid) {
+            cycle = valid.map((v) => [...v] as [FaceConfig, FaceConfig, FaceConfig, FaceConfig]);
+            if (!cycle.some((v) => v.join("|") === curKey)) cycle.unshift([...fb.faces]);
+          } else {
+            cycle = [];
+            for (const f0 of FACE_CONFIGS) for (const f1 of FACE_CONFIGS)
+              for (const f2 of FACE_CONFIGS) for (const f3 of FACE_CONFIGS)
+                cycle.push([f0, f1, f2, f3]);
+          }
+          if (cycle.length <= 1) return s;
+          const curIdx = cycle.findIndex((v) => v.join("|") === curKey);
+          if (curIdx === -1) return s;
+          const nextIdx = (((curIdx + dir) % cycle.length) + cycle.length) % cycle.length;
+          const nextFaces = cycle[nextIdx];
+          if (nextFaces.join("|") === curKey) return s;
+          const newType: FreeBuildPipeSpec = { ...fb, faces: nextFaces };
+          const newBlock: Block = { pos: pipeBlock.pos, type: newType };
+          const removed = doRemove(s.blocks, s.spatialIndex, s.hiddenFaces, pipeKey, pipeBlock);
+          const added = doAdd(removed.blocks, s.spatialIndex, removed.hiddenFaces, pipeKey, newBlock);
+          const cmd: UndoCommand = { kind: "replace", key: pipeKey, oldBlock: pipeBlock, newBlock };
+          return {
+            blocks: added.blocks,
+            hiddenFaces: added.hiddenFaces,
+            history: [...s.history, cmd].slice(-MAX_HISTORY),
+            future: [],
+          };
+        });
+        return;
+      }
       if (pipeBlock && isPipeType(pipeBlock.type)) {
         set((s) => {
           const oldType = pipeBlock.type as PipeType;

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -3,7 +3,8 @@ import { useKeybindStore } from "./keybindStore";
 import type { Flow } from "../utils/flows";
 import type {
   Position3D, Block, BlockType, CubeType, PipeVariant, PipeType, SpatialIndex, FaceMask,
-  BuildDirection, UndeterminedCubeInfo, ViewMode, IsoAxis, PortMeta, PortIO,
+  BuildDirection, UndeterminedCubeInfo, ViewMode, IsoAxis, PortMeta, PortIO, FBPreset,
+  FreeBuildPipeSpec,
 } from "../types";
 import {
   posKey,
@@ -13,9 +14,12 @@ import {
   hasCubeColorConflict,
   hasPipeColorConflict,
   hasYCubePipeAxisConflict,
+  isFreeBuildBlock,
+  isFreeBuildPipeSpec,
   isPipeType,
   isValidBlockPos,
   isValidPos,
+  pipeAxisFromPos,
   resolvePipeType,
   buildSpatialIndex,
   addToSpatialIndex,
@@ -141,6 +145,13 @@ interface BlockStore {
   cubeType: BlockType;
   pipeVariant: PipeVariant | null;
   /**
+   * Currently selected free-build pipe preset. When non-null, placement
+   * constructs an FB pipe from the preset spec (openAxis resolved from the
+   * target pipe slot). Mutually exclusive with `pipeVariant` and TQEC
+   * `cubeType`-as-pipe state.
+   */
+  fbPreset: FBPreset | null;
+  /**
    * True between pointerdown on a placeable toolbar button and the
    * subsequent window-level pointerup. While true, the pointerup handler
    * places a block at the current hoveredGridPos (drag-from-palette gesture).
@@ -218,6 +229,7 @@ interface BlockStore {
   setXHeld: (held: boolean) => void;
   setCubeType: (cubeType: BlockType) => void;
   setPipeVariant: (variant: PipeVariant) => void;
+  setFBPreset: (preset: FBPreset | null) => void;
   setPlacePort: (on: boolean) => void;
   /** Cycle the armed placeable by ±1 within PLACEABLE_ORDER (Drag / Drop mode only). */
   cycleArmedType: (dir: -1 | 1) => void;
@@ -612,6 +624,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   xHeld: false,
   cubeType: "XZZ",
   pipeVariant: null,
+  fbPreset: null,
   paletteDragging: false,
   portWarning: null,
   hoveredGridPos: null,
@@ -644,7 +657,15 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   lastBuildAxis: null,
 
   freeBuild: false,
-  toggleFreeBuild: () => set((s) => ({ freeBuild: !s.freeBuild })),
+  toggleFreeBuild: () => set((s) => {
+    const next = !s.freeBuild;
+    // Disabling Free Build clears any armed FB preset so the user can't
+    // accidentally place an FB pipe via a stale arm state.
+    if (!next && s.fbPreset) {
+      return { freeBuild: next, fbPreset: null, armedTool: "pointer" };
+    }
+    return { freeBuild: next };
+  }),
 
   showGrid: true,
   showHints: true,
@@ -770,8 +791,22 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     ...(tool !== "pointer" ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null } : {}),
   }),
   setXHeld: (held) => set({ xHeld: held, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),
-  setCubeType: (cubeType) => set({ cubeType, armedTool: "cube", pipeVariant: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
-  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], armedTool: "pipe", portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
+  setCubeType: (cubeType) => set({ cubeType, armedTool: "cube", pipeVariant: null, fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
+  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], armedTool: "pipe", fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
+  setFBPreset: (preset) => set({
+    fbPreset: preset,
+    pipeVariant: null,
+    armedTool: preset ? "pipe" : "pointer",
+    portWarning: null,
+    hoveredGridPos: null,
+    hoveredBlockType: null,
+    hoveredInvalid: false,
+    hoveredInvalidReason: null,
+    hoveredReplace: false,
+    selectedKeys: new Set<string>(),
+    selectedPortPositions: new Set<string>(),
+    selectionPivot: null,
+  }),
   setPlacePort: (on) => set({ armedTool: on ? "port" : "pointer", pipeVariant: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, ...(on ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null } : {}) }),
   cycleArmedType: (dir) => {
     const s = get();
@@ -1092,8 +1127,15 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       const store = get();
       let blockType: BlockType = store.cubeType;
 
-      // If pipe variant selected, resolve to correct PipeType based on position
-      if (store.pipeVariant) {
+      // FB pipe preset takes precedence over TQEC pipe variant. The preset's
+      // openAxis is overridden to match the target pipe slot's axis.
+      if (store.fbPreset) {
+        const tqecAxis = pipeAxisFromPos(pos);
+        if (tqecAxis === null) return state;
+        const spec: FreeBuildPipeSpec = { ...store.fbPreset.spec, openAxis: tqecAxis };
+        blockType = spec;
+      } else if (store.pipeVariant) {
+        // If pipe variant selected, resolve to correct PipeType based on position
         const resolved = resolvePipeType(store.pipeVariant, pos);
         if (!resolved) return state;
         blockType = resolved;
@@ -1113,9 +1155,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         return state;
       }
       if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex, existing ? key : undefined)) return state;
+      // Free-build pieces must only be placed when Free Build is on.
+      if (isFreeBuildPipeSpec(blockType) && !store.freeBuild) return state;
       if (!store.freeBuild) {
         if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
-        if (!isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
+        if (!isPipeType(blockType) && !isFreeBuildPipeSpec(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
         if (hasYCubePipeAxisConflict(blockType, pos, state.blocks)) return state;
       }
 
@@ -1785,7 +1829,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, sr.key, curSrc));
             const newSrcOptions = determineCubeOptions(step.prevCursorPos, blocks);
             const candidates = newSrcOptions.determined ? [newSrcOptions.type] : newSrcOptions.options;
-            const validForPipe = candidates.filter(ct => step.pipe && inferPipeType(ct, step.pipe.block.type.replace("H", "").indexOf("O") as 0 | 1 | 2) !== null);
+            const validForPipe = candidates.filter(ct => step.pipe && isPipeType(step.pipe.block.type) && inferPipeType(ct, step.pipe.block.type.replace("H", "").indexOf("O") as 0 | 1 | 2) !== null);
             const srcType = validForPipe.length > 0 ? validForPipe[0] : sr.prevType;
             ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, sr.key, { pos: step.prevCursorPos, type: srcType }));
           }
@@ -3517,3 +3561,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   setZXPanelOpen: (open) => set({ zxPanelOpen: open }),
   toggleZXPanel: () => set((s) => ({ zxPanelOpen: !s.zxPanelOpen })),
 }));
+
+/**
+ * Selector: true iff the scene contains at least one free-build (non-TQEC)
+ * block. Used to disable Verify and Export DAE so TQEC operations never run
+ * on a scene that mixes TQEC and free-build pieces.
+ */
+export const sceneHasFreeBuildBlocks = (s: BlockStore): boolean => {
+  for (const b of s.blocks.values()) if (isFreeBuildBlock(b)) return true;
+  return false;
+};

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -20,6 +20,7 @@ import {
   isValidBlockPos,
   isValidPos,
   pipeAxisFromPos,
+  pipeOpenAxisOf,
   resolvePipeType,
   buildSpatialIndex,
   addToSpatialIndex,
@@ -473,15 +474,14 @@ function syncPortsAndPromote(
  * don't falsely skip a port whose only remaining pipe just got deleted.
  */
 function orphanedPortKeysFromRemovedPipes(
-  removedPipes: Array<{ pos: Position3D; type: PipeType }>,
+  removedPipes: Array<{ pos: Position3D; type: PipeType | FreeBuildPipeSpec }>,
   blocksAfter: Map<string, Block>,
   portPositions: Set<string>,
 ): string[] {
   const result: string[] = [];
   const seen = new Set<string>();
   for (const pipe of removedPipes) {
-    const base = pipe.type.replace("H", "");
-    const openAxis = base.indexOf("O");
+    const openAxis = pipeOpenAxisOf(pipe.type);
     const coords: [number, number, number] = [pipe.pos.x, pipe.pos.y, pipe.pos.z];
     for (const offset of [-1, 2]) {
       const n: [number, number, number] = [coords[0], coords[1], coords[2]];
@@ -1074,7 +1074,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       const block = state.blocks.get(key);
       if (!block) return state;
       // Converting a pipe to a port makes no sense — pipes aren't cube-slot blocks.
-      if (isPipeType(block.type)) {
+      if (isPipeType(block.type) || isFreeBuildPipeSpec(block.type)) {
         return { portWarning: "Only cubes can be converted to a port." };
       }
       const pipeCount = countAttachedPipes(pos, state.blocks);
@@ -1242,7 +1242,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       // the pipes (each becomes a dangling segment with two ports). Take them out
       // in the same operation so the model stays consistent. Single-pipe and
       // pipeless cubes delete cleanly without cascade.
-      const cascadeKeys = !isPipeType(block.type) && countAttachedPipes(pos, state.blocks) >= 2
+      const blockIsCube = !isPipeType(block.type) && !isFreeBuildPipeSpec(block.type);
+      const cascadeKeys = blockIsCube && countAttachedPipes(pos, state.blocks) >= 2
         ? getAttachedPipeKeys(pos, state.blocks)
         : [];
 
@@ -1250,9 +1251,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         const { blocks, hiddenFaces } = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, block);
         const newUndetermined = new Map(state.undeterminedCubes);
         newUndetermined.delete(key);
-        const removedPipes = isPipeType(block.type)
-          ? [{ pos: block.pos, type: block.type as PipeType }]
-          : [];
+        const removedPipes: Array<{ pos: Position3D; type: PipeType | FreeBuildPipeSpec }> =
+          isPipeType(block.type) || isFreeBuildPipeSpec(block.type)
+            ? [{ pos: block.pos, type: block.type as PipeType | FreeBuildPipeSpec }]
+            : [];
         const orphanedPortKeys = removedPipes.length > 0
           ? orphanedPortKeysFromRemovedPipes(removedPipes, blocks, state.portPositions)
           : [];
@@ -1286,9 +1288,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       }
 
       const entries: Array<{ key: string; block: Block }> = [{ key, block }];
-      const removedPipes: Array<{ pos: Position3D; type: PipeType }> = isPipeType(block.type)
-        ? [{ pos: block.pos, type: block.type as PipeType }]
-        : [];
+      const removedPipes: Array<{ pos: Position3D; type: PipeType | FreeBuildPipeSpec }> =
+        isPipeType(block.type) || isFreeBuildPipeSpec(block.type)
+          ? [{ pos: block.pos, type: block.type as PipeType | FreeBuildPipeSpec }]
+          : [];
       let blocks = state.blocks;
       let hiddenFaces = state.hiddenFaces;
       ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, key, block));
@@ -1298,7 +1301,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         const cb = blocks.get(ck);
         if (!cb) continue;
         entries.push({ key: ck, block: cb });
-        if (isPipeType(cb.type)) removedPipes.push({ pos: cb.pos, type: cb.type as PipeType });
+        if (isPipeType(cb.type) || isFreeBuildPipeSpec(cb.type)) {
+          removedPipes.push({ pos: cb.pos, type: cb.type as PipeType | FreeBuildPipeSpec });
+        }
         ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, ck, cb));
         newUndetermined.delete(ck);
       }
@@ -2245,7 +2250,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     set((state) => {
       if (state.selectedKeys.size === 0 && state.selectedPortPositions.size === 0) return state;
       const entries: Array<{ key: string; block: Block }> = [];
-      const removedPipes: Array<{ pos: Position3D; type: PipeType }> = [];
+      const removedPipes: Array<{ pos: Position3D; type: PipeType | FreeBuildPipeSpec }> = [];
       const seen = new Set<string>();
       let { blocks, hiddenFaces } = { blocks: state.blocks, hiddenFaces: state.hiddenFaces };
       for (const key of state.selectedKeys) {
@@ -2254,11 +2259,14 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (!block) continue;
         // Junction-cube cascade: selecting a cube with ≥2 attached pipes also removes
         // those pipes, mirroring single-block removeBlock behaviour.
-        const cascadeKeys = !isPipeType(block.type) && countAttachedPipes(block.pos, blocks) >= 2
+        const blockIsCube = !isPipeType(block.type) && !isFreeBuildPipeSpec(block.type);
+        const cascadeKeys = blockIsCube && countAttachedPipes(block.pos, blocks) >= 2
           ? getAttachedPipeKeys(block.pos, blocks)
           : [];
         entries.push({ key, block });
-        if (isPipeType(block.type)) removedPipes.push({ pos: block.pos, type: block.type as PipeType });
+        if (isPipeType(block.type) || isFreeBuildPipeSpec(block.type)) {
+          removedPipes.push({ pos: block.pos, type: block.type as PipeType | FreeBuildPipeSpec });
+        }
         seen.add(key);
         ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, key, block));
         for (const ck of cascadeKeys) {
@@ -2266,7 +2274,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const cb = blocks.get(ck);
           if (!cb) continue;
           entries.push({ key: ck, block: cb });
-          if (isPipeType(cb.type)) removedPipes.push({ pos: cb.pos, type: cb.type as PipeType });
+          if (isPipeType(cb.type) || isFreeBuildPipeSpec(cb.type)) {
+            removedPipes.push({ pos: cb.pos, type: cb.type as PipeType | FreeBuildPipeSpec });
+          }
           seen.add(ck);
           ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, ck, cb));
         }

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -4,11 +4,13 @@ import type { Flow } from "../utils/flows";
 import type {
   Position3D, Block, BlockType, CubeType, PipeVariant, PipeType, SpatialIndex, FaceMask,
   BuildDirection, UndeterminedCubeInfo, ViewMode, IsoAxis, PortMeta, PortIO, FBPreset,
+  FaceConfig,
   FreeBuildPipeSpec,
 } from "../types";
 import {
   posKey,
   getAllPortPositions,
+  getOrderedPortPositions,
   defaultPortIO,
   hasBlockOverlap,
   hasCubeColorConflict,
@@ -52,11 +54,6 @@ export type Mode = "edit" | "build";
 export type ArmedTool = "pointer" | "cube" | "pipe" | "port" | "paste";
 
 const MAX_HISTORY = 100;
-
-/** Canonical X-open PipeType for each variant, used as cubeType fallback. */
-const PIPE_VARIANT_CANONICAL: Record<PipeVariant, BlockType> = {
-  ZX: "OZX", XZ: "OXZ", ZXH: "OZXH", XZH: "OXZH",
-};
 
 // ---------------------------------------------------------------------------
 // Command-based undo — stores the operation, not a full state snapshot.
@@ -143,7 +140,7 @@ interface BlockStore {
    * Drag / Drop mode, regardless of the currently armed tool.
    */
   xHeld: boolean;
-  cubeType: BlockType;
+  cubeType: CubeType | "Y";
   pipeVariant: PipeVariant | null;
   /**
    * Currently selected free-build pipe preset. When non-null, placement
@@ -202,6 +199,13 @@ interface BlockStore {
   /** Whether the right-docked ZX-diagram panel is visible. */
   zxPanelOpen: boolean;
 
+  /**
+   * Position (posKey) of the free-build pipe currently being edited via the
+   * variants panel. Auto-set when an FB pipe is placed or selected; clears
+   * when the user closes the panel or selection changes off it.
+   */
+  fbVariantsPos: string | null;
+
   /** Last-computed flows (with surface geometry), published by FlowsPanel. */
   flows: Flow[];
   /** Signature of the diagram when `flows` was last computed; used to detect stale data. */
@@ -228,7 +232,7 @@ interface BlockStore {
   setMode: (mode: Mode) => void;
   setArmedTool: (tool: ArmedTool) => void;
   setXHeld: (held: boolean) => void;
-  setCubeType: (cubeType: BlockType) => void;
+  setCubeType: (cubeType: CubeType | "Y") => void;
   setPipeVariant: (variant: PipeVariant) => void;
   setFBPreset: (preset: FBPreset | null) => void;
   setPlacePort: (on: boolean) => void;
@@ -304,8 +308,19 @@ interface BlockStore {
   ensurePortLabels: () => void;
   setPortLabel: (pos: Position3D, label: string) => void;
   setPortIO: (pos: Position3D, io: PortIO) => void;
+  /**
+   * Reorder ports by moving the port at `fromIndex` (in the current
+   * user-ordered port list) to `toIndex`, then rewriting all ranks
+   * 0..N-1 so the array indices match the stored ranks.
+   */
+  reorderPort: (fromIndex: number, toIndex: number) => void;
   setFlowsPanelOpen: (open: boolean) => void;
   toggleFlowsPanel: () => void;
+
+  /** Open the FB variant picker for the given block, or close it (pos=null). */
+  setFBVariantsPos: (pos: Position3D | null) => void;
+  /** Replace an FB pipe block's `faces` tuple in place. Used by the variant picker. */
+  setFBPipeFaces: (pos: Position3D, faces: [FaceConfig, FaceConfig, FaceConfig, FaceConfig]) => void;
 
   /** Publish computed flows (with surface geometry) for the 3D overlay to read. */
   setFlows: (flows: Flow[], signature: string) => void;
@@ -638,6 +653,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   portMeta: new Map(),
   flowsPanelOpen: false,
   zxPanelOpen: false,
+  fbVariantsPos: null,
   flows: [],
   flowsSignature: null,
   selectedFlowIndex: null,
@@ -792,7 +808,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   }),
   setXHeld: (held) => set({ xHeld: held, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),
   setCubeType: (cubeType) => set({ cubeType, armedTool: "cube", pipeVariant: null, fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
-  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], armedTool: "pipe", fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
+  setPipeVariant: (variant) => set({ pipeVariant: variant, armedTool: "pipe", fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
   setFBPreset: (preset) => set({
     fbPreset: preset,
     pipeVariant: null,
@@ -1164,6 +1180,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       }
 
       const block: Block = { pos, type: blockType };
+      // Auto-open the FB variant picker for a freshly-placed FB pipe so the
+      // user immediately sees the 256 candidate variants. Placing any other
+      // block type clears the panel — the user is no longer focused on a
+      // specific FB pipe.
+      const fbVariantsPos = isFreeBuildPipeSpec(blockType) ? key : null;
 
       if (existing) {
         // Skip if same type — nothing to replace
@@ -1179,6 +1200,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           history: [...state.history, cmd].slice(-MAX_HISTORY),
           future: [],
           undeterminedCubes: newUndetermined,
+          fbVariantsPos,
         };
       }
 
@@ -1207,6 +1229,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             history: [...state.history, cmd].slice(-MAX_HISTORY),
             future: [],
             portPositions: newPorts,
+            fbVariantsPos,
           };
         }
       }
@@ -1221,6 +1244,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           history: [...state.history, cmd].slice(-MAX_HISTORY),
           future: [],
           portPositions: newPorts,
+          fbVariantsPos,
         };
       }
 
@@ -1229,6 +1253,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         hiddenFaces,
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
+        fbVariantsPos,
       };
     }),
 
@@ -2210,17 +2235,30 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       } else {
         next.add(key);
       }
+      // Surface the FB variants picker iff exactly one FB pipe is now selected.
+      let fbVariantsPos: string | null = null;
+      if (next.size === 1) {
+        const onlyKey = next.values().next().value as string;
+        const onlyBlock = state.blocks.get(onlyKey);
+        if (onlyBlock && isFreeBuildPipeSpec(onlyBlock.type)) fbVariantsPos = onlyKey;
+      }
       return {
         selectedKeys: next,
         selectedPortPositions: additive ? state.selectedPortPositions : new Set<string>(),
         selectionPivot: null,
+        fbVariantsPos,
       };
     }),
 
   clearSelection: () =>
     set((state) => {
       if (state.selectedKeys.size === 0 && state.selectedPortPositions.size === 0) return state;
-      return { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null };
+      return {
+        selectedKeys: new Set<string>(),
+        selectedPortPositions: new Set<string>(),
+        selectionPivot: null,
+        fbVariantsPos: null,
+      };
     }),
 
   togglePortSelection: (pos, additive) =>
@@ -3493,7 +3531,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       for (const k of stale) next.delete(k);
 
       const used = new Set<string>();
-      for (const meta of next.values()) used.add(meta.label);
+      let maxRank = -1;
+      for (const meta of next.values()) {
+        used.add(meta.label);
+        if (meta.rank !== undefined && meta.rank > maxRank) maxRank = meta.rank;
+      }
       let nextId = 1;
       const allocLabel = (): string => {
         while (used.has(`P${nextId}`)) nextId++;
@@ -3503,9 +3545,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       };
 
       for (const pos of missing) {
+        maxRank += 1;
         next.set(posKey(pos), {
           label: allocLabel(),
           io: defaultPortIO(pos, state.blocks),
+          rank: maxRank,
         });
       }
       return { portMeta: next };
@@ -3550,6 +3594,34 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       return { portMeta: next };
     }),
 
+  reorderPort: (fromIndex, toIndex) =>
+    set((state) => {
+      const ordered = getOrderedPortPositions(
+        state.blocks,
+        state.portPositions,
+        state.portMeta,
+      );
+      if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= ordered.length ||
+        toIndex >= ordered.length
+      ) {
+        return state;
+      }
+      const keys = ordered.map(posKey);
+      const [moved] = keys.splice(fromIndex, 1);
+      keys.splice(toIndex, 0, moved);
+
+      const next = new Map(state.portMeta);
+      keys.forEach((k, i) => {
+        const m = next.get(k);
+        if (m && m.rank !== i) next.set(k, { ...m, rank: i });
+      });
+      return { portMeta: next };
+    }),
+
   setFlowsPanelOpen: (open) =>
     set(open ? { flowsPanelOpen: true } : { flowsPanelOpen: false, flowVizMode: false }),
   toggleFlowsPanel: () =>
@@ -3558,6 +3630,25 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         ? { flowsPanelOpen: false, flowVizMode: false }
         : { flowsPanelOpen: true },
     ),
+
+  setFBVariantsPos: (pos) => set({ fbVariantsPos: pos ? posKey(pos) : null }),
+  setFBPipeFaces: (pos, faces) =>
+    set((state) => {
+      const key = posKey(pos);
+      const block = state.blocks.get(key);
+      if (!block || !isFreeBuildPipeSpec(block.type)) return state;
+      const newType: FreeBuildPipeSpec = { ...block.type, faces };
+      const newBlock: Block = { pos: block.pos, type: newType };
+      const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, block);
+      const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, key, newBlock);
+      const cmd: UndoCommand = { kind: "replace", key, oldBlock: block, newBlock };
+      return {
+        blocks,
+        hiddenFaces,
+        history: [...state.history, cmd].slice(-MAX_HISTORY),
+        future: [],
+      };
+    }),
 
   setFlows: (flows, signature) =>
     set({

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -42,7 +42,7 @@ import {
   PIPE_VARIANTS,
   VARIANT_AXIS_MAP,
   PIPE_TYPE_TO_VARIANT,
-  validFBPipeVariantsXZZXAxis,
+  validFBPipeVariantsForCubePair,
   toggleHadamard,
   swapPipeVariant,
   traversedPipeKey,
@@ -852,11 +852,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (target !== undefined) return;
         set((s) => {
           const fb = pipeBlock.type as FreeBuildPipeSpec;
-          const valid = validFBPipeVariantsXZZXAxis(pipeBlock, s.blocks);
+          const valid = validFBPipeVariantsForCubePair(pipeBlock, s.blocks);
           const curKey = fb.faces.join("|");
           let cycle: Array<[FaceConfig, FaceConfig, FaceConfig, FaceConfig]>;
           if (valid) {
-            cycle = valid.map((v) => [...v] as [FaceConfig, FaceConfig, FaceConfig, FaceConfig]);
+            cycle = valid.faces.map((v) => [...v] as [FaceConfig, FaceConfig, FaceConfig, FaceConfig]);
             if (!cycle.some((v) => v.join("|") === curKey)) cycle.unshift([...fb.faces]);
           } else {
             cycle = [];
@@ -1209,8 +1209,6 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         return state;
       }
       if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex, existing ? key : undefined)) return state;
-      // Free-build pieces must only be placed when Free Build is on.
-      if (isFreeBuildPipeSpec(blockType) && !store.freeBuild) return state;
       if (!store.freeBuild) {
         if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
         if (!isPipeType(blockType) && !isFreeBuildPipeSpec(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
@@ -2421,7 +2419,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             if (hasPipeColorConflict(type, pos, proposed)) {
               return { hoveredInvalidReason: flipBlocked };
             }
-          } else if (type !== "Y") {
+          } else if (!isFreeBuildPipeSpec(type) && type !== "Y") {
             if (hasCubeColorConflict(type as CubeType, pos, proposed)) {
               return { hoveredInvalidReason: flipBlocked };
             }
@@ -2688,7 +2686,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const t = e.newBlock.type;
           const fails =
             (isPipeType(t) && hasPipeColorConflict(t, e.newBlock.pos, blocks)) ||
-            (!isPipeType(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, e.newBlock.pos, blocks)) ||
+            (!isPipeType(t) && !isFreeBuildPipeSpec(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, e.newBlock.pos, blocks)) ||
             hasYCubePipeAxisConflict(t, e.newBlock.pos, blocks);
           if (fails) {
             for (const r of entries) {

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -1,20 +1,29 @@
 import { describe, expect, it } from "vitest";
+import { Vector3 } from "three";
 import {
   createBlockGeometry,
   createYDefectEdges,
   blockTqecSize,
+  countAttachedPipes,
+  getAdjacentPos,
+  getAttachedPipeKeys,
   isFreeBuildBlock,
   isFreeBuildPipeSpec,
   isPipeType,
+  isValidPipePos,
   isValidPos,
   flipBlockType,
   blockTypeCacheKey,
+  pipeAxisFromPos,
+  pipeOpenAxisOf,
+  posKey,
   H_COLOR,
   X_COLOR,
   Z_COLOR,
   FB_PRESETS,
 } from "./index";
-import type { Block, BlockType, FreeBuildPipeSpec } from "./index";
+import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances";
 
 const Z_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
@@ -190,5 +199,131 @@ describe("FB_PRESETS", () => {
     expect(zx!.spec.baseAtEnd).toBe("X");
     expect(xz!.spec.baseAtStart).toBe("X");
     expect(xz!.spec.baseAtEnd).toBe("Z");
+  });
+});
+
+// Regression: free-build pipes must snap to ports/blocks the same way regular
+// pipes do. Before this fix, the gates in OpenPipeGhosts and BlockInstances
+// only checked store.pipeVariant, so an armed FB preset fell through to the
+// cube-placement path. resolveFBSpecFromFace is the FB-aware analogue of
+// resolvePipeTypeFromFace and gives back BOTH the snapped slot and the spec
+// with openAxis matching that slot's TQEC axis.
+describe("resolveFBSpecFromFace (port-adjacent FB pipe snapping)", () => {
+  const PRESET: FBPreset = FB_PRESETS[0]; // swap-zx, openAxis=2 in template
+  const PORT: Position3D = { x: 0, y: 0, z: 0 };
+
+  it("snaps to the +X pipe slot with +X face normal", () => {
+    const r = resolveFBSpecFromFace(PORT, "XZZ", new Vector3(1, 0, 0), PRESET);
+    expect(r).not.toBeNull();
+    expect(r!.adj).toEqual({ x: 1, y: 0, z: 0 });
+    expect(isValidPipePos(r!.adj)).toBe(true);
+    expect(pipeAxisFromPos(r!.adj)).toBe(0);
+    expect(r!.spec.openAxis).toBe(0);
+    expect(r!.spec.kind).toBe("fb-pipe");
+  });
+
+  it("snaps to the -X pipe slot with -X face normal", () => {
+    const r = resolveFBSpecFromFace(PORT, "XZZ", new Vector3(-1, 0, 0), PRESET);
+    expect(r).not.toBeNull();
+    expect(r!.adj).toEqual({ x: -2, y: 0, z: 0 });
+    expect(r!.spec.openAxis).toBe(0);
+  });
+
+  it("snaps to a Z-axis pipe slot with Three +Y face normal (TQEC +Z)", () => {
+    const r = resolveFBSpecFromFace(PORT, "XZZ", new Vector3(0, 1, 0), PRESET);
+    expect(r).not.toBeNull();
+    expect(r!.adj).toEqual({ x: 0, y: 0, z: 1 });
+    expect(r!.spec.openAxis).toBe(2);
+  });
+
+  it("snaps to a Y-axis pipe slot with Three +Z face normal (TQEC -Y)", () => {
+    const r = resolveFBSpecFromFace(PORT, "XZZ", new Vector3(0, 0, 1), PRESET);
+    expect(r).not.toBeNull();
+    expect(r!.adj).toEqual({ x: 0, y: -2, z: 0 });
+    expect(r!.spec.openAxis).toBe(1);
+  });
+
+  it("preserves the preset's color/defect template, only overriding openAxis", () => {
+    const r = resolveFBSpecFromFace(PORT, "XZZ", new Vector3(1, 0, 0), PRESET);
+    expect(r).not.toBeNull();
+    expect(r!.spec.baseAtStart).toBe(PRESET.spec.baseAtStart);
+    expect(r!.spec.baseAtEnd).toBe(PRESET.spec.baseAtEnd);
+    expect(r!.spec.defectPositions).toEqual(PRESET.spec.defectPositions);
+  });
+
+  it("computes the same adj position as resolvePipeTypeFromFace for every face direction", () => {
+    // Snap parity: an FB preset hovering a port should land on the same grid slot
+    // as a regular pipe variant — the only thing that differs is the resulting
+    // block type (FB spec vs concrete PipeType).
+    const port: Position3D = { x: 3, y: 6, z: 0 };
+    const normals = [
+      new Vector3(1, 0, 0),
+      new Vector3(-1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, -1, 0),
+      new Vector3(0, 0, 1),
+      new Vector3(0, 0, -1),
+    ];
+    for (const n of normals) {
+      const fb = resolveFBSpecFromFace(port, "XZZ", n, PRESET);
+      const reg = resolvePipeTypeFromFace(port, "XZZ", n, "ZX");
+      expect(fb).not.toBeNull();
+      expect(reg).not.toBeNull();
+      const regAdj = getAdjacentPos(port, "XZZ", n, reg!);
+      expect(fb!.adj).toEqual(regAdj);
+    }
+  });
+});
+
+// FB pipes must participate in attached-pipe accounting so that cubes with FB
+// pipes attached cascade-delete those pipes (instead of orphaning them as
+// floating segments) and converting a junction cube to a port is refused.
+describe("attached-pipe accounting recognizes FB pipes", () => {
+  function makeBlocks(entries: Block[]): Map<string, Block> {
+    const map = new Map<string, Block>();
+    for (const b of entries) map.set(posKey(b.pos), b);
+    return map;
+  }
+
+  it("pipeOpenAxisOf returns the spec axis for FB pipes and the O-index for TQEC pipes", () => {
+    expect(pipeOpenAxisOf(X_OPEN_SPEC)).toBe(0);
+    expect(pipeOpenAxisOf(Y_OPEN_SPEC)).toBe(1);
+    expect(pipeOpenAxisOf(Z_OPEN_SPEC)).toBe(2);
+    expect(pipeOpenAxisOf("OZX")).toBe(0);
+    expect(pipeOpenAxisOf("ZOX")).toBe(1);
+    expect(pipeOpenAxisOf("ZXO")).toBe(2);
+    expect(pipeOpenAxisOf("OZXH")).toBe(0);
+  });
+
+  it("countAttachedPipes counts FB pipes alongside TQEC pipes", () => {
+    // Cube at origin with one TQEC pipe on +X and one FB pipe on +Y.
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
+      { pos: { x: 1, y: 0, z: 0 }, type: "OZX" },
+      { pos: { x: 0, y: 1, z: 0 }, type: Y_OPEN_SPEC },
+    ]);
+    expect(countAttachedPipes({ x: 0, y: 0, z: 0 }, blocks)).toBe(2);
+  });
+
+  it("getAttachedPipeKeys returns FB pipe keys", () => {
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
+      { pos: { x: 1, y: 0, z: 0 }, type: X_OPEN_SPEC },
+      { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC },
+    ]);
+    const keys = getAttachedPipeKeys({ x: 0, y: 0, z: 0 }, blocks);
+    expect(keys.sort()).toEqual(["0,0,1", "1,0,0"]);
+  });
+
+  it("does not count an FB pipe whose open axis doesn't point at the cube", () => {
+    // A Z-open FB pipe at (1,0,0) is NOT a +X-attached pipe of the cube at origin
+    // (it occupies a Z-axis slot, but its position isn't even a valid pipe slot).
+    // This is a parity check: regular pipes are filtered the same way.
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
+      // Wrong-axis FB pipe at +X slot — open along Y, not X.
+      { pos: { x: 1, y: 0, z: 0 }, type: Y_OPEN_SPEC },
+    ]);
+    expect(countAttachedPipes({ x: 0, y: 0, z: 0 }, blocks)).toBe(0);
   });
 });

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -140,6 +140,32 @@ describe("createYDefectEdges for FB pipes", () => {
     const twoDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [0.33, 0.67] };
     expect(edgeCount(createYDefectEdges(twoDefects))).toBe(12);
   });
+
+  it("half-swap FB pipe emits 4 half-length corners + 2 ring segments = 6", () => {
+    // swapAxes "first": below midpoint, ca0/ca1 differ → 4 corners on the
+    // lower half. Above midpoint, both walls share the same basis → no
+    // corners. Ring at the defect only crosses the swapping (ca0) walls,
+    // contributing 2 segments instead of 4.
+    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
+    expect(edgeCount(createYDefectEdges(halfSpec))).toBe(6);
+  });
+
+  it("half-swap FB pipe corner segments span only the lower half of the open axis", () => {
+    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
+    const arr = createYDefectEdges(halfSpec).getAttribute("position").array as Float32Array;
+    // Z_OPEN_SPEC has Three.js openAxis = 1 (Y). Corner edges are the first 4
+    // line segments; ring segments come last. Each segment is two 3-vec verts.
+    // For a half-swap pipe, corner segments must run from the negative-Y end
+    // to the midpoint (Y = 0), not all the way across.
+    for (let i = 0; i < 4; i++) {
+      const y0 = arr[i * 6 + 1];
+      const y1 = arr[i * 6 + 4];
+      const yMin = Math.min(y0, y1);
+      const yMax = Math.max(y0, y1);
+      expect(yMin).toBeLessThan(0);
+      expect(yMax).toBeCloseTo(0, 6);
+    }
+  });
 });
 
 describe("flipBlockType on FB pipes", () => {
@@ -167,8 +193,8 @@ describe("blockTypeCacheKey", () => {
   });
 
   it("returns a deterministic content-based key for FB specs", () => {
-    expect(blockTypeCacheKey(Z_OPEN_SPEC)).toBe("fb:2|Z|X|0.5");
-    expect(blockTypeCacheKey(X_OPEN_SPEC)).toBe("fb:0|Z|X|0.5");
+    expect(blockTypeCacheKey(Z_OPEN_SPEC)).toBe("fb:2|Z|X|0.5|all");
+    expect(blockTypeCacheKey(X_OPEN_SPEC)).toBe("fb:0|Z|X|0.5|all");
   });
 
   it("two structurally equal specs produce the same key", () => {
@@ -176,13 +202,15 @@ describe("blockTypeCacheKey", () => {
     const b: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
     expect(blockTypeCacheKey(a)).toBe(blockTypeCacheKey(b));
   });
+
+  it("specs that differ only in swapAxes produce different keys", () => {
+    const full: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
+    const half: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
+    expect(blockTypeCacheKey(full)).not.toBe(blockTypeCacheKey(half));
+  });
 });
 
 describe("FB_PRESETS", () => {
-  it("ships exactly two presets in v1", () => {
-    expect(FB_PRESETS).toHaveLength(2);
-  });
-
   it("all presets have a single Y defect at 0.5", () => {
     for (const p of FB_PRESETS) {
       expect(p.spec.kind).toBe("fb-pipe");
@@ -190,7 +218,7 @@ describe("FB_PRESETS", () => {
     }
   });
 
-  it("the two presets are color-swap mirrors of each other (Z→X and X→Z)", () => {
+  it("the full presets are color-swap mirrors of each other (Z→X and X→Z)", () => {
     const zx = FB_PRESETS.find((p) => p.id === "swap-zx");
     const xz = FB_PRESETS.find((p) => p.id === "swap-xz");
     expect(zx).toBeDefined();
@@ -199,6 +227,89 @@ describe("FB_PRESETS", () => {
     expect(zx!.spec.baseAtEnd).toBe("X");
     expect(xz!.spec.baseAtStart).toBe("X");
     expect(xz!.spec.baseAtEnd).toBe("Z");
+    expect(zx!.spec.swapAxes ?? "all").toBe("all");
+    expect(xz!.spec.swapAxes ?? "all").toBe("all");
+  });
+
+  it("ships half-swap presets that change only 2 opposite faces", () => {
+    const halfZx = FB_PRESETS.find((p) => p.id === "half-zx");
+    const halfXz = FB_PRESETS.find((p) => p.id === "half-xz");
+    expect(halfZx).toBeDefined();
+    expect(halfXz).toBeDefined();
+    expect(halfZx!.spec.swapAxes).toBe("first");
+    expect(halfXz!.spec.swapAxes).toBe("first");
+    expect(halfZx!.spec.baseAtStart).toBe("Z");
+    expect(halfZx!.spec.baseAtEnd).toBe("X");
+    expect(halfXz!.spec.baseAtStart).toBe("X");
+    expect(halfXz!.spec.baseAtEnd).toBe("Z");
+  });
+});
+
+describe("FB pipe geometry honors swapAxes", () => {
+  function vertexColors(geo: ReturnType<typeof createBlockGeometry>): { r: number; g: number; b: number }[] {
+    const arr = geo.getAttribute("color").array as Float32Array;
+    const out: { r: number; g: number; b: number }[] = [];
+    for (let i = 0; i < arr.length; i += 3) out.push({ r: arr[i], g: arr[i + 1], b: arr[i + 2] });
+    return out;
+  }
+  function colorEq(a: { r: number; g: number; b: number }, c: typeof X_COLOR): boolean {
+    return Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
+  }
+
+  it("full-swap pipe has each base color count balanced (all 4 walls swap)", () => {
+    const colors = vertexColors(createBlockGeometry(Z_OPEN_SPEC));
+    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
+    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
+    // 4 walls × 2 strips × 4 verts = 32 colored verts; each base appears on
+    // 4 strips (2 below + 2 above per axis pair), so counts are equal.
+    expect(xCount).toBe(zCount);
+    expect(xCount + zCount).toBe(32);
+  });
+
+  it("half-swap pipe biases toward the start-side base (3 strips of one color, 1 of the other)", () => {
+    // Z→X half: closed axis 0 wall pair shows Z below + X above.
+    //           closed axis 1 wall pair shows X below AND X above (no swap).
+    // Total Z verts: 1 strip × 2 walls × 4 verts = 8.
+    // Total X verts: 3 strips × 2 walls × 4 verts = 24.
+    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
+    const colors = vertexColors(createBlockGeometry(halfSpec));
+    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
+    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
+    expect(xCount).toBe(24);
+    expect(zCount).toBe(8);
+  });
+
+  it("swapAxes 'second' mirrors 'first' on the other closed-axis pair", () => {
+    // Z→X second-axis half: closed axis 0 wall pair stays Z (no swap).
+    //                       closed axis 1 wall pair shows X below + Z above.
+    // Total Z verts: 3 strips × 2 walls × 4 verts = 24.
+    // Total X verts: 1 strip × 2 walls × 4 verts = 8.
+    // Mirror of the "first" case above (swap on the opposite axis pair).
+    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "second" };
+    const colors = vertexColors(createBlockGeometry(halfSpec));
+    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
+    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
+    expect(xCount).toBe(8);
+    expect(zCount).toBe(24);
+  });
+
+  it("swapAxes 'second' Y-defect ring lies on the second closed-axis wall pair", () => {
+    // Z_OPEN_SPEC has Three.js openAxis=1 (Y), closedAxes=[0,2]=[X,Z].
+    // swapAxes "second" → only the Z-axis wall pair (closed[1]) swaps. The
+    // ring segments at the defect must therefore vary in X (i.e., run along
+    // the X axis, lying on the Z-walls), not in Z. Total: 4 corners (lower
+    // half) + 2 ring segments = 6 edges, mirroring the "first" case.
+    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "second" };
+    const arr = createYDefectEdges(halfSpec).getAttribute("position").array as Float32Array;
+    expect(arr.length / 6).toBe(6);
+    // Last 2 segments are the ring; verify they vary in X (Three.js axis 0)
+    // and stay constant in Z (Three.js axis 2).
+    for (let i = 4; i < 6; i++) {
+      const x0 = arr[i * 6 + 0], x1 = arr[i * 6 + 3];
+      const z0 = arr[i * 6 + 2], z1 = arr[i * 6 + 5];
+      expect(Math.abs(x1 - x0)).toBeGreaterThan(0.5);
+      expect(z0).toBeCloseTo(z1, 6);
+    }
   });
 });
 

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -21,32 +21,36 @@ import {
   X_COLOR,
   Z_COLOR,
   FB_PRESETS,
+  FB_DEFAULT_FACES,
+  migrateLegacyFBSpec,
+  normalizeFBSpec,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
-import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
 
+// Z-open full-swap reference (matches legacy `baseAtStart:Z, baseAtEnd:X` semantics
+// for Z-open pipes: ca0=X-axis takes Z-below + X-above; ca1=Z-axis takes X-below + Z-above).
 const Z_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 2,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["ZX", "ZX", "XZ", "XZ"],
 };
 
 const X_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 0,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["ZX", "ZX", "XZ", "XZ"],
 };
 
+// Legacy Y-open spec mirrored the start/end pair (tail-orientation flip), so the
+// equivalent new spec puts XZ on ca0 (X-axis Three.js) and ZX on ca1 (Y-axis Three.js).
 const Y_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 1,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["XZ", "XZ", "ZX", "ZX"],
 };
 
 describe("isFreeBuildBlock / isFreeBuildPipeSpec", () => {
@@ -95,12 +99,14 @@ describe("createBlockGeometry for FB pipes", () => {
     for (let i = 0; i < arr.length; i += 3) out.push({ r: arr[i], g: arr[i + 1], b: arr[i + 2] });
     return out;
   }
+  function colorEq(a: { r: number; g: number; b: number }, c: typeof X_COLOR): boolean {
+    return Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
+  }
 
   it("emits no yellow (H_COLOR) vertices — FB has no Hadamard band", () => {
     const geo = createBlockGeometry(Z_OPEN_SPEC);
     const colors = vertexColors(geo);
     for (const c of colors) {
-      // Yellow Hadamard band would be (H_COLOR.r, H_COLOR.g, H_COLOR.b).
       const isYellow =
         Math.abs(c.r - H_COLOR.r) < 1e-6 &&
         Math.abs(c.g - H_COLOR.g) < 1e-6 &&
@@ -109,80 +115,128 @@ describe("createBlockGeometry for FB pipes", () => {
     }
   });
 
-  it("contains both X_COLOR and Z_COLOR vertices (color swap at midpoint)", () => {
+  it("contains both X_COLOR and Z_COLOR vertices when a wall swaps", () => {
     const geo = createBlockGeometry(Z_OPEN_SPEC);
     const colors = vertexColors(geo);
-    const sameAs = (a: { r: number; g: number; b: number }, c: typeof X_COLOR) =>
-      Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
-    expect(colors.some((c) => sameAs(c, X_COLOR))).toBe(true);
-    expect(colors.some((c) => sameAs(c, Z_COLOR))).toBe(true);
+    expect(colors.some((c) => colorEq(c, X_COLOR))).toBe(true);
+    expect(colors.some((c) => colorEq(c, Z_COLOR))).toBe(true);
+  });
+
+  it("solid-X pipe has only X_COLOR vertices on every wall", () => {
+    const solid: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "X", "X", "X"] };
+    const colors = vertexColors(createBlockGeometry(solid));
+    for (const c of colors) {
+      // All non-zero color verts must be red (X) — open-axis faces are stripped.
+      if (c.r === 0 && c.g === 0 && c.b === 0) continue;
+      expect(colorEq(c, X_COLOR)).toBe(true);
+    }
+  });
+
+  it("each FaceConfig produces the expected (below, above) basis pair", () => {
+    // Each wall has 2 strips × 4 verts = 8 colored verts. Build a single-wall
+    // probe: vary one face at a time, leave the other 3 as solid X.
+    const cases: Array<{ fc: "XZ" | "ZX" | "X" | "Z"; below: typeof X_COLOR; above: typeof X_COLOR }> = [
+      { fc: "X", below: X_COLOR, above: X_COLOR },
+      { fc: "Z", below: Z_COLOR, above: Z_COLOR },
+      { fc: "XZ", below: X_COLOR, above: Z_COLOR },
+      { fc: "ZX", below: Z_COLOR, above: X_COLOR },
+    ];
+    for (const { fc, below, above } of cases) {
+      const spec: FreeBuildPipeSpec = {
+        ...Z_OPEN_SPEC,
+        faces: [fc, "X", "X", "X"],
+      };
+      const colors = vertexColors(createBlockGeometry(spec));
+      // The first wall (face 0 = +ca0) emits 2 strips × 4 verts. With ca0 = X
+      // (Three.js axis 0), the +ca0 wall verts can be identified by x-coord
+      // > 0. Below-strip verts have y < 0; above-strip verts have y > 0
+      // (Three.js openAxis = 1 for Z-open). We pull both strips and check.
+      const positions = createBlockGeometry(spec).getAttribute("position").array as Float32Array;
+      let belowFound = false;
+      let aboveFound = false;
+      for (let i = 0; i < positions.length / 3; i++) {
+        const px = positions[i * 3];
+        const py = positions[i * 3 + 1];
+        if (px <= 0) continue;
+        const c = colors[i];
+        if (py < 0 && colorEq(c, below)) belowFound = true;
+        if (py > 0 && colorEq(c, above)) aboveFound = true;
+      }
+      expect(belowFound).toBe(true);
+      expect(aboveFound).toBe(true);
+    }
   });
 });
 
-describe("createYDefectEdges for FB pipes", () => {
+describe("createYDefectEdges for FB pipes (per-face)", () => {
   function edgeCount(geo: ReturnType<typeof createYDefectEdges>): number {
     const arr = geo.getAttribute("position").array as Float32Array;
     return arr.length / 6;
   }
 
-  it("FB pipe with one defect emits 4 corner edges + 4 ring segments = 8", () => {
+  it("full-swap pipe (all 4 walls swap) emits 4 corner edges + 4 ring segments = 8", () => {
     expect(edgeCount(createYDefectEdges(Z_OPEN_SPEC))).toBe(8);
     expect(edgeCount(createYDefectEdges(X_OPEN_SPEC))).toBe(8);
     expect(edgeCount(createYDefectEdges(Y_OPEN_SPEC))).toBe(8);
   });
 
-  it("FB pipe with no defects emits only the 4 corner edges (no ring)", () => {
-    const noDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [] };
-    expect(edgeCount(createYDefectEdges(noDefects))).toBe(4);
+  it("solid pipe (every face same basis) emits no Y-defect edges", () => {
+    const solid: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "X", "X", "X"] };
+    expect(edgeCount(createYDefectEdges(solid))).toBe(0);
   });
 
-  it("FB pipe with two defects emits 4 corners + 2 rings × 4 = 12", () => {
-    const twoDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [0.33, 0.67] };
-    expect(edgeCount(createYDefectEdges(twoDefects))).toBe(12);
+  it("one swapping face puts a ring on that face plus corner cylinders on its 2 adjacent corners", () => {
+    // Faces: [+ca0=XZ, -ca0=X, +ca1=X, -ca1=X]. Below: +ca0 X = -ca0 X = +ca1 X = -ca1 X (no diff).
+    // Above: +ca0 Z, others X — corners (+ca0,±ca1) light up above. So 2 above-half corners
+    // + 1 ring on the swapping face = 3 edges total.
+    const spec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["XZ", "X", "X", "X"] };
+    expect(edgeCount(createYDefectEdges(spec))).toBe(3);
   });
 
-  it("half-swap FB pipe emits 4 half-length corners + 2 ring segments = 6", () => {
-    // swapAxes "first": below midpoint, ca0/ca1 differ → 4 corners on the
-    // lower half. Above midpoint, both walls share the same basis → no
-    // corners. Ring at the defect only crosses the swapping (ca0) walls,
-    // contributing 2 segments instead of 4.
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
+  it("half-swap pipe (one pair swaps, the other stays solid X) emits 4 half-corners + 2 rings = 6", () => {
+    // Migrating the legacy {baseAtStart:Z, swapAxes:"first"} → faces=["ZX","ZX","X","X"].
+    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["ZX", "ZX", "X", "X"] };
     expect(edgeCount(createYDefectEdges(halfSpec))).toBe(6);
   });
 
-  it("half-swap FB pipe corner segments span only the lower half of the open axis", () => {
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
-    const arr = createYDefectEdges(halfSpec).getAttribute("position").array as Float32Array;
-    // Z_OPEN_SPEC has Three.js openAxis = 1 (Y). Corner edges are the first 4
-    // line segments; ring segments come last. Each segment is two 3-vec verts.
-    // For a half-swap pipe, corner segments must run from the negative-Y end
-    // to the midpoint (Y = 0), not all the way across.
-    for (let i = 0; i < 4; i++) {
-      const y0 = arr[i * 6 + 1];
-      const y1 = arr[i * 6 + 4];
-      const yMin = Math.min(y0, y1);
-      const yMax = Math.max(y0, y1);
-      expect(yMin).toBeLessThan(0);
-      expect(yMax).toBeCloseTo(0, 6);
-    }
+  it("pipe with no defects: corner cylinder appears iff bases differ across the whole length", () => {
+    // Solid faces only — different colors on opposite walls give 4 corners (no rings, no defect).
+    const noDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [], faces: ["X", "X", "Z", "Z"] };
+    expect(edgeCount(createYDefectEdges(noDefects))).toBe(4);
+  });
+
+  it("opposite-direction swaps on a pair (XZ vs ZX) light up Y-defects on both halves", () => {
+    // ca0 +face XZ (X→Z), ca0 -face ZX (Z→X). At the corner with the orthogonal wall (X solid):
+    //   below: +ca0 = X vs ca1 = X — no diff
+    //   above: +ca0 = Z vs ca1 = X — diff → cylinder above
+    //   below: -ca0 = Z vs ca1 = X — diff → cylinder below
+    //   above: -ca0 = X vs ca1 = X — no diff
+    // Both ca0 walls swap → 2 ring segments. Total: 2 above-corners + 2 below-corners + 2 rings = 6.
+    const spec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["XZ", "ZX", "X", "X"] };
+    expect(edgeCount(createYDefectEdges(spec))).toBe(6);
   });
 });
 
 describe("flipBlockType on FB pipes", () => {
-  it("swaps baseAtStart and baseAtEnd between X and Z, leaving defects unchanged", () => {
+  it("flips X↔Z on every face config (X↔Z, XZ↔ZX), leaving openAxis/defects unchanged", () => {
     const flipped = flipBlockType(Z_OPEN_SPEC) as FreeBuildPipeSpec;
     expect(flipped.kind).toBe("fb-pipe");
-    expect(flipped.baseAtStart).toBe("X");
-    expect(flipped.baseAtEnd).toBe("Z");
-    expect(flipped.defectPositions).toEqual([0.5]);
     expect(flipped.openAxis).toBe(2);
+    expect(flipped.defectPositions).toEqual([0.5]);
+    // Z_OPEN_SPEC.faces = ["ZX","ZX","XZ","XZ"] → ["XZ","XZ","ZX","ZX"]
+    expect(flipped.faces).toEqual(["XZ", "XZ", "ZX", "ZX"]);
   });
 
   it("is an involution on FB pipes (flip twice = original)", () => {
     const once = flipBlockType(Z_OPEN_SPEC) as FreeBuildPipeSpec;
     const twice = flipBlockType(once) as FreeBuildPipeSpec;
-    expect(twice.baseAtStart).toBe(Z_OPEN_SPEC.baseAtStart);
-    expect(twice.baseAtEnd).toBe(Z_OPEN_SPEC.baseAtEnd);
+    expect(twice.faces).toEqual(Z_OPEN_SPEC.faces);
+  });
+
+  it("solid faces flip too: X→Z, Z→X", () => {
+    const solid: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "Z", "X", "Z"] };
+    const flipped = flipBlockType(solid) as FreeBuildPipeSpec;
+    expect(flipped.faces).toEqual(["Z", "X", "Z", "X"]);
   });
 });
 
@@ -193,8 +247,8 @@ describe("blockTypeCacheKey", () => {
   });
 
   it("returns a deterministic content-based key for FB specs", () => {
-    expect(blockTypeCacheKey(Z_OPEN_SPEC)).toBe("fb:2|Z|X|0.5|all");
-    expect(blockTypeCacheKey(X_OPEN_SPEC)).toBe("fb:0|Z|X|0.5|all");
+    expect(blockTypeCacheKey(Z_OPEN_SPEC)).toBe("fb:2|ZXZXXZXZ|0.5");
+    expect(blockTypeCacheKey(X_OPEN_SPEC)).toBe("fb:0|ZXZXXZXZ|0.5");
   });
 
   it("two structurally equal specs produce the same key", () => {
@@ -203,113 +257,99 @@ describe("blockTypeCacheKey", () => {
     expect(blockTypeCacheKey(a)).toBe(blockTypeCacheKey(b));
   });
 
-  it("specs that differ only in swapAxes produce different keys", () => {
-    const full: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
-    const half: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
-    expect(blockTypeCacheKey(full)).not.toBe(blockTypeCacheKey(half));
+  it("specs that differ in any face produce different keys", () => {
+    const a: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
+    const b: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "X", "X", "X"] };
+    expect(blockTypeCacheKey(a)).not.toBe(blockTypeCacheKey(b));
   });
 });
 
 describe("FB_PRESETS", () => {
-  it("all presets have a single Y defect at 0.5", () => {
-    for (const p of FB_PRESETS) {
-      expect(p.spec.kind).toBe("fb-pipe");
-      expect(p.spec.defectPositions).toEqual([0.5]);
-    }
-  });
-
-  it("the full presets are color-swap mirrors of each other (Z→X and X→Z)", () => {
-    const zx = FB_PRESETS.find((p) => p.id === "swap-zx");
-    const xz = FB_PRESETS.find((p) => p.id === "swap-xz");
-    expect(zx).toBeDefined();
-    expect(xz).toBeDefined();
-    expect(zx!.spec.baseAtStart).toBe("Z");
-    expect(zx!.spec.baseAtEnd).toBe("X");
-    expect(xz!.spec.baseAtStart).toBe("X");
-    expect(xz!.spec.baseAtEnd).toBe("Z");
-    expect(zx!.spec.swapAxes ?? "all").toBe("all");
-    expect(xz!.spec.swapAxes ?? "all").toBe("all");
-  });
-
-  it("ships half-swap presets that change only 2 opposite faces", () => {
-    const halfZx = FB_PRESETS.find((p) => p.id === "half-zx");
-    const halfXz = FB_PRESETS.find((p) => p.id === "half-xz");
-    expect(halfZx).toBeDefined();
-    expect(halfXz).toBeDefined();
-    expect(halfZx!.spec.swapAxes).toBe("first");
-    expect(halfXz!.spec.swapAxes).toBe("first");
-    expect(halfZx!.spec.baseAtStart).toBe("Z");
-    expect(halfZx!.spec.baseAtEnd).toBe("X");
-    expect(halfXz!.spec.baseAtStart).toBe("X");
-    expect(halfXz!.spec.baseAtEnd).toBe("Z");
+  it("ships a single Free Pipe preset (variants are picked from the side panel)", () => {
+    expect(FB_PRESETS).toHaveLength(1);
+    const fp = FB_PRESETS[0];
+    expect(fp.id).toBe("free-pipe");
+    expect(fp.spec.kind).toBe("fb-pipe");
+    expect(fp.spec.defectPositions).toEqual([0.5]);
+    expect(fp.spec.faces).toEqual(FB_DEFAULT_FACES);
   });
 });
 
-describe("FB pipe geometry honors swapAxes", () => {
-  function vertexColors(geo: ReturnType<typeof createBlockGeometry>): { r: number; g: number; b: number }[] {
-    const arr = geo.getAttribute("color").array as Float32Array;
-    const out: { r: number; g: number; b: number }[] = [];
-    for (let i = 0; i < arr.length; i += 3) out.push({ r: arr[i], g: arr[i + 1], b: arr[i + 2] });
-    return out;
-  }
-  function colorEq(a: { r: number; g: number; b: number }, c: typeof X_COLOR): boolean {
-    return Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
-  }
-
-  it("full-swap pipe has each base color count balanced (all 4 walls swap)", () => {
-    const colors = vertexColors(createBlockGeometry(Z_OPEN_SPEC));
-    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
-    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
-    // 4 walls × 2 strips × 4 verts = 32 colored verts; each base appears on
-    // 4 strips (2 below + 2 above per axis pair), so counts are equal.
-    expect(xCount).toBe(zCount);
-    expect(xCount + zCount).toBe(32);
+describe("legacy FB spec migration", () => {
+  it("converts {baseAtStart:Z, baseAtEnd:X, swapAxes:'all'} to per-face equivalent", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 2 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["ZX", "ZX", "XZ", "XZ"]);
+    expect(migrated.openAxis).toBe(2);
+    expect(migrated.defectPositions).toEqual([0.5]);
   });
 
-  it("half-swap pipe biases toward the start-side base (3 strips of one color, 1 of the other)", () => {
-    // Z→X half: closed axis 0 wall pair shows Z below + X above.
-    //           closed axis 1 wall pair shows X below AND X above (no swap).
-    // Total Z verts: 1 strip × 2 walls × 4 verts = 8.
-    // Total X verts: 3 strips × 2 walls × 4 verts = 24.
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
-    const colors = vertexColors(createBlockGeometry(halfSpec));
-    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
-    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
-    expect(xCount).toBe(24);
-    expect(zCount).toBe(8);
+  it("converts swapAxes:'first' (only ca0 pair flips)", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 2 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+      swapAxes: "first" as const,
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["ZX", "ZX", "X", "X"]);
   });
 
-  it("swapAxes 'second' mirrors 'first' on the other closed-axis pair", () => {
-    // Z→X second-axis half: closed axis 0 wall pair stays Z (no swap).
-    //                       closed axis 1 wall pair shows X below + Z above.
-    // Total Z verts: 3 strips × 2 walls × 4 verts = 24.
-    // Total X verts: 1 strip × 2 walls × 4 verts = 8.
-    // Mirror of the "first" case above (swap on the opposite axis pair).
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "second" };
-    const colors = vertexColors(createBlockGeometry(halfSpec));
-    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
-    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
-    expect(xCount).toBe(8);
-    expect(zCount).toBe(24);
+  it("converts swapAxes:'second' (only ca1 pair flips)", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 2 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+      swapAxes: "second" as const,
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["Z", "Z", "XZ", "XZ"]);
   });
 
-  it("swapAxes 'second' Y-defect ring lies on the second closed-axis wall pair", () => {
-    // Z_OPEN_SPEC has Three.js openAxis=1 (Y), closedAxes=[0,2]=[X,Z].
-    // swapAxes "second" → only the Z-axis wall pair (closed[1]) swaps. The
-    // ring segments at the defect must therefore vary in X (i.e., run along
-    // the X axis, lying on the Z-walls), not in Z. Total: 4 corners (lower
-    // half) + 2 ring segments = 6 edges, mirroring the "first" case.
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "second" };
-    const arr = createYDefectEdges(halfSpec).getAttribute("position").array as Float32Array;
-    expect(arr.length / 6).toBe(6);
-    // Last 2 segments are the ring; verify they vary in X (Three.js axis 0)
-    // and stay constant in Z (Three.js axis 2).
-    for (let i = 4; i < 6; i++) {
-      const x0 = arr[i * 6 + 0], x1 = arr[i * 6 + 3];
-      const z0 = arr[i * 6 + 2], z1 = arr[i * 6 + 5];
-      expect(Math.abs(x1 - x0)).toBeGreaterThan(0.5);
-      expect(z0).toBeCloseTo(z1, 6);
-    }
+  it("Y-open mirror: legacy code flipped wallColors, so migration applies the same flip", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 1 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["XZ", "XZ", "ZX", "ZX"]);
+  });
+
+  it("normalizeFBSpec passes through new-shape specs untouched", () => {
+    const newSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
+    expect(normalizeFBSpec(newSpec)).toBe(newSpec);
+  });
+
+  it("normalizeFBSpec migrates a legacy spec", () => {
+    const legacy = {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "Z",
+      baseAtEnd: "X",
+      defectPositions: [0.5],
+    };
+    const out = normalizeFBSpec(legacy);
+    expect(out).not.toBeNull();
+    expect(out!.faces).toEqual(["ZX", "ZX", "XZ", "XZ"]);
+  });
+
+  it("normalizeFBSpec rejects non-FB inputs", () => {
+    expect(normalizeFBSpec(null)).toBeNull();
+    expect(normalizeFBSpec({ kind: "other" })).toBeNull();
+    expect(normalizeFBSpec("OZX")).toBeNull();
   });
 });
 
@@ -320,7 +360,7 @@ describe("FB pipe geometry honors swapAxes", () => {
 // resolvePipeTypeFromFace and gives back BOTH the snapped slot and the spec
 // with openAxis matching that slot's TQEC axis.
 describe("resolveFBSpecFromFace (port-adjacent FB pipe snapping)", () => {
-  const PRESET: FBPreset = FB_PRESETS[0]; // swap-zx, openAxis=2 in template
+  const PRESET: FBPreset = FB_PRESETS[0];
   const PORT: Position3D = { x: 0, y: 0, z: 0 };
 
   it("snaps to the +X pipe slot with +X face normal", () => {
@@ -354,18 +394,14 @@ describe("resolveFBSpecFromFace (port-adjacent FB pipe snapping)", () => {
     expect(r!.spec.openAxis).toBe(1);
   });
 
-  it("preserves the preset's color/defect template, only overriding openAxis", () => {
+  it("preserves the preset's faces/defects template, only overriding openAxis", () => {
     const r = resolveFBSpecFromFace(PORT, "XZZ", new Vector3(1, 0, 0), PRESET);
     expect(r).not.toBeNull();
-    expect(r!.spec.baseAtStart).toBe(PRESET.spec.baseAtStart);
-    expect(r!.spec.baseAtEnd).toBe(PRESET.spec.baseAtEnd);
+    expect(r!.spec.faces).toEqual(PRESET.spec.faces);
     expect(r!.spec.defectPositions).toEqual(PRESET.spec.defectPositions);
   });
 
   it("computes the same adj position as resolvePipeTypeFromFace for every face direction", () => {
-    // Snap parity: an FB preset hovering a port should land on the same grid slot
-    // as a regular pipe variant — the only thing that differs is the resulting
-    // block type (FB spec vs concrete PipeType).
     const port: Position3D = { x: 3, y: 6, z: 0 };
     const normals = [
       new Vector3(1, 0, 0),
@@ -407,7 +443,6 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
   });
 
   it("countAttachedPipes counts FB pipes alongside TQEC pipes", () => {
-    // Cube at origin with one TQEC pipe on +X and one FB pipe on +Y.
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
       { pos: { x: 1, y: 0, z: 0 }, type: "OZX" },
@@ -427,12 +462,8 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
   });
 
   it("does not count an FB pipe whose open axis doesn't point at the cube", () => {
-    // A Z-open FB pipe at (1,0,0) is NOT a +X-attached pipe of the cube at origin
-    // (it occupies a Z-axis slot, but its position isn't even a valid pipe slot).
-    // This is a parity check: regular pipes are filtered the same way.
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
-      // Wrong-axis FB pipe at +X slot — open along Y, not X.
       { pos: { x: 1, y: 0, z: 0 }, type: Y_OPEN_SPEC },
     ]);
     expect(countAttachedPipes({ x: 0, y: 0, z: 0 }, blocks)).toBe(0);

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -24,7 +24,7 @@ import {
   FB_DEFAULT_FACES,
   migrateLegacyFBSpec,
   normalizeFBSpec,
-  validFBPipeVariantsXZZXAxis,
+  validFBPipeVariantsForCubePair,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
 import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
@@ -471,85 +471,174 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
   });
 });
 
-describe("validFBPipeVariantsXZZXAxis", () => {
+describe("validFBPipeVariantsForCubePair", () => {
   function makeBlocks(entries: Block[]): Map<string, Block> {
     const map = new Map<string, Block>();
     for (const b of entries) map.set(posKey(b.pos), b);
     return map;
   }
 
-  const PIPE_POS: Position3D = { x: 1, y: 0, z: 0 };
-  const NEG_POS: Position3D = { x: 0, y: 0, z: 0 };
-  const POS_POS: Position3D = { x: 3, y: 0, z: 0 };
-  const FB_X_PIPE: Block = { pos: PIPE_POS, type: X_OPEN_SPEC };
+  // X-axis cases ----------------------------------------------------------
+  const X_PIPE_POS: Position3D = { x: 1, y: 0, z: 0 };
+  const X_NEG_POS: Position3D = { x: 0, y: 0, z: 0 };
+  const X_POS_POS: Position3D = { x: 3, y: 0, z: 0 };
+  const FB_X_PIPE: Block = { pos: X_PIPE_POS, type: X_OPEN_SPEC };
 
-  it("returns the all-Z tuple for the canonical XZZ–FB–XZZ X-axis sandwich", () => {
+  it("XZZ–XZZ along X yields all-Z (both closed axes Z=Z)", () => {
     const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
+      { pos: X_NEG_POS, type: "XZZ" },
       FB_X_PIPE,
-      { pos: POS_POS, type: "XZZ" },
+      { pos: X_POS_POS, type: "XZZ" },
     ]);
-    const result = validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks);
-    expect(result).toEqual([["Z", "Z", "Z", "Z"]]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r).not.toBeNull();
+    expect(r!.faces).toEqual([["Z", "Z", "Z", "Z"]]);
+    expect(r!.negType).toBe("XZZ");
+    expect(r!.posType).toBe("XZZ");
+    expect(r!.openAxis).toBe(0);
   });
 
-  it("returns null when the FB pipe is Y-open", () => {
+  it("ZXX–XZZ along X yields all-XZ (X-below → Z-above on both closed axes)", () => {
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "ZXX" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "XZZ" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["XZ", "XZ", "XZ", "XZ"]]);
+    expect(r!.negType).toBe("ZXX");
+    expect(r!.posType).toBe("XZZ");
+  });
+
+  it("XZZ–ZXX along X (reversed) yields all-ZX", () => {
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "ZXX" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "ZX", "ZX"]]);
+  });
+
+  it("XZZ–ZXZ along X yields different face configs on the two closed axes", () => {
+    // XZZ closed (Y,Z) = (Z,Z); ZXZ closed (Y,Z) = (X,Z).
+    // Y-axis: Z→X = "ZX". Z-axis: Z→Z = "Z".
+    // ca0 (Three.js X→TQEC X is open; ca0=Three Y=TQEC Z): faces[0,1] = "Z".
+    // ca1 (Three.js Z→TQEC Y): faces[2,3] = "ZX".
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "ZXZ" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["Z", "Z", "ZX", "ZX"]]);
+  });
+
+  it("ZXZ–ZXX along X yields a mix of solid X and ZX swap", () => {
+    // ZXZ closed (Y,Z) = (X,Z); ZXX closed (Y,Z) = (X,X).
+    // Y-axis: X→X = "X". Z-axis: Z→X = "ZX".
+    // ca0 (TQEC Z): faces[0,1] = "ZX". ca1 (TQEC Y): faces[2,3] = "X".
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "ZXZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "ZXX" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "X", "X"]]);
+  });
+
+  // Y-axis ---------------------------------------------------------------
+  it("XZZ–XZZ along Y yields all-X (closed axes X=X both ends)", () => {
+    // openAxis=1 (Y). Closed TQEC axes: X (0) and Z (2). Both ends XZZ.
+    // X-axis basis: X. Z-axis basis: Z. Both same below=above. So solid X on
+    // one ca and solid Z on the other.
+    // ca0 (Three.js X = TQEC X): "X". ca1 (Three.js Y = TQEC Z): "Z".
     const fbY: Block = { pos: { x: 0, y: 1, z: 0 }, type: Y_OPEN_SPEC };
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
       fbY,
       { pos: { x: 0, y: 3, z: 0 }, type: "XZZ" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(fbY, blocks)).toBeNull();
+    const r = validFBPipeVariantsForCubePair(fbY, blocks);
+    expect(r!.faces).toEqual([["X", "X", "Z", "Z"]]);
+    expect(r!.openAxis).toBe(1);
   });
 
-  it("returns null when the FB pipe is Z-open", () => {
+  it("ZXZ–XZZ along Y yields a swap on the X-axis closed wall and solid Z on the Z-axis wall", () => {
+    // ZXZ closed (X,Z) = (Z,Z); XZZ closed (X,Z) = (X,Z).
+    // X-axis: Z→X = "ZX". Z-axis: Z→Z = "Z".
+    // ca0 = TQEC X: "ZX". ca1 = TQEC Z: "Z".
+    const fbY: Block = { pos: { x: 0, y: 1, z: 0 }, type: Y_OPEN_SPEC };
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "ZXZ" },
+      fbY,
+      { pos: { x: 0, y: 3, z: 0 }, type: "XZZ" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(fbY, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "Z", "Z"]]);
+  });
+
+  // Z-axis ---------------------------------------------------------------
+  it("XZZ–XZZ along Z yields one solid X wall and one solid Z wall", () => {
+    // openAxis=2 (Z). Closed TQEC axes: X (0) and Y (1).
+    // XZZ X=X, XZZ Y=Z. Both ends same. ca0=TQEC X→"X", ca1=TQEC Y→"Z".
     const fbZ: Block = { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC };
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
       fbZ,
       { pos: { x: 0, y: 0, z: 3 }, type: "XZZ" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(fbZ, blocks)).toBeNull();
+    const r = validFBPipeVariantsForCubePair(fbZ, blocks);
+    expect(r!.faces).toEqual([["X", "X", "Z", "Z"]]);
+    expect(r!.openAxis).toBe(2);
   });
 
-  it("returns null when the −X neighbour is missing", () => {
+  it("ZXX–XXZ along Z yields a swap on each closed-axis wall", () => {
+    // ZXX (X=Z, Y=X); XXZ (X=X, Y=X). X-axis: Z→X = "ZX". Y-axis: X→X = "X".
+    const fbZ: Block = { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC };
     const blocks = makeBlocks([
-      FB_X_PIPE,
-      { pos: POS_POS, type: "XZZ" },
+      { pos: { x: 0, y: 0, z: 0 }, type: "ZXX" },
+      fbZ,
+      { pos: { x: 0, y: 0, z: 3 }, type: "XXZ" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+    const r = validFBPipeVariantsForCubePair(fbZ, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "X", "X"]]);
   });
 
-  it("returns null when the +X neighbour is missing", () => {
-    const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
-      FB_X_PIPE,
-    ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  // Null-returning cases -------------------------------------------------
+  it("returns null when the −openAxis neighbour is missing", () => {
+    const blocks = makeBlocks([FB_X_PIPE, { pos: X_POS_POS, type: "XZZ" }]);
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
   });
 
-  it("returns null when an X-axis neighbour is a non-XZZ cube", () => {
-    const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
-      FB_X_PIPE,
-      { pos: POS_POS, type: "ZXZ" },
-    ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  it("returns null when the +openAxis neighbour is missing", () => {
+    const blocks = makeBlocks([{ pos: X_NEG_POS, type: "XZZ" }, FB_X_PIPE]);
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
   });
 
-  it("returns null when an X-axis neighbour is a Y block", () => {
+  it("returns null when a neighbour is a Y block", () => {
     const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
+      { pos: X_NEG_POS, type: "XZZ" },
       FB_X_PIPE,
-      { pos: POS_POS, type: "Y" },
+      { pos: X_POS_POS, type: "Y" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when a neighbour is an FB pipe (only plain cubes count)", () => {
+    // Hypothetical FB pipe at X_POS_POS — block positions can't legally hold a
+    // pipe, but the rule should reject any non-cube neighbour regardless.
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: X_OPEN_SPEC },
+    ]);
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
   });
 
   it("returns null when the input block is not an FB pipe", () => {
-    const cube: Block = { pos: NEG_POS, type: "XZZ" };
+    const cube: Block = { pos: X_NEG_POS, type: "XZZ" };
     const blocks = makeBlocks([cube]);
-    expect(validFBPipeVariantsXZZXAxis(cube, blocks)).toBeNull();
+    expect(validFBPipeVariantsForCubePair(cube, blocks)).toBeNull();
   });
 });

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -24,6 +24,7 @@ import {
   FB_DEFAULT_FACES,
   migrateLegacyFBSpec,
   normalizeFBSpec,
+  validFBPipeVariantsXZZXAxis,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
 import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
@@ -467,5 +468,88 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
       { pos: { x: 1, y: 0, z: 0 }, type: Y_OPEN_SPEC },
     ]);
     expect(countAttachedPipes({ x: 0, y: 0, z: 0 }, blocks)).toBe(0);
+  });
+});
+
+describe("validFBPipeVariantsXZZXAxis", () => {
+  function makeBlocks(entries: Block[]): Map<string, Block> {
+    const map = new Map<string, Block>();
+    for (const b of entries) map.set(posKey(b.pos), b);
+    return map;
+  }
+
+  const PIPE_POS: Position3D = { x: 1, y: 0, z: 0 };
+  const NEG_POS: Position3D = { x: 0, y: 0, z: 0 };
+  const POS_POS: Position3D = { x: 3, y: 0, z: 0 };
+  const FB_X_PIPE: Block = { pos: PIPE_POS, type: X_OPEN_SPEC };
+
+  it("returns the all-Z tuple for the canonical XZZ–FB–XZZ X-axis sandwich", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: POS_POS, type: "XZZ" },
+    ]);
+    const result = validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks);
+    expect(result).toEqual([["Z", "Z", "Z", "Z"]]);
+  });
+
+  it("returns null when the FB pipe is Y-open", () => {
+    const fbY: Block = { pos: { x: 0, y: 1, z: 0 }, type: Y_OPEN_SPEC };
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
+      fbY,
+      { pos: { x: 0, y: 3, z: 0 }, type: "XZZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(fbY, blocks)).toBeNull();
+  });
+
+  it("returns null when the FB pipe is Z-open", () => {
+    const fbZ: Block = { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC };
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
+      fbZ,
+      { pos: { x: 0, y: 0, z: 3 }, type: "XZZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(fbZ, blocks)).toBeNull();
+  });
+
+  it("returns null when the −X neighbour is missing", () => {
+    const blocks = makeBlocks([
+      FB_X_PIPE,
+      { pos: POS_POS, type: "XZZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when the +X neighbour is missing", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when an X-axis neighbour is a non-XZZ cube", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: POS_POS, type: "ZXZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when an X-axis neighbour is a Y block", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: POS_POS, type: "Y" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when the input block is not an FB pipe", () => {
+    const cube: Block = { pos: NEG_POS, type: "XZZ" };
+    const blocks = makeBlocks([cube]);
+    expect(validFBPipeVariantsXZZXAxis(cube, blocks)).toBeNull();
   });
 });

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -1,0 +1,194 @@
+import { describe, expect, it } from "vitest";
+import {
+  createBlockGeometry,
+  createYDefectEdges,
+  blockTqecSize,
+  isFreeBuildBlock,
+  isFreeBuildPipeSpec,
+  isPipeType,
+  isValidPos,
+  flipBlockType,
+  blockTypeCacheKey,
+  H_COLOR,
+  X_COLOR,
+  Z_COLOR,
+  FB_PRESETS,
+} from "./index";
+import type { Block, BlockType, FreeBuildPipeSpec } from "./index";
+
+const Z_OPEN_SPEC: FreeBuildPipeSpec = {
+  kind: "fb-pipe",
+  openAxis: 2,
+  baseAtStart: "Z",
+  baseAtEnd: "X",
+  defectPositions: [0.5],
+};
+
+const X_OPEN_SPEC: FreeBuildPipeSpec = {
+  kind: "fb-pipe",
+  openAxis: 0,
+  baseAtStart: "Z",
+  baseAtEnd: "X",
+  defectPositions: [0.5],
+};
+
+const Y_OPEN_SPEC: FreeBuildPipeSpec = {
+  kind: "fb-pipe",
+  openAxis: 1,
+  baseAtStart: "Z",
+  baseAtEnd: "X",
+  defectPositions: [0.5],
+};
+
+describe("isFreeBuildBlock / isFreeBuildPipeSpec", () => {
+  it("recognizes FB pipe blocks", () => {
+    const fb: Block = { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC };
+    expect(isFreeBuildBlock(fb)).toBe(true);
+  });
+
+  it("returns false for TQEC blocks", () => {
+    const tqec: Block = { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" };
+    expect(isFreeBuildBlock(tqec)).toBe(false);
+  });
+
+  it("FB specs are not detected by isPipeType (which is TQEC-string-only)", () => {
+    expect(isPipeType(Z_OPEN_SPEC)).toBe(false);
+    expect(isFreeBuildPipeSpec(Z_OPEN_SPEC)).toBe(true);
+  });
+});
+
+describe("blockTqecSize for FB pipes", () => {
+  it("X-open FB pipe = [2, 1, 1]", () => {
+    expect(blockTqecSize(X_OPEN_SPEC)).toEqual([2, 1, 1]);
+  });
+  it("Y-open FB pipe = [1, 2, 1]", () => {
+    expect(blockTqecSize(Y_OPEN_SPEC)).toEqual([1, 2, 1]);
+  });
+  it("Z-open FB pipe = [1, 1, 2]", () => {
+    expect(blockTqecSize(Z_OPEN_SPEC)).toEqual([1, 1, 2]);
+  });
+});
+
+describe("isValidPos for FB pipes", () => {
+  it("accepts a valid pipe slot position", () => {
+    // Z-open pipe slot: z ≡ 1 mod 3, x and y ≡ 0 mod 3
+    expect(isValidPos({ x: 0, y: 0, z: 1 }, Z_OPEN_SPEC)).toBe(true);
+  });
+  it("rejects a non-pipe-slot position", () => {
+    expect(isValidPos({ x: 0, y: 0, z: 0 }, Z_OPEN_SPEC)).toBe(false);
+  });
+});
+
+describe("createBlockGeometry for FB pipes", () => {
+  function vertexColors(geo: ReturnType<typeof createBlockGeometry>): { r: number; g: number; b: number }[] {
+    const arr = geo.getAttribute("color").array as Float32Array;
+    const out: { r: number; g: number; b: number }[] = [];
+    for (let i = 0; i < arr.length; i += 3) out.push({ r: arr[i], g: arr[i + 1], b: arr[i + 2] });
+    return out;
+  }
+
+  it("emits no yellow (H_COLOR) vertices — FB has no Hadamard band", () => {
+    const geo = createBlockGeometry(Z_OPEN_SPEC);
+    const colors = vertexColors(geo);
+    for (const c of colors) {
+      // Yellow Hadamard band would be (H_COLOR.r, H_COLOR.g, H_COLOR.b).
+      const isYellow =
+        Math.abs(c.r - H_COLOR.r) < 1e-6 &&
+        Math.abs(c.g - H_COLOR.g) < 1e-6 &&
+        Math.abs(c.b - H_COLOR.b) < 1e-6;
+      expect(isYellow).toBe(false);
+    }
+  });
+
+  it("contains both X_COLOR and Z_COLOR vertices (color swap at midpoint)", () => {
+    const geo = createBlockGeometry(Z_OPEN_SPEC);
+    const colors = vertexColors(geo);
+    const sameAs = (a: { r: number; g: number; b: number }, c: typeof X_COLOR) =>
+      Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
+    expect(colors.some((c) => sameAs(c, X_COLOR))).toBe(true);
+    expect(colors.some((c) => sameAs(c, Z_COLOR))).toBe(true);
+  });
+});
+
+describe("createYDefectEdges for FB pipes", () => {
+  function edgeCount(geo: ReturnType<typeof createYDefectEdges>): number {
+    const arr = geo.getAttribute("position").array as Float32Array;
+    return arr.length / 6;
+  }
+
+  it("FB pipe with one defect emits 4 corner edges + 4 ring segments = 8", () => {
+    expect(edgeCount(createYDefectEdges(Z_OPEN_SPEC))).toBe(8);
+    expect(edgeCount(createYDefectEdges(X_OPEN_SPEC))).toBe(8);
+    expect(edgeCount(createYDefectEdges(Y_OPEN_SPEC))).toBe(8);
+  });
+
+  it("FB pipe with no defects emits only the 4 corner edges (no ring)", () => {
+    const noDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [] };
+    expect(edgeCount(createYDefectEdges(noDefects))).toBe(4);
+  });
+
+  it("FB pipe with two defects emits 4 corners + 2 rings × 4 = 12", () => {
+    const twoDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [0.33, 0.67] };
+    expect(edgeCount(createYDefectEdges(twoDefects))).toBe(12);
+  });
+});
+
+describe("flipBlockType on FB pipes", () => {
+  it("swaps baseAtStart and baseAtEnd between X and Z, leaving defects unchanged", () => {
+    const flipped = flipBlockType(Z_OPEN_SPEC) as FreeBuildPipeSpec;
+    expect(flipped.kind).toBe("fb-pipe");
+    expect(flipped.baseAtStart).toBe("X");
+    expect(flipped.baseAtEnd).toBe("Z");
+    expect(flipped.defectPositions).toEqual([0.5]);
+    expect(flipped.openAxis).toBe(2);
+  });
+
+  it("is an involution on FB pipes (flip twice = original)", () => {
+    const once = flipBlockType(Z_OPEN_SPEC) as FreeBuildPipeSpec;
+    const twice = flipBlockType(once) as FreeBuildPipeSpec;
+    expect(twice.baseAtStart).toBe(Z_OPEN_SPEC.baseAtStart);
+    expect(twice.baseAtEnd).toBe(Z_OPEN_SPEC.baseAtEnd);
+  });
+});
+
+describe("blockTypeCacheKey", () => {
+  it("returns the string itself for TQEC types", () => {
+    expect(blockTypeCacheKey("OZX" as BlockType)).toBe("OZX");
+    expect(blockTypeCacheKey("Y" as BlockType)).toBe("Y");
+  });
+
+  it("returns a deterministic content-based key for FB specs", () => {
+    expect(blockTypeCacheKey(Z_OPEN_SPEC)).toBe("fb:2|Z|X|0.5");
+    expect(blockTypeCacheKey(X_OPEN_SPEC)).toBe("fb:0|Z|X|0.5");
+  });
+
+  it("two structurally equal specs produce the same key", () => {
+    const a: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
+    const b: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
+    expect(blockTypeCacheKey(a)).toBe(blockTypeCacheKey(b));
+  });
+});
+
+describe("FB_PRESETS", () => {
+  it("ships exactly two presets in v1", () => {
+    expect(FB_PRESETS).toHaveLength(2);
+  });
+
+  it("all presets have a single Y defect at 0.5", () => {
+    for (const p of FB_PRESETS) {
+      expect(p.spec.kind).toBe("fb-pipe");
+      expect(p.spec.defectPositions).toEqual([0.5]);
+    }
+  });
+
+  it("the two presets are color-swap mirrors of each other (Z→X and X→Z)", () => {
+    const zx = FB_PRESETS.find((p) => p.id === "swap-zx");
+    const xz = FB_PRESETS.find((p) => p.id === "swap-xz");
+    expect(zx).toBeDefined();
+    expect(xz).toBeDefined();
+    expect(zx!.spec.baseAtStart).toBe("Z");
+    expect(zx!.spec.baseAtEnd).toBe("X");
+    expect(xz!.spec.baseAtStart).toBe("X");
+    expect(xz!.spec.baseAtEnd).toBe("Z");
+  });
+});

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -576,9 +576,11 @@ describe("createYDefectEdges", () => {
     expect(edgeCount(createYDefectEdges("ZXO"))).toBe(4);
   });
 
-  it("Hadamard pipes emit the same 4 wall-meeting edges (band ring is v1 follow-up)", () => {
-    expect(edgeCount(createYDefectEdges("OZXH"))).toBe(4);
-    expect(edgeCount(createYDefectEdges("XZOH"))).toBe(4);
+  it("Hadamard pipes emit 4 wall-meeting edges + 2 band rings (8 ring segments) = 12", () => {
+    // 4 corner edges along the open axis + 2 rings (top + bottom of the
+    // yellow band) × 4 segments each = 8 ring segments. Total: 12.
+    expect(edgeCount(createYDefectEdges("OZXH"))).toBe(12);
+    expect(edgeCount(createYDefectEdges("XZOH"))).toBe(12);
   });
 
   it("skips every edge adjacent to a hidden face (continuous surface across the join)", () => {

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, CUBE_TYPES, PIPE_TYPES } from "./index";
-import type { PipeType, CubeType } from "./index";
+import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, CUBE_TYPES, PIPE_TYPES } from "./index";
+import type { PipeType, CubeType, PortMeta } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
 
@@ -602,5 +602,62 @@ describe("createYDefectEdges", () => {
     // Sanity: hiding everything yields zero edges.
     const all = FACE_POS_X | FACE_NEG_X | FACE_POS_Y | FACE_NEG_Y | FACE_POS_Z | FACE_NEG_Z;
     expect(edgeCount(createYDefectEdges("XZZ", all))).toBe(0);
+  });
+});
+
+describe("getOrderedPortPositions", () => {
+  const explicitPorts = new Set([
+    "0,0,0",
+    "3,0,0",
+    "6,0,0",
+    "9,0,0",
+  ]);
+  const blocks = new Map<
+    string,
+    { pos: { x: number; y: number; z: number }; type: BlockType }
+  >();
+
+  it("falls back to spatial sort when no ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["3,0,0", { label: "P1", io: "in" }],
+      ["0,0,0", { label: "P2", io: "in" }],
+      ["9,0,0", { label: "P3", io: "in" }],
+      ["6,0,0", { label: "P4", io: "in" }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 3, 6, 9]);
+  });
+
+  it("orders ports by rank when ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["0,0,0", { label: "P1", io: "in", rank: 3 }],
+      ["3,0,0", { label: "P2", io: "in", rank: 1 }],
+      ["6,0,0", { label: "P3", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P4", io: "in", rank: 2 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([6, 3, 9, 0]);
+  });
+
+  it("places ranked ports before unranked ones; unranked sort spatially", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["9,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["3,0,0", { label: "P2", io: "in" }],
+      ["0,0,0", { label: "P3", io: "in" }],
+      // P4 at (6,0,0) has no PortMeta entry at all — also unranked.
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([9, 0, 3, 6]);
+  });
+
+  it("breaks ties between equal ranks by spatial order", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["6,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["0,0,0", { label: "P2", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P3", io: "in", rank: 1 }],
+      ["3,0,0", { label: "P4", io: "in", rank: 1 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 6, 3, 9]);
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -1469,6 +1469,31 @@ export function hasPipeColorConflict(
 }
 
 /**
+ * v1 hardcoded build rule: returns the (single) valid FB face tuple when the
+ * FB pipe sits between two XZZ cubes along X (offsets −1 and +2). Returns
+ * null in every other configuration (different openAxis, missing neighbour,
+ * non-cube neighbour, non-XZZ cube). Future passes will generalise.
+ *
+ * The single valid variant is `["Z","Z","Z","Z"]` because XZZ has Z on both
+ * its Y and Z axes, so every wall of an X-open pipe must be solid Z on both
+ * sides of the defect.
+ */
+export function validFBPipeVariantsXZZXAxis(
+  block: Block,
+  blocks: BlocksLookup,
+): ReadonlyArray<readonly [FaceConfig, FaceConfig, FaceConfig, FaceConfig]> | null {
+  const t = block.type;
+  if (!isFreeBuildPipeSpec(t) || t.openAxis !== 0) return null;
+  const negPos: Position3D = { x: block.pos.x - 1, y: block.pos.y, z: block.pos.z };
+  const posPos: Position3D = { x: block.pos.x + 2, y: block.pos.y, z: block.pos.z };
+  const neg = blocks.get(posKey(negPos));
+  const pos = blocks.get(posKey(posPos));
+  if (!neg || !pos) return null;
+  if (neg.type !== "XZZ" || pos.type !== "XZZ") return null;
+  return [["Z", "Z", "Z", "Z"]];
+}
+
+/**
  * Check whether a cube placement conflicts with adjacent pipe colors.
  * For each of the 3 TQEC axes, checks both possible neighboring pipe positions.
  * For Hadamard pipes, determines which end faces the cube and uses the right colors.

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -41,7 +41,25 @@ export type CubeType = (typeof CUBE_TYPES)[number];
 export const PIPE_TYPES = ["OZX", "OXZ", "OZXH", "OXZH", "ZOX", "XOZ", "ZOXH", "XOZH", "ZXO", "XZO", "ZXOH", "XZOH"] as const;
 export type PipeType = (typeof PIPE_TYPES)[number];
 
-export type BlockType = CubeType | "Y" | PipeType;
+/**
+ * Free-build pipe spec — a non-TQEC pipe parameterized by Y-defect positions.
+ * `defectPositions` are normalized 0..1 along the open axis; physical defects
+ * sit strictly inside (0,1). One defect at 0.5 = today's color-swap pipe.
+ * Two defects = a future 3-color pipe. Zero defects = a future solid pipe.
+ *
+ * FB blocks ride the existing Y-defect overlay for boundary visualization
+ * (magenta cylinders at each defect position) and are excluded from `.dae`
+ * export and TQEC validation.
+ */
+export interface FreeBuildPipeSpec {
+  kind: "fb-pipe";
+  openAxis: 0 | 1 | 2;          // TQEC axis (0=x, 1=y, 2=z)
+  baseAtStart: "X" | "Z";       // closed-axis bases at the open-axis START end
+  baseAtEnd: "X" | "Z";         // ...at the END end
+  defectPositions: number[];    // 0..1 along the open axis
+}
+
+export type BlockType = CubeType | "Y" | PipeType | FreeBuildPipeSpec;
 export type FaceMask = number;
 
 export const FACE_POS_X = 1 << 0; // +X face in Three.js box geometry order
@@ -63,6 +81,31 @@ export const FACE_BIT_BY_INDEX: ReadonlyArray<number> = [
 /** Pipe variant: the two non-O face characters (+ optional H). Open axis determined by position. */
 export type PipeVariant = "ZX" | "XZ" | "ZXH" | "XZH";
 export const PIPE_VARIANTS: PipeVariant[] = ["ZX", "XZ", "ZXH", "XZH"];
+
+/**
+ * Free-build pipe presets shown in the toolbar's "Free Build" group.
+ * The `spec` is a TEMPLATE — `openAxis` is overridden at placement time
+ * based on which pipe slot the user clicks.
+ */
+export interface FBPreset {
+  id: string;
+  label: string;
+  spec: FreeBuildPipeSpec;
+}
+
+/** v1 FB presets: two color-swap pipes with one Y defect at the midpoint. */
+export const FB_PRESETS: ReadonlyArray<FBPreset> = [
+  {
+    id: "swap-zx",
+    label: "Z→X",
+    spec: { kind: "fb-pipe", openAxis: 2, baseAtStart: "Z", baseAtEnd: "X", defectPositions: [0.5] },
+  },
+  {
+    id: "swap-xz",
+    label: "X→Z",
+    spec: { kind: "fb-pipe", openAxis: 2, baseAtStart: "X", baseAtEnd: "Z", defectPositions: [0.5] },
+  },
+];
 
 /**
  * Toolbar-order list of placeable items (Port + 6 cubes + Y + 4 pipes).
@@ -139,7 +182,32 @@ const FACE_MASK_EPS = 1e-9;
 // ---------------------------------------------------------------------------
 
 export function isPipeType(bt: BlockType): bt is PipeType {
-  return (PIPE_TYPES as readonly string[]).includes(bt);
+  return typeof bt === "string" && (PIPE_TYPES as readonly string[]).includes(bt);
+}
+
+/** True iff the block is a free-build (non-TQEC) block. */
+export function isFreeBuildBlock(b: Block): b is Block & { type: FreeBuildPipeSpec } {
+  return typeof b.type === "object" && b.type !== null && b.type.kind === "fb-pipe";
+}
+
+/** True iff the BlockType is a free-build pipe spec (object, not a TQEC string). */
+export function isFreeBuildPipeSpec(bt: BlockType): bt is FreeBuildPipeSpec {
+  return typeof bt === "object" && bt !== null && bt.kind === "fb-pipe";
+}
+
+/** True iff this block is any pipe (TQEC pipe OR free-build pipe). */
+export function isAnyPipeBlock(b: Block): boolean {
+  return isFreeBuildBlock(b) || isPipeType(b.type);
+}
+
+/**
+ * Deterministic string key for a BlockType — works for both TQEC strings and
+ * FreeBuildPipeSpec objects. Used as a cache/grouping key in BlockInstances
+ * and YDefectOverlay so distinct FB specs don't collide on `[object Object]`.
+ */
+export function blockTypeCacheKey(bt: BlockType): string {
+  if (typeof bt === "string") return bt;
+  return `fb:${bt.openAxis}|${bt.baseAtStart}|${bt.baseAtEnd}|${bt.defectPositions.join(",")}`;
 }
 
 /** Map a TQEC basis character ('X' or 'Z') to its THREE.Color. */
@@ -177,7 +245,7 @@ export function isValidPipePos(pos: Position3D): boolean {
 }
 
 export function isValidPos(pos: Position3D, blockType: BlockType): boolean {
-  if (isPipeType(blockType)) return isValidPipePos(pos);
+  if (isPipeType(blockType) || isFreeBuildPipeSpec(blockType)) return isValidPipePos(pos);
   return isValidBlockPos(pos);
 }
 
@@ -258,6 +326,12 @@ export function snapGroundPos(rawX: number, rawY: number, forPipe: boolean): Pos
 
 /** TQEC dimensions [X, Y, Z] for each block type. */
 export function blockTqecSize(blockType: BlockType): [number, number, number] {
+  if (isFreeBuildPipeSpec(blockType)) {
+    // Free-build pipes have the same shape as TQEC pipes: 2 along the open axis, 1 elsewhere.
+    const dims: [number, number, number] = [1, 1, 1];
+    dims[blockType.openAxis] = 2;
+    return dims;
+  }
   switch (blockType) {
     case "Y": return [1, 1, 0.5];
     case "ZXO": case "XZO": case "ZXOH": case "XZOH": return [1, 1, 2];
@@ -333,27 +407,33 @@ const THREE_TO_TQEC_AXIS = [0, 2, 1] as const;
 /**
  * Unified pipe geometry constructor. Builds a pipe open along one Three.js axis.
  *
- * For non-Hadamard pipes: a BoxGeometry with the open-axis face pair removed and
- * closed-axis walls inset by WALL_EPS.
- *
- * For Hadamard pipes: each wall is subdivided into 3 strips (below band, yellow
- * Hadamard band, above band) with the two wall colors swapping above the band.
+ * Three modes, determined by `splitMode`:
+ *   - "none": uniform-color walls (BoxGeometry with the open-axis face pair removed
+ *     and closed-axis walls inset by WALL_EPS). Used by plain TQEC pipes.
+ *   - "band": walls subdivided into 3 strips (below band, yellow Hadamard band,
+ *     above band) with the two wall colors swapping above the band. Used by
+ *     Hadamard TQEC pipes; pass `bandColor=H_COLOR`.
+ *   - "split": walls subdivided into 2 strips (below split, above split) with
+ *     colors swapping at the split line. NO middle band. Used by free-build
+ *     color-swap pipes; pass `bandColor=null`.
  *
  * @param openAxis   Three.js axis index (0=X, 1=Y, 2=Z) that is open (length 2)
  * @param wallColors Colors for the two closed-axis wall pairs, ordered by Three.js axis number
- * @param hadamard   If true, subdivide walls with a yellow Hadamard band; colors swap above it
+ * @param splitMode  "none" | "band" | "split"
+ * @param bandColor  Color of the middle band (mode="band" only). Ignored otherwise.
  * @param hiddenFaces Bitmask of faces to omit from geometry
  */
 function createPipeGeometry(
   openAxis: number,
   wallColors: [THREE.Color, THREE.Color],
-  hadamard: boolean,
+  splitMode: "none" | "band" | "split",
+  bandColor: THREE.Color | null = null,
   hiddenFaces: FaceMask = 0,
   hBandHalfHeight?: number,
 ): THREE.BufferGeometry {
   const closedAxes = [0, 1, 2].filter(a => a !== openAxis) as [number, number];
 
-  if (!hadamard) {
+  if (splitMode === "none") {
     const e = WALL_EPS;
     const dims: [number, number, number] = [1, 1, 1];
     dims[openAxis] = 2;
@@ -398,11 +478,13 @@ function createPipeGeometry(
     return geo;
   }
 
-  // --- Hadamard pipe: 4 walls × 3 strips each ---
+  // --- Split pipe: 4 walls × (2 or 3) strips each ---
+  // mode "band": 3 strips (below / band / above), middle uses bandColor.
+  // mode "split": 2 strips (below / above) meeting at the midpoint, no band.
 
   const halfExt: [number, number, number] = [0.5, 0.5, 0.5];
   for (const ca of closedAxes) halfExt[ca] -= WALL_EPS;
-  const bh = hBandHalfHeight ?? H_BAND_HALF_HEIGHT;
+  const bh = splitMode === "split" ? 0 : (hBandHalfHeight ?? H_BAND_HALF_HEIGHT);
   // Above the band, the two closed-axis colors swap per TQEC convention
   const wallColorsAbove: [THREE.Color, THREE.Color] = [wallColors[1], wallColors[0]];
 
@@ -458,11 +540,14 @@ function createPipeGeometry(
         return [make(t0, -ocDir), make(t1, -ocDir), make(t1, ocDir), make(t0, ocDir)];
       };
 
-      // Three strips along the open axis: below band, yellow band, above band
+      // Strips along the open axis. In "band" mode: below / band / above.
+      // In "split" mode: below / above only (bh = 0, middle has zero extent).
       const [b0, b1, b2, b3] = quad(-1, -bh);
       addQuad(b0, b1, b2, b3, n, wallColors[i]);
-      const [m0, m1, m2, m3] = quad(-bh, bh);
-      addQuad(m0, m1, m2, m3, n, H_COLOR);
+      if (splitMode === "band" && bandColor) {
+        const [m0, m1, m2, m3] = quad(-bh, bh);
+        addQuad(m0, m1, m2, m3, n, bandColor);
+      }
       const [a0, a1, a2, a3] = quad(bh, 1);
       addQuad(a0, a1, a2, a3, n, wallColorsAbove[i]);
     }
@@ -484,6 +569,29 @@ function createPipeGeometry(
  * for that TQEC axis ('X', 'Z', or 'O' for open). Hadamard variants end in 'H'.
  */
 export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
+  if (isFreeBuildPipeSpec(blockType)) {
+    // Free-build color-swap pipe: same wall geometry as a Hadamard pipe but
+    // without the yellow band. Wall colors swap at each defect position.
+    // v1: only one defect at 0.5 is rendered correctly; multi-defect support
+    // is future work.
+    const tqecOpenAxis = blockType.openAxis;
+    const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpenAxis];
+    const closedAxes = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
+    // Below-split colors: bases-at-start mapped to the two closed-axis walls.
+    // Walls are ordered by Three.js axis number (closedAxes[0] then [1]).
+    // Per the TQEC convention used by string-typed pipes, the FIRST closed
+    // wall takes baseAtStart and the SECOND takes its opposite.
+    const startBase = blockType.baseAtStart;
+    const otherStart = startBase === "X" ? "Z" : "X";
+    let wallColors: [THREE.Color, THREE.Color] = [basisColor(startBase), basisColor(otherStart)];
+    // Y-open pipes: same orientation pre-swap as Hadamard (tail at -Z in Three.js).
+    if (tqecOpenAxis === 1) {
+      wallColors = [wallColors[1], wallColors[0]];
+    }
+    void closedAxes; // closedAxes computed for symmetry with TQEC branch; unused here.
+    return createPipeGeometry(threeOpenAxis, wallColors, "split", null, hiddenFaces, hBandHalfHeight);
+  }
+
   if (isPipeType(blockType)) {
     const base = blockType.replace("H", "");
     const hadamard = blockType.length > 3;
@@ -497,7 +605,14 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
     if (hadamard && tqecOpenAxis === 1) {
       wallColors = [wallColors[1], wallColors[0]];
     }
-    return createPipeGeometry(threeOpenAxis, wallColors, hadamard, hiddenFaces, hBandHalfHeight);
+    return createPipeGeometry(
+      threeOpenAxis,
+      wallColors,
+      hadamard ? "band" : "none",
+      hadamard ? H_COLOR : null,
+      hiddenFaces,
+      hBandHalfHeight,
+    );
   }
 
   if (blockType === "Y") {
@@ -557,10 +672,12 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
   return geo;
 }
 
-/** Edge line segments for a block type, including Hadamard band edges for H pipes. */
+/** Edge line segments for a block type, including Hadamard band edges for H pipes.
+ *  Free-build pipes use the same outline as a plain pipe (no extra band-ring
+ *  wireframe — the boundary is marked by magenta Y-defect cylinders instead). */
 export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
   const [bx, by, bz] = blockThreeSize(blockType);
-  const pipe = isPipeType(blockType);
+  const pipe = isPipeType(blockType) || isFreeBuildPipeSpec(blockType);
   const e2 = pipe ? 2 * WALL_EPS : 0;
   const hx = bx / 2 - e2 / 2;
   const hy = by / 2 - e2 / 2;
@@ -605,8 +722,9 @@ export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0
     }
   }
 
-  // Hadamard band edge rings
-  if (pipe && blockType.endsWith("H")) {
+  // Hadamard band edge rings (TQEC Hadamard pipes only — FB pipes don't get
+  // wireframe band rings; their boundary is marked by Y-defect cylinders).
+  if (isPipeType(blockType) && blockType.endsWith("H")) {
     const base = blockType.replace("H", "");
     const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
     const threeOpen = TQEC_TO_THREE_AXIS[tqecOpen];
@@ -655,9 +773,12 @@ export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0
  *
  * Cubes: 8 of 12 edges qualify for any TQEC cube type (the 4 edges parallel to
  * the matched-basis axis are the same-basis pair and are skipped).
- * Pipes: the 4 edges along the open axis (where the two wall-pairs of opposite
- * basis meet). End caps and band rings are not emitted in v1; the H-pipe band
- * ring is a known follow-up.
+ * TQEC pipes: the 4 edges along the open axis (where the two wall-pairs of
+ * opposite basis meet). Hadamard pipes additionally get TWO band rings at
+ * `±H_BAND_HALF_HEIGHT` along the open axis (the boundaries of the Y-basis
+ * band region).
+ * Free-build pipes: same 4 corner edges as TQEC pipes, plus ONE ring per
+ * `defectPositions[i]` mapped from 0..1 to the open-axis local range.
  * Y blocks: empty (single-basis block, no X/Z transitions).
  *
  * An edge is skipped if both adjacent faces are hidden.
@@ -672,7 +793,7 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
   if (blockType === "Y") return empty();
 
   const [bx, by, bz] = blockThreeSize(blockType);
-  const pipe = isPipeType(blockType);
+  const pipe = isPipeType(blockType) || isFreeBuildPipeSpec(blockType);
   const e2 = pipe ? 2 * WALL_EPS : 0;
   const hx = bx / 2 - e2 / 2;
   const hy = by / 2 - e2 / 2;
@@ -716,15 +837,49 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
     [FACE_POS_Z]: null, [FACE_NEG_Z]: null,
   };
 
-  if (pipe) {
+  // Open-axis info: which Three.js axis is open (for ring emission). null = cube.
+  let threeOpenAxis: number | null = null;
+  // Ring positions in open-axis local coordinates (range -1..+1, since the pipe
+  // spans [-1,+1] along the open axis with halfExt[oa]=1 in the wall geometry).
+  const ringOaVals: number[] = [];
+
+  if (isFreeBuildPipeSpec(blockType)) {
+    const tqecOpen = blockType.openAxis;
+    threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen];
+    const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
+    // FB pipe: closed-axis walls always have OPPOSITE bases (the "below split"
+    // colors). Corner edges along the open axis are therefore Y defects in
+    // both halves regardless of swap, so a single basis assignment works for
+    // the corner-edge detection.
+    const startBase = blockType.baseAtStart;
+    const otherStart = startBase === "X" ? "Z" : "X";
+    // Match the same wall-color assignment used by createBlockGeometry: the
+    // first closed Three.js axis takes baseAtStart (post Y-open swap), the
+    // second takes its opposite.
+    const ca0Basis: "X" | "Z" = tqecOpen === 1 ? otherStart : startBase;
+    const ca1Basis: "X" | "Z" = tqecOpen === 1 ? startBase : otherStart;
+    faceBasis[FACE_BIT_BY_INDEX[closed[0] * 2]] = ca0Basis;
+    faceBasis[FACE_BIT_BY_INDEX[closed[0] * 2 + 1]] = ca0Basis;
+    faceBasis[FACE_BIT_BY_INDEX[closed[1] * 2]] = ca1Basis;
+    faceBasis[FACE_BIT_BY_INDEX[closed[1] * 2 + 1]] = ca1Basis;
+    // Map normalized 0..1 defect positions to open-axis local coords -1..+1.
+    for (const p of blockType.defectPositions) {
+      ringOaVals.push(-1 + 2 * p);
+    }
+  } else if (isPipeType(blockType)) {
     const base = blockType.replace("H", "");
     const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
-    const threeOpen = TQEC_TO_THREE_AXIS[tqecOpen];
-    const closed = [0, 1, 2].filter(a => a !== threeOpen) as [number, number];
+    threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen];
+    const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
     for (const ta of closed) {
       const ch = base[THREE_TO_TQEC_AXIS[ta]] as "X" | "Z";
       faceBasis[FACE_BIT_BY_INDEX[ta * 2]] = ch;
       faceBasis[FACE_BIT_BY_INDEX[ta * 2 + 1]] = ch;
+    }
+    // Hadamard pipes: emit TWO rings at ±H_BAND_HALF_HEIGHT (the boundaries of
+    // the yellow Y-basis band region). Resolves the previous follow-up.
+    if (blockType.endsWith("H")) {
+      ringOaVals.push(-H_BAND_HALF_HEIGHT, H_BAND_HALF_HEIGHT);
     }
     // Open-axis faces stay null (no basis).
   } else {
@@ -751,6 +906,27 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
     // Acceptable trade-off; tagged as known limitation.)
     if ((hiddenFaces & faceA) || (hiddenFaces & faceB)) continue;
     linePoints.push(...corners[i], ...corners[j]);
+  }
+
+  // Band-ring emission: a 4-segment loop around the cross-section at each
+  // ring position along the open axis. Used by Hadamard pipes (2 rings) and
+  // free-build pipes (1 per defect).
+  if (threeOpenAxis !== null && ringOaVals.length > 0) {
+    const halfExts = [hx, hy, hz];
+    const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
+    for (const oaVal of ringOaVals) {
+      const ringCorners: [number, number, number][] = [];
+      for (const [s1, s2] of [[-1, -1], [1, -1], [1, 1], [-1, 1]] as const) {
+        const v: [number, number, number] = [0, 0, 0];
+        v[threeOpenAxis] = oaVal;
+        v[closed[0]] = s1 * halfExts[closed[0]];
+        v[closed[1]] = s2 * halfExts[closed[1]];
+        ringCorners.push(v);
+      }
+      for (let k = 0; k < 4; k++) {
+        linePoints.push(...ringCorners[k], ...ringCorners[(k + 1) % 4]);
+      }
+    }
   }
 
   const geo = new THREE.BufferGeometry();
@@ -1082,6 +1258,11 @@ export function hasPipeColorConflict(
 
     if (neighbor.type === "Y") continue;
     if (isPipeType(neighbor.type)) continue;
+    // Free-build pipe neighbors are non-TQEC; treat them as "no constraint"
+    // for TQEC color validation. (TQEC operations are blocked at the UI layer
+    // when FB blocks exist, so this path is mostly reachable only via tests
+    // or programmatic calls.)
+    if (isFreeBuildPipeSpec(neighbor.type)) continue;
 
     for (let axis = 0; axis < 3; axis++) {
       if (axis === openAxis) continue;
@@ -1254,6 +1435,13 @@ export function swapPipeVariant(pipeBase: string): string {
  */
 export function flipBlockType(type: BlockType): BlockType {
   if (type === "Y") return type;
+  if (isFreeBuildPipeSpec(type)) {
+    return {
+      ...type,
+      baseAtStart: type.baseAtStart === "X" ? "Z" : "X",
+      baseAtEnd: type.baseAtEnd === "X" ? "Z" : "X",
+    };
+  }
   let out = "";
   for (const ch of type) {
     if (ch === "X") out += "Z";

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -1469,28 +1469,66 @@ export function hasPipeColorConflict(
 }
 
 /**
- * v1 hardcoded build rule: returns the (single) valid FB face tuple when the
- * FB pipe sits between two XZZ cubes along X (offsets −1 and +2). Returns
- * null in every other configuration (different openAxis, missing neighbour,
- * non-cube neighbour, non-XZZ cube). Future passes will generalise.
+ * Hardcoded build rule: for any FB pipe flanked by two plain TQEC cubes along
+ * its open axis, returns the single valid FB face tuple per the touching-faces
+ * rule. Each closed-axis wall's "below" basis must equal the −openAxis cube's
+ * basis on that closed axis, and its "above" basis must equal the +openAxis
+ * cube's basis. There is always exactly one solution for any cube pair.
  *
- * The single valid variant is `["Z","Z","Z","Z"]` because XZZ has Z on both
- * its Y and Z axes, so every wall of an X-open pipe must be solid Z on both
- * sides of the defect.
+ * Returns null when:
+ *   - the input block isn't an FB pipe,
+ *   - either neighbour at offset −1 / +2 along openAxis is missing, or
+ *   - either neighbour isn't a plain CUBE_TYPES cube (Y, TQEC pipes, FB pipes
+ *     all excluded).
+ *
+ * The result also carries the matched cube types and openAxis so the caller
+ * can label the section header (e.g., "ZXX–XZZ in X") without re-reading the
+ * neighbours.
  */
-export function validFBPipeVariantsXZZXAxis(
+export function validFBPipeVariantsForCubePair(
   block: Block,
   blocks: BlocksLookup,
-): ReadonlyArray<readonly [FaceConfig, FaceConfig, FaceConfig, FaceConfig]> | null {
+): {
+  faces: ReadonlyArray<readonly [FaceConfig, FaceConfig, FaceConfig, FaceConfig]>;
+  negType: CubeType;
+  posType: CubeType;
+  openAxis: 0 | 1 | 2;
+} | null {
   const t = block.type;
-  if (!isFreeBuildPipeSpec(t) || t.openAxis !== 0) return null;
-  const negPos: Position3D = { x: block.pos.x - 1, y: block.pos.y, z: block.pos.z };
-  const posPos: Position3D = { x: block.pos.x + 2, y: block.pos.y, z: block.pos.z };
-  const neg = blocks.get(posKey(negPos));
-  const pos = blocks.get(posKey(posPos));
+  if (!isFreeBuildPipeSpec(t)) return null;
+  const openAxis = t.openAxis;
+  const negCoords: [number, number, number] = [block.pos.x, block.pos.y, block.pos.z];
+  const posCoords: [number, number, number] = [block.pos.x, block.pos.y, block.pos.z];
+  negCoords[openAxis] -= 1;
+  posCoords[openAxis] += 2;
+  const neg = blocks.get(posKey({ x: negCoords[0], y: negCoords[1], z: negCoords[2] }));
+  const pos = blocks.get(posKey({ x: posCoords[0], y: posCoords[1], z: posCoords[2] }));
   if (!neg || !pos) return null;
-  if (neg.type !== "XZZ" || pos.type !== "XZZ") return null;
-  return [["Z", "Z", "Z", "Z"]];
+  const isCube = (bt: BlockType): bt is CubeType =>
+    typeof bt === "string" && (CUBE_TYPES as readonly string[]).includes(bt);
+  if (!isCube(neg.type) || !isCube(pos.type)) return null;
+  const negType: CubeType = neg.type;
+  const posType: CubeType = pos.type;
+  // Map ca0 / ca1 (Three.js closed-axis indices, ascending) back to TQEC axis
+  // indices so we can read cube basis chars at the right positions in the type string.
+  const threeOpen = TQEC_TO_THREE_AXIS[openAxis];
+  const threeClosed = ([0, 1, 2] as const).filter((a) => a !== threeOpen);
+  const tqecCa0 = THREE_TO_TQEC_AXIS[threeClosed[0]];
+  const tqecCa1 = THREE_TO_TQEC_AXIS[threeClosed[1]];
+  const fcFor = (tqecAxis: number): FaceConfig => {
+    const below = negType[tqecAxis] as "X" | "Z";
+    const above = posType[tqecAxis] as "X" | "Z";
+    if (below === above) return below;
+    return below === "X" ? "XZ" : "ZX";
+  };
+  const fc0 = fcFor(tqecCa0);
+  const fc1 = fcFor(tqecCa1);
+  return {
+    faces: [[fc0, fc0, fc1, fc1]],
+    negType,
+    posType,
+    openAxis,
+  };
 }
 
 /**

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -1522,6 +1522,13 @@ export function determineCubeOptions(
  * Used by the cube → port conversion (must have ≤1) and by the cascade-delete
  * path (deleting a junction cube also removes its attached pipes).
  */
+/** Open-axis for a TQEC pipe or free-build pipe. Single source of truth so call
+ * sites don't need to special-case FreeBuildPipeSpec vs string PipeType. */
+export function pipeOpenAxisOf(type: PipeType | FreeBuildPipeSpec): 0 | 1 | 2 {
+  if (isFreeBuildPipeSpec(type)) return type.openAxis;
+  return type.replace("H", "").indexOf("O") as 0 | 1 | 2;
+}
+
 export function getAttachedPipeKeys(
   cubePos: Position3D,
   blocks: Map<string, Block>,
@@ -1534,9 +1541,9 @@ export function getAttachedPipeKeys(
       nCoords[axis] += pipeOffset;
       const k = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
       const neighbor = blocks.get(k);
-      if (!neighbor || !isPipeType(neighbor.type)) continue;
-      const base = neighbor.type.replace("H", "");
-      if (base.indexOf("O") === axis) keys.push(k);
+      if (!neighbor) continue;
+      if (!isPipeType(neighbor.type) && !isFreeBuildPipeSpec(neighbor.type)) continue;
+      if (pipeOpenAxisOf(neighbor.type) === axis) keys.push(k);
     }
   }
   return keys;

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -47,6 +47,12 @@ export type PipeType = (typeof PIPE_TYPES)[number];
  * sit strictly inside (0,1). One defect at 0.5 = today's color-swap pipe.
  * Two defects = a future 3-color pipe. Zero defects = a future solid pipe.
  *
+ * `swapAxes` controls which closed-axis wall pairs participate in the basis
+ * swap at each defect position. "all" (default) flips both pairs — all 4 walls
+ * change color. "first" / "second" flip only one pair (2 opposite faces); the
+ * other pair shows its baseAtStart-derived color as a solid throughout.
+ * "first" / "second" index the closedAxes array in Three.js axis order.
+ *
  * FB blocks ride the existing Y-defect overlay for boundary visualization
  * (magenta cylinders at each defect position) and are excluded from `.dae`
  * export and TQEC validation.
@@ -57,6 +63,7 @@ export interface FreeBuildPipeSpec {
   baseAtStart: "X" | "Z";       // closed-axis bases at the open-axis START end
   baseAtEnd: "X" | "Z";         // ...at the END end
   defectPositions: number[];    // 0..1 along the open axis
+  swapAxes?: "all" | "first" | "second"; // which closed-axis pair(s) swap; default "all"
 }
 
 export type BlockType = CubeType | "Y" | PipeType | FreeBuildPipeSpec;
@@ -93,7 +100,11 @@ export interface FBPreset {
   spec: FreeBuildPipeSpec;
 }
 
-/** v1 FB presets: two color-swap pipes with one Y defect at the midpoint. */
+/**
+ * FB presets: color-swap pipes with one Y defect at the midpoint.
+ * Full presets swap all 4 walls; half presets swap only one closed-axis pair
+ * (the other pair shows its baseAtStart-derived color as a solid).
+ */
 export const FB_PRESETS: ReadonlyArray<FBPreset> = [
   {
     id: "swap-zx",
@@ -104,6 +115,30 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
     id: "swap-xz",
     label: "X→Z",
     spec: { kind: "fb-pipe", openAxis: 2, baseAtStart: "X", baseAtEnd: "Z", defectPositions: [0.5] },
+  },
+  {
+    id: "half-zx",
+    label: "Z→X½",
+    spec: {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "Z",
+      baseAtEnd: "X",
+      defectPositions: [0.5],
+      swapAxes: "first",
+    },
+  },
+  {
+    id: "half-xz",
+    label: "X→Z½",
+    spec: {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "X",
+      baseAtEnd: "Z",
+      defectPositions: [0.5],
+      swapAxes: "first",
+    },
   },
 ];
 
@@ -207,7 +242,8 @@ export function isAnyPipeBlock(b: Block): boolean {
  */
 export function blockTypeCacheKey(bt: BlockType): string {
   if (typeof bt === "string") return bt;
-  return `fb:${bt.openAxis}|${bt.baseAtStart}|${bt.baseAtEnd}|${bt.defectPositions.join(",")}`;
+  const sw = bt.swapAxes ?? "all";
+  return `fb:${bt.openAxis}|${bt.baseAtStart}|${bt.baseAtEnd}|${bt.defectPositions.join(",")}|${sw}`;
 }
 
 /** Map a TQEC basis character ('X' or 'Z') to its THREE.Color. */
@@ -430,6 +466,7 @@ function createPipeGeometry(
   bandColor: THREE.Color | null = null,
   hiddenFaces: FaceMask = 0,
   hBandHalfHeight?: number,
+  swapAxes: "all" | "first" | "second" = "all",
 ): THREE.BufferGeometry {
   const closedAxes = [0, 1, 2].filter(a => a !== openAxis) as [number, number];
 
@@ -542,6 +579,14 @@ function createPipeGeometry(
 
       // Strips along the open axis. In "band" mode: below / band / above.
       // In "split" mode: below / above only (bh = 0, middle has zero extent).
+      // For FB pipes, swapAxes can suppress the swap on a specific wall pair:
+      // when this wall is on the non-swapping closed axis, the above strip
+      // reuses the below color so the wall is visually solid.
+      const swapsThisWall =
+        swapAxes === "all" ||
+        (swapAxes === "first" && i === 0) ||
+        (swapAxes === "second" && i === 1);
+      const aboveColor = swapsThisWall ? wallColorsAbove[i] : wallColors[i];
       const [b0, b1, b2, b3] = quad(-1, -bh);
       addQuad(b0, b1, b2, b3, n, wallColors[i]);
       if (splitMode === "band" && bandColor) {
@@ -549,7 +594,7 @@ function createPipeGeometry(
         addQuad(m0, m1, m2, m3, n, bandColor);
       }
       const [a0, a1, a2, a3] = quad(bh, 1);
-      addQuad(a0, a1, a2, a3, n, wallColorsAbove[i]);
+      addQuad(a0, a1, a2, a3, n, aboveColor);
     }
   }
 
@@ -589,7 +634,15 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
       wallColors = [wallColors[1], wallColors[0]];
     }
     void closedAxes; // closedAxes computed for symmetry with TQEC branch; unused here.
-    return createPipeGeometry(threeOpenAxis, wallColors, "split", null, hiddenFaces, hBandHalfHeight);
+    return createPipeGeometry(
+      threeOpenAxis,
+      wallColors,
+      "split",
+      null,
+      hiddenFaces,
+      hBandHalfHeight,
+      blockType.swapAxes ?? "all",
+    );
   }
 
   if (isPipeType(blockType)) {
@@ -777,8 +830,9 @@ export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0
  * opposite basis meet). Hadamard pipes additionally get TWO band rings at
  * `±H_BAND_HALF_HEIGHT` along the open axis (the boundaries of the Y-basis
  * band region).
- * Free-build pipes: same 4 corner edges as TQEC pipes, plus ONE ring per
- * `defectPositions[i]` mapped from 0..1 to the open-axis local range.
+ * Free-build pipes: corner edges only span open-axis runs where the two
+ * closed-axis wall pairs hold different bases; ring segments at each defect
+ * are emitted only on walls whose closed axis actually swaps (per `swapAxes`).
  * Y blocks: empty (single-basis block, no X/Z transitions).
  *
  * An edge is skipped if both adjacent faces are hidden.
@@ -798,6 +852,11 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
   const hx = bx / 2 - e2 / 2;
   const hy = by / 2 - e2 / 2;
   const hz = bz / 2 - e2 / 2;
+
+  if (isFreeBuildPipeSpec(blockType)) {
+    return createFBYDefectEdges(blockType, hiddenFaces, [hx, hy, hz]);
+  }
+
   const corners: Array<[number, number, number]> = [
     [-hx, -hy, -hz],
     [-hx, -hy,  hz],
@@ -843,30 +902,7 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
   // spans [-1,+1] along the open axis with halfExt[oa]=1 in the wall geometry).
   const ringOaVals: number[] = [];
 
-  if (isFreeBuildPipeSpec(blockType)) {
-    const tqecOpen = blockType.openAxis;
-    threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen];
-    const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
-    // FB pipe: closed-axis walls always have OPPOSITE bases (the "below split"
-    // colors). Corner edges along the open axis are therefore Y defects in
-    // both halves regardless of swap, so a single basis assignment works for
-    // the corner-edge detection.
-    const startBase = blockType.baseAtStart;
-    const otherStart = startBase === "X" ? "Z" : "X";
-    // Match the same wall-color assignment used by createBlockGeometry: the
-    // first closed Three.js axis takes baseAtStart (post Y-open swap), the
-    // second takes its opposite.
-    const ca0Basis: "X" | "Z" = tqecOpen === 1 ? otherStart : startBase;
-    const ca1Basis: "X" | "Z" = tqecOpen === 1 ? startBase : otherStart;
-    faceBasis[FACE_BIT_BY_INDEX[closed[0] * 2]] = ca0Basis;
-    faceBasis[FACE_BIT_BY_INDEX[closed[0] * 2 + 1]] = ca0Basis;
-    faceBasis[FACE_BIT_BY_INDEX[closed[1] * 2]] = ca1Basis;
-    faceBasis[FACE_BIT_BY_INDEX[closed[1] * 2 + 1]] = ca1Basis;
-    // Map normalized 0..1 defect positions to open-axis local coords -1..+1.
-    for (const p of blockType.defectPositions) {
-      ringOaVals.push(-1 + 2 * p);
-    }
-  } else if (isPipeType(blockType)) {
+  if (isPipeType(blockType)) {
     const base = blockType.replace("H", "");
     const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
     threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen];
@@ -909,8 +945,7 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
   }
 
   // Band-ring emission: a 4-segment loop around the cross-section at each
-  // ring position along the open axis. Used by Hadamard pipes (2 rings) and
-  // free-build pipes (1 per defect).
+  // ring position along the open axis. Used by Hadamard pipes (2 rings).
   if (threeOpenAxis !== null && ringOaVals.length > 0) {
     const halfExts = [hx, hy, hz];
     const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
@@ -925,6 +960,120 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
       }
       for (let k = 0; k < 4; k++) {
         linePoints.push(...ringCorners[k], ...ringCorners[(k + 1) % 4]);
+      }
+    }
+  }
+
+  const geo = new THREE.BufferGeometry();
+  geo.setAttribute("position", new THREE.BufferAttribute(new Float32Array(linePoints), 3));
+  return geo;
+}
+
+/**
+ * FB-specific Y-defect edges. Walks the open axis as a sequence of segments
+ * separated by `defectPositions`, tracking the basis on each closed-axis wall
+ * pair (which flips at every defect according to `swapAxes`). A corner edge is
+ * a Y defect only on segments where the two closed-axis walls hold different
+ * bases. Ring segments at a defect cover only the walls whose axis flipped
+ * there.
+ */
+function createFBYDefectEdges(
+  blockType: FreeBuildPipeSpec,
+  hiddenFaces: FaceMask,
+  halfExts: [number, number, number],
+): THREE.BufferGeometry {
+  const tqecOpen = blockType.openAxis;
+  const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen];
+  const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
+  const swapAxes = blockType.swapAxes ?? "all";
+  const swapsCa0 = swapAxes === "all" || swapAxes === "first";
+  const swapsCa1 = swapAxes === "all" || swapAxes === "second";
+
+  const startBase = blockType.baseAtStart;
+  const otherStart: "X" | "Z" = startBase === "X" ? "Z" : "X";
+  // Match the wall-color assignment used by createBlockGeometry: the first
+  // closed Three.js axis takes baseAtStart, the second takes its opposite,
+  // with a Y-open swap (mirrors the geometry's tail-orientation flip).
+  let curCa0: "X" | "Z" = tqecOpen === 1 ? otherStart : startBase;
+  let curCa1: "X" | "Z" = tqecOpen === 1 ? startBase : otherStart;
+
+  // Build segments along the open axis. Defects (sorted) split [-1, +1] into
+  // N+1 segments; `bases` records (ca0, ca1) on each one.
+  const sortedDefects = [...blockType.defectPositions].sort((a, b) => a - b);
+  const breakpoints = [0, ...sortedDefects, 1].map(p => -1 + 2 * p);
+  type Seg = { start: number; end: number; ca0: "X" | "Z"; ca1: "X" | "Z" };
+  const segments: Seg[] = [];
+  for (let s = 0; s < breakpoints.length - 1; s++) {
+    segments.push({ start: breakpoints[s], end: breakpoints[s + 1], ca0: curCa0, ca1: curCa1 });
+    if (s < sortedDefects.length) {
+      if (swapsCa0) curCa0 = curCa0 === "X" ? "Z" : "X";
+      if (swapsCa1) curCa1 = curCa1 === "X" ? "Z" : "X";
+    }
+  }
+
+  // Coalesce adjacent Y-defect segments so a fully-swapping pipe still emits
+  // one corner edge per corner instead of one per inter-defect segment.
+  const yDefectRuns: Array<{ start: number; end: number }> = [];
+  let runStart: number | null = null;
+  for (let s = 0; s < segments.length; s++) {
+    const isYDefect = segments[s].ca0 !== segments[s].ca1;
+    if (isYDefect && runStart === null) runStart = segments[s].start;
+    if (!isYDefect && runStart !== null) {
+      yDefectRuns.push({ start: runStart, end: segments[s - 1].end });
+      runStart = null;
+    }
+  }
+  if (runStart !== null) {
+    yDefectRuns.push({ start: runStart, end: segments[segments.length - 1].end });
+  }
+
+  const linePoints: number[] = [];
+
+  // Corner edges along the open axis, one per (ca0-sign, ca1-sign) pair per
+  // Y-defect run. Skipped if either adjacent wall face is hidden.
+  for (const run of yDefectRuns) {
+    for (const [s1, s2] of [[-1, -1], [1, -1], [-1, 1], [1, 1]] as const) {
+      const faceA = FACE_BIT_BY_INDEX[closed[0] * 2 + (s1 > 0 ? 0 : 1)];
+      const faceB = FACE_BIT_BY_INDEX[closed[1] * 2 + (s2 > 0 ? 0 : 1)];
+      if ((hiddenFaces & faceA) || (hiddenFaces & faceB)) continue;
+      const v0: [number, number, number] = [0, 0, 0];
+      const v1: [number, number, number] = [0, 0, 0];
+      v0[closed[0]] = s1 * halfExts[closed[0]];
+      v0[closed[1]] = s2 * halfExts[closed[1]];
+      v0[threeOpenAxis] = run.start * halfExts[threeOpenAxis];
+      v1[closed[0]] = s1 * halfExts[closed[0]];
+      v1[closed[1]] = s2 * halfExts[closed[1]];
+      v1[threeOpenAxis] = run.end * halfExts[threeOpenAxis];
+      linePoints.push(...v0, ...v1);
+    }
+  }
+
+  // Ring segments at each defect, restricted to the walls whose closed axis
+  // actually swaps there. A ring edge running along ca1 lies on a ca0=± wall
+  // and is a Y defect iff ca0 swaps; symmetrically for the other direction.
+  for (const p of sortedDefects) {
+    const oaVal = -1 + 2 * p;
+    const corner = (s1: -1 | 1, s2: -1 | 1): [number, number, number] => {
+      const v: [number, number, number] = [0, 0, 0];
+      v[threeOpenAxis] = oaVal;
+      v[closed[0]] = s1 * halfExts[closed[0]];
+      v[closed[1]] = s2 * halfExts[closed[1]];
+      return v;
+    };
+    if (swapsCa0) {
+      // 2 segments on ca0=± walls (run along ca1).
+      for (const s1 of [1, -1] as const) {
+        const faceBit = FACE_BIT_BY_INDEX[closed[0] * 2 + (s1 > 0 ? 0 : 1)];
+        if (hiddenFaces & faceBit) continue;
+        linePoints.push(...corner(s1, -1), ...corner(s1, 1));
+      }
+    }
+    if (swapsCa1) {
+      // 2 segments on ca1=± walls (run along ca0).
+      for (const s2 of [1, -1] as const) {
+        const faceBit = FACE_BIT_BY_INDEX[closed[1] * 2 + (s2 > 0 ? 0 : 1)];
+        if (hiddenFaces & faceBit) continue;
+        linePoints.push(...corner(-1, s2), ...corner(1, s2));
       }
     }
   }

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -42,29 +42,53 @@ export const PIPE_TYPES = ["OZX", "OXZ", "OZXH", "OXZH", "ZOX", "XOZ", "ZOXH", "
 export type PipeType = (typeof PIPE_TYPES)[number];
 
 /**
- * Free-build pipe spec — a non-TQEC pipe parameterized by Y-defect positions.
- * `defectPositions` are normalized 0..1 along the open axis; physical defects
- * sit strictly inside (0,1). One defect at 0.5 = today's color-swap pipe.
- * Two defects = a future 3-color pipe. Zero defects = a future solid pipe.
+ * Per-face state for a free-build pipe wall.
+ *   "X"  = solid X (red) all the way along the open axis
+ *   "Z"  = solid Z (blue)
+ *   "XZ" = swap X→Z at the defect (red below, blue above)
+ *   "ZX" = swap Z→X at the defect (blue below, red above)
+ */
+export type FaceConfig = "X" | "Z" | "XZ" | "ZX";
+export const FACE_CONFIGS: ReadonlyArray<FaceConfig> = ["X", "Z", "XZ", "ZX"];
+
+/** Basis of a face's strip. Below-strip is left of the defect along open axis. */
+export function faceBelowBasis(fc: FaceConfig): "X" | "Z" {
+  return fc === "X" || fc === "XZ" ? "X" : "Z";
+}
+export function faceAboveBasis(fc: FaceConfig): "X" | "Z" {
+  return fc === "X" || fc === "ZX" ? "X" : "Z";
+}
+
+/**
+ * Free-build pipe spec — a non-TQEC pipe with independently-colored walls.
  *
- * `swapAxes` controls which closed-axis wall pairs participate in the basis
- * swap at each defect position. "all" (default) flips both pairs — all 4 walls
- * change color. "first" / "second" flip only one pair (2 opposite faces); the
- * other pair shows its baseAtStart-derived color as a solid throughout.
- * "first" / "second" index the closedAxes array in Three.js axis order.
+ * Each of the 4 closed-axis walls carries its own `FaceConfig`, so the user
+ * can cycle through every visual variant (256 per open axis) from the
+ * variants panel after placement.
  *
- * FB blocks ride the existing Y-defect overlay for boundary visualization
- * (magenta cylinders at each defect position) and are excluded from `.dae`
- * export and TQEC validation.
+ * `faces` index order is **Three.js closed-axis order**:
+ *   [0] = +ca0, [1] = −ca0, [2] = +ca1, [3] = −ca1
+ * where `closedAxes = [0,1,2].filter(a => a !== TQEC_TO_THREE_AXIS[openAxis])`
+ * in ascending order. The geometry and Y-defect overlay both consume this
+ * tuple directly.
+ *
+ * `defectPositions` are normalized 0..1 along the open axis; v1 always uses
+ * `[0.5]` (single midpoint defect). Faces marked `XZ`/`ZX` flip color at the
+ * defect; `X`/`Z` faces stay solid through it.
+ *
+ * FB blocks are excluded from `.dae` export and TQEC validation.
  */
 export interface FreeBuildPipeSpec {
   kind: "fb-pipe";
   openAxis: 0 | 1 | 2;          // TQEC axis (0=x, 1=y, 2=z)
-  baseAtStart: "X" | "Z";       // closed-axis bases at the open-axis START end
-  baseAtEnd: "X" | "Z";         // ...at the END end
   defectPositions: number[];    // 0..1 along the open axis
-  swapAxes?: "all" | "first" | "second"; // which closed-axis pair(s) swap; default "all"
+  faces: [FaceConfig, FaceConfig, FaceConfig, FaceConfig];
 }
+
+/** Default config for the toolbar's generic Free Pipe — solid X (red) tube. */
+export const FB_DEFAULT_FACES: [FaceConfig, FaceConfig, FaceConfig, FaceConfig] = [
+  "X", "X", "X", "X",
+];
 
 export type BlockType = CubeType | "Y" | PipeType | FreeBuildPipeSpec;
 export type FaceMask = number;
@@ -101,43 +125,20 @@ export interface FBPreset {
 }
 
 /**
- * FB presets: color-swap pipes with one Y defect at the midpoint.
- * Full presets swap all 4 walls; half presets swap only one closed-axis pair
- * (the other pair shows its baseAtStart-derived color as a solid).
+ * FB presets: a single generic Free Pipe entry whose 256 visual variants are
+ * reached by clicking cells in the variants panel that opens after placement.
+ * The default `faces` here just gives the ghost a recognizable shape — the
+ * user picks a real config from the panel.
  */
 export const FB_PRESETS: ReadonlyArray<FBPreset> = [
   {
-    id: "swap-zx",
-    label: "Z→X",
-    spec: { kind: "fb-pipe", openAxis: 2, baseAtStart: "Z", baseAtEnd: "X", defectPositions: [0.5] },
-  },
-  {
-    id: "swap-xz",
-    label: "X→Z",
-    spec: { kind: "fb-pipe", openAxis: 2, baseAtStart: "X", baseAtEnd: "Z", defectPositions: [0.5] },
-  },
-  {
-    id: "half-zx",
-    label: "Z→X½",
+    id: "free-pipe",
+    label: "Free Pipe",
     spec: {
       kind: "fb-pipe",
       openAxis: 2,
-      baseAtStart: "Z",
-      baseAtEnd: "X",
       defectPositions: [0.5],
-      swapAxes: "first",
-    },
-  },
-  {
-    id: "half-xz",
-    label: "X→Z½",
-    spec: {
-      kind: "fb-pipe",
-      openAxis: 2,
-      baseAtStart: "X",
-      baseAtEnd: "Z",
-      defectPositions: [0.5],
-      swapAxes: "first",
+      faces: [...FB_DEFAULT_FACES],
     },
   },
 ];
@@ -149,13 +150,13 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
  */
 export type Placeable =
   | { kind: "port" }
-  | { kind: "cube"; cubeType: BlockType }
+  | { kind: "cube"; cubeType: CubeType | "Y" }
   | { kind: "pipe"; variant: PipeVariant };
 
 export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
   { kind: "port" },
-  ...CUBE_TYPES.map((t) => ({ kind: "cube" as const, cubeType: t as BlockType })),
-  { kind: "cube" as const, cubeType: "Y" as BlockType },
+  ...CUBE_TYPES.map((t) => ({ kind: "cube" as const, cubeType: t })),
+  { kind: "cube" as const, cubeType: "Y" as const },
   ...PIPE_VARIANTS.map((v) => ({ kind: "pipe" as const, variant: v })),
 ];
 
@@ -165,7 +166,7 @@ export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
  */
 export function currentPlaceableIndex(
   armedTool: "pointer" | "cube" | "pipe" | "port" | "paste",
-  cubeType: BlockType,
+  cubeType: CubeType | "Y",
   pipeVariant: PipeVariant | null,
 ): number {
   if (armedTool === "pointer" || armedTool === "paste") return -1;
@@ -187,6 +188,13 @@ export type PortIO = "in" | "out";
 export interface PortMeta {
   label: string;
   io: PortIO;
+  /**
+   * User-defined display order, used by the Ports table and Stabilizer Flows
+   * panel to determine the qubit-register position of each port. Lower ranks
+   * sort first; ports without a rank fall back to spatial sort and appear
+   * after ranked ports.
+   */
+  rank?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -242,8 +250,67 @@ export function isAnyPipeBlock(b: Block): boolean {
  */
 export function blockTypeCacheKey(bt: BlockType): string {
   if (typeof bt === "string") return bt;
-  const sw = bt.swapAxes ?? "all";
-  return `fb:${bt.openAxis}|${bt.baseAtStart}|${bt.baseAtEnd}|${bt.defectPositions.join(",")}|${sw}`;
+  return `fb:${bt.openAxis}|${bt.faces.join("")}|${bt.defectPositions.join(",")}`;
+}
+
+/**
+ * Legacy FB spec (pre-faces): defined as `{ openAxis, baseAtStart, baseAtEnd,
+ * swapAxes?, defectPositions }`. Convert to the new per-face shape on read so
+ * old `.dae` files and old URL-hashed scenes keep loading without surprise.
+ */
+type LegacyFBSpec = {
+  kind: "fb-pipe";
+  openAxis: 0 | 1 | 2;
+  baseAtStart: "X" | "Z";
+  baseAtEnd: "X" | "Z";
+  defectPositions: number[];
+  swapAxes?: "all" | "first" | "second";
+};
+
+function isLegacyFBSpec(o: unknown): o is LegacyFBSpec {
+  if (typeof o !== "object" || o === null) return false;
+  const r = o as { kind?: unknown; faces?: unknown; baseAtStart?: unknown };
+  return r.kind === "fb-pipe" && r.faces === undefined && typeof r.baseAtStart === "string";
+}
+
+/**
+ * Migrate a legacy FB spec (baseAtStart/baseAtEnd/swapAxes) to the new
+ * per-face shape. Pure: same in → same out.
+ *
+ * The legacy convention picked wall colors via:
+ *   wallColors[0] = baseAtStart, wallColors[1] = opposite(baseAtStart)
+ * with a Y-open swap that flips the pair (mirroring the geometry's
+ * tail-orientation flip for TQEC openAxis === 1). swapAxes "first"/"second"
+ * select which pair flips at the defect; both faces of a pair shared a config.
+ */
+export function migrateLegacyFBSpec(legacy: LegacyFBSpec): FreeBuildPipeSpec {
+  const startBase = legacy.baseAtStart;
+  const otherStart: "X" | "Z" = startBase === "X" ? "Z" : "X";
+  const isYOpen = legacy.openAxis === 1;
+  const ca0Below: "X" | "Z" = isYOpen ? otherStart : startBase;
+  const ca1Below: "X" | "Z" = isYOpen ? startBase : otherStart;
+  const swap = legacy.swapAxes ?? "all";
+  const swapsCa0 = swap === "all" || swap === "first";
+  const swapsCa1 = swap === "all" || swap === "second";
+  const ca0: FaceConfig = swapsCa0 ? (ca0Below === "X" ? "XZ" : "ZX") : ca0Below;
+  const ca1: FaceConfig = swapsCa1 ? (ca1Below === "X" ? "XZ" : "ZX") : ca1Below;
+  return {
+    kind: "fb-pipe",
+    openAxis: legacy.openAxis,
+    defectPositions: [...legacy.defectPositions],
+    faces: [ca0, ca0, ca1, ca1],
+  };
+}
+
+/** Apply migration if needed; pass-through otherwise. */
+export function normalizeFBSpec(o: unknown): FreeBuildPipeSpec | null {
+  if (typeof o !== "object" || o === null) return null;
+  if (isLegacyFBSpec(o)) return migrateLegacyFBSpec(o);
+  const r = o as Partial<FreeBuildPipeSpec> & { kind?: unknown };
+  if (r.kind === "fb-pipe" && Array.isArray(r.faces) && r.faces.length === 4) {
+    return r as FreeBuildPipeSpec;
+  }
+  return null;
 }
 
 /** Map a TQEC basis character ('X' or 'Z') to its THREE.Color. */
@@ -466,7 +533,13 @@ function createPipeGeometry(
   bandColor: THREE.Color | null = null,
   hiddenFaces: FaceMask = 0,
   hBandHalfHeight?: number,
-  swapAxes: "all" | "first" | "second" = "all",
+  /**
+   * Optional per-face overrides for "split" mode (free-build pipes). When
+   * provided, each of the 4 walls reads its own (below, above) colors from
+   * `faceConfigs` instead of the shared `wallColors` + `swapAxes` rule.
+   * Index order: [+ca0, −ca0, +ca1, −ca1] in Three.js closed-axis order.
+   */
+  faceConfigs?: [FaceConfig, FaceConfig, FaceConfig, FaceConfig],
 ): THREE.BufferGeometry {
   const closedAxes = [0, 1, 2].filter(a => a !== openAxis) as [number, number];
 
@@ -579,16 +652,18 @@ function createPipeGeometry(
 
       // Strips along the open axis. In "band" mode: below / band / above.
       // In "split" mode: below / above only (bh = 0, middle has zero extent).
-      // For FB pipes, swapAxes can suppress the swap on a specific wall pair:
-      // when this wall is on the non-swapping closed axis, the above strip
-      // reuses the below color so the wall is visually solid.
-      const swapsThisWall =
-        swapAxes === "all" ||
-        (swapAxes === "first" && i === 0) ||
-        (swapAxes === "second" && i === 1);
-      const aboveColor = swapsThisWall ? wallColorsAbove[i] : wallColors[i];
+      // For FB pipes, faceConfigs gives each face an independent (below,
+      // above) basis. Index: i=closed-axis pair, sign=+1/-1 → faces tuple
+      // entry `i*2 + (sign>0?0:1)` ([+ca0,-ca0,+ca1,-ca1]).
+      let belowColor = wallColors[i];
+      let aboveColor = wallColorsAbove[i];
+      if (faceConfigs) {
+        const fc = faceConfigs[i * 2 + (sign > 0 ? 0 : 1)];
+        belowColor = basisColor(faceBelowBasis(fc));
+        aboveColor = basisColor(faceAboveBasis(fc));
+      }
       const [b0, b1, b2, b3] = quad(-1, -bh);
-      addQuad(b0, b1, b2, b3, n, wallColors[i]);
+      addQuad(b0, b1, b2, b3, n, belowColor);
       if (splitMode === "band" && bandColor) {
         const [m0, m1, m2, m3] = quad(-bh, bh);
         addQuad(m0, m1, m2, m3, n, bandColor);
@@ -615,33 +690,18 @@ function createPipeGeometry(
  */
 export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
   if (isFreeBuildPipeSpec(blockType)) {
-    // Free-build color-swap pipe: same wall geometry as a Hadamard pipe but
-    // without the yellow band. Wall colors swap at each defect position.
-    // v1: only one defect at 0.5 is rendered correctly; multi-defect support
-    // is future work.
-    const tqecOpenAxis = blockType.openAxis;
-    const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpenAxis];
-    const closedAxes = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
-    // Below-split colors: bases-at-start mapped to the two closed-axis walls.
-    // Walls are ordered by Three.js axis number (closedAxes[0] then [1]).
-    // Per the TQEC convention used by string-typed pipes, the FIRST closed
-    // wall takes baseAtStart and the SECOND takes its opposite.
-    const startBase = blockType.baseAtStart;
-    const otherStart = startBase === "X" ? "Z" : "X";
-    let wallColors: [THREE.Color, THREE.Color] = [basisColor(startBase), basisColor(otherStart)];
-    // Y-open pipes: same orientation pre-swap as Hadamard (tail at -Z in Three.js).
-    if (tqecOpenAxis === 1) {
-      wallColors = [wallColors[1], wallColors[0]];
-    }
-    void closedAxes; // closedAxes computed for symmetry with TQEC branch; unused here.
+    // Free-build pipe: per-face configs drive each wall's below/above colors.
+    // wallColors here is a placeholder (overridden by faceConfigs in the
+    // geometry constructor); pass red/blue so any unknown face still reads.
+    const threeOpenAxis = TQEC_TO_THREE_AXIS[blockType.openAxis];
     return createPipeGeometry(
       threeOpenAxis,
-      wallColors,
+      [X_COLOR, Z_COLOR],
       "split",
       null,
       hiddenFaces,
       hBandHalfHeight,
-      blockType.swapAxes ?? "all",
+      blockType.faces,
     );
   }
 
@@ -970,110 +1030,96 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
 }
 
 /**
- * FB-specific Y-defect edges. Walks the open axis as a sequence of segments
- * separated by `defectPositions`, tracking the basis on each closed-axis wall
- * pair (which flips at every defect according to `swapAxes`). A corner edge is
- * a Y defect only on segments where the two closed-axis walls hold different
- * bases. Ring segments at a defect cover only the walls whose axis flipped
- * there.
+ * FB-specific Y-defect edges (per-face configs).
+ *
+ * For each of the 4 open-axis corners (ca0±, ca1±), the two adjacent walls'
+ * bases are checked separately on the below-defect strip and the above-defect
+ * strip. A corner cylinder is drawn for whichever strips show an X/Z mismatch.
+ *
+ * Ring segments at the defect are emitted around any wall whose `FaceConfig`
+ * is `XZ` or `ZX` — those are the walls where the basis itself flips at the
+ * defect, which is exactly where the wall acquires a Y-defect ring.
+ *
+ * v1 only honours the first defect position; multi-defect FB pipes are future
+ * work and the current code base never produces them.
  */
 function createFBYDefectEdges(
   blockType: FreeBuildPipeSpec,
   hiddenFaces: FaceMask,
   halfExts: [number, number, number],
 ): THREE.BufferGeometry {
-  const tqecOpen = blockType.openAxis;
-  const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen];
+  const threeOpenAxis = TQEC_TO_THREE_AXIS[blockType.openAxis];
   const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
-  const swapAxes = blockType.swapAxes ?? "all";
-  const swapsCa0 = swapAxes === "all" || swapAxes === "first";
-  const swapsCa1 = swapAxes === "all" || swapAxes === "second";
+  const faces = blockType.faces;
+  // faces tuple is [+ca0, -ca0, +ca1, -ca1] in Three.js closed-axis order.
+  const faceAt = (caIdx: 0 | 1, sign: 1 | -1): FaceConfig =>
+    faces[caIdx * 2 + (sign > 0 ? 0 : 1)];
 
-  const startBase = blockType.baseAtStart;
-  const otherStart: "X" | "Z" = startBase === "X" ? "Z" : "X";
-  // Match the wall-color assignment used by createBlockGeometry: the first
-  // closed Three.js axis takes baseAtStart, the second takes its opposite,
-  // with a Y-open swap (mirrors the geometry's tail-orientation flip).
-  let curCa0: "X" | "Z" = tqecOpen === 1 ? otherStart : startBase;
-  let curCa1: "X" | "Z" = tqecOpen === 1 ? startBase : otherStart;
-
-  // Build segments along the open axis. Defects (sorted) split [-1, +1] into
-  // N+1 segments; `bases` records (ca0, ca1) on each one.
   const sortedDefects = [...blockType.defectPositions].sort((a, b) => a - b);
-  const breakpoints = [0, ...sortedDefects, 1].map(p => -1 + 2 * p);
-  type Seg = { start: number; end: number; ca0: "X" | "Z"; ca1: "X" | "Z" };
-  const segments: Seg[] = [];
-  for (let s = 0; s < breakpoints.length - 1; s++) {
-    segments.push({ start: breakpoints[s], end: breakpoints[s + 1], ca0: curCa0, ca1: curCa1 });
-    if (s < sortedDefects.length) {
-      if (swapsCa0) curCa0 = curCa0 === "X" ? "Z" : "X";
-      if (swapsCa1) curCa1 = curCa1 === "X" ? "Z" : "X";
-    }
-  }
-
-  // Coalesce adjacent Y-defect segments so a fully-swapping pipe still emits
-  // one corner edge per corner instead of one per inter-defect segment.
-  const yDefectRuns: Array<{ start: number; end: number }> = [];
-  let runStart: number | null = null;
-  for (let s = 0; s < segments.length; s++) {
-    const isYDefect = segments[s].ca0 !== segments[s].ca1;
-    if (isYDefect && runStart === null) runStart = segments[s].start;
-    if (!isYDefect && runStart !== null) {
-      yDefectRuns.push({ start: runStart, end: segments[s - 1].end });
-      runStart = null;
-    }
-  }
-  if (runStart !== null) {
-    yDefectRuns.push({ start: runStart, end: segments[segments.length - 1].end });
-  }
+  const hasDefect = sortedDefects.length > 0;
+  const defectOaVal = hasDefect ? -1 + 2 * sortedDefects[0] : 0;
 
   const linePoints: number[] = [];
 
-  // Corner edges along the open axis, one per (ca0-sign, ca1-sign) pair per
-  // Y-defect run. Skipped if either adjacent wall face is hidden.
-  for (const run of yDefectRuns) {
-    for (const [s1, s2] of [[-1, -1], [1, -1], [-1, 1], [1, 1]] as const) {
+  // ---- Corner edges (one per corner, possibly split into below/above runs)
+  // Each corner sits where two adjacent walls meet. We compare bases on each
+  // strip; emit a cylinder along the strips where the bases differ.
+  for (const s1 of [-1, 1] as const) {
+    for (const s2 of [-1, 1] as const) {
       const faceA = FACE_BIT_BY_INDEX[closed[0] * 2 + (s1 > 0 ? 0 : 1)];
       const faceB = FACE_BIT_BY_INDEX[closed[1] * 2 + (s2 > 0 ? 0 : 1)];
       if ((hiddenFaces & faceA) || (hiddenFaces & faceB)) continue;
-      const v0: [number, number, number] = [0, 0, 0];
-      const v1: [number, number, number] = [0, 0, 0];
-      v0[closed[0]] = s1 * halfExts[closed[0]];
-      v0[closed[1]] = s2 * halfExts[closed[1]];
-      v0[threeOpenAxis] = run.start * halfExts[threeOpenAxis];
-      v1[closed[0]] = s1 * halfExts[closed[0]];
-      v1[closed[1]] = s2 * halfExts[closed[1]];
-      v1[threeOpenAxis] = run.end * halfExts[threeOpenAxis];
-      linePoints.push(...v0, ...v1);
+
+      const fcA = faceAt(0, s1);
+      const fcB = faceAt(1, s2);
+      const belowDiff = faceBelowBasis(fcA) !== faceBelowBasis(fcB);
+      const aboveDiff = faceAboveBasis(fcA) !== faceAboveBasis(fcB);
+
+      const cornerPoint = (oa: number): [number, number, number] => {
+        const v: [number, number, number] = [0, 0, 0];
+        v[closed[0]] = s1 * halfExts[closed[0]];
+        v[closed[1]] = s2 * halfExts[closed[1]];
+        v[threeOpenAxis] = oa * halfExts[threeOpenAxis];
+        return v;
+      };
+
+      if (!hasDefect) {
+        if (belowDiff) linePoints.push(...cornerPoint(-1), ...cornerPoint(1));
+        continue;
+      }
+      // Coalesce when both strips share the mismatch, so a fully-mismatched
+      // corner emits a single cylinder spanning [-1, +1] instead of two
+      // butt-joined ones at the defect.
+      if (belowDiff && aboveDiff) {
+        linePoints.push(...cornerPoint(-1), ...cornerPoint(1));
+      } else if (belowDiff) {
+        linePoints.push(...cornerPoint(-1), ...cornerPoint(defectOaVal));
+      } else if (aboveDiff) {
+        linePoints.push(...cornerPoint(defectOaVal), ...cornerPoint(1));
+      }
     }
   }
 
-  // Ring segments at each defect, restricted to the walls whose closed axis
-  // actually swaps there. A ring edge running along ca1 lies on a ca0=± wall
-  // and is a Y defect iff ca0 swaps; symmetrically for the other direction.
-  for (const p of sortedDefects) {
-    const oaVal = -1 + 2 * p;
-    const corner = (s1: -1 | 1, s2: -1 | 1): [number, number, number] => {
-      const v: [number, number, number] = [0, 0, 0];
-      v[threeOpenAxis] = oaVal;
-      v[closed[0]] = s1 * halfExts[closed[0]];
-      v[closed[1]] = s2 * halfExts[closed[1]];
-      return v;
-    };
-    if (swapsCa0) {
-      // 2 segments on ca0=± walls (run along ca1).
-      for (const s1 of [1, -1] as const) {
-        const faceBit = FACE_BIT_BY_INDEX[closed[0] * 2 + (s1 > 0 ? 0 : 1)];
+  // ---- Ring segments around any swapping wall at the defect.
+  if (hasDefect) {
+    const oaVal = defectOaVal;
+    for (let i = 0; i < 2; i++) {
+      const ca = closed[i];
+      const oc = closed[1 - i];
+      for (const sign of [1, -1] as const) {
+        const fc = faceAt(i as 0 | 1, sign);
+        if (fc !== "XZ" && fc !== "ZX") continue;
+        const faceBit = FACE_BIT_BY_INDEX[ca * 2 + (sign > 0 ? 0 : 1)];
         if (hiddenFaces & faceBit) continue;
-        linePoints.push(...corner(s1, -1), ...corner(s1, 1));
-      }
-    }
-    if (swapsCa1) {
-      // 2 segments on ca1=± walls (run along ca0).
-      for (const s2 of [1, -1] as const) {
-        const faceBit = FACE_BIT_BY_INDEX[closed[1] * 2 + (s2 > 0 ? 0 : 1)];
-        if (hiddenFaces & faceBit) continue;
-        linePoints.push(...corner(-1, s2), ...corner(1, s2));
+        const v0: [number, number, number] = [0, 0, 0];
+        const v1: [number, number, number] = [0, 0, 0];
+        v0[threeOpenAxis] = oaVal;
+        v1[threeOpenAxis] = oaVal;
+        v0[ca] = sign * halfExts[ca];
+        v1[ca] = sign * halfExts[ca];
+        v0[oc] = -halfExts[oc];
+        v1[oc] = halfExts[oc];
+        linePoints.push(...v0, ...v1);
       }
     }
   }
@@ -1585,10 +1631,16 @@ export function swapPipeVariant(pipeBase: string): string {
 export function flipBlockType(type: BlockType): BlockType {
   if (type === "Y") return type;
   if (isFreeBuildPipeSpec(type)) {
+    const flipFace = (fc: FaceConfig): FaceConfig =>
+      fc === "X" ? "Z" : fc === "Z" ? "X" : fc === "XZ" ? "ZX" : "XZ";
     return {
       ...type,
-      baseAtStart: type.baseAtStart === "X" ? "Z" : "X",
-      baseAtEnd: type.baseAtEnd === "X" ? "Z" : "X",
+      faces: [
+        flipFace(type.faces[0]),
+        flipFace(type.faces[1]),
+        flipFace(type.faces[2]),
+        flipFace(type.faces[3]),
+      ],
     };
   }
   let out = "";
@@ -1747,6 +1799,28 @@ export function getAllPortPositions(
 
   result.sort((a, b) => a.x - b.x || a.y - b.y || a.z - b.z);
   return result;
+}
+
+/**
+ * Like `getAllPortPositions`, but ordered by user-defined `PortMeta.rank`
+ * with spatial sort as fallback for any port without a rank. This is the
+ * order shown in the Ports table and used to position qubits in the
+ * Stabilizer Flows table when interpreted as a circuit.
+ */
+export function getOrderedPortPositions(
+  blocks: Map<string, Block>,
+  explicitPorts: Set<string>,
+  portMeta: Map<string, PortMeta>,
+): Position3D[] {
+  const positions = getAllPortPositions(blocks, explicitPorts);
+  return positions.slice().sort((a, b) => {
+    const ra = portMeta.get(posKey(a))?.rank;
+    const rb = portMeta.get(posKey(b))?.rank;
+    const ka = ra ?? Number.POSITIVE_INFINITY;
+    const kb = rb ?? Number.POSITIVE_INFINITY;
+    if (ka !== kb) return ka - kb;
+    return a.x - b.x || a.y - b.y || a.z - b.z;
+  });
 }
 
 /**

--- a/gui/src/utils/blockRotation.ts
+++ b/gui/src/utils/blockRotation.ts
@@ -1,5 +1,5 @@
 import type { Block, Position3D } from "../types";
-import { isPipeType } from "../types";
+import { isFreeBuildPipeSpec, isPipeType } from "../types";
 
 // ---------------------------------------------------------------------------
 // Hadamard direction equivalences (same as tqec's adjust_hadamards_direction)
@@ -172,6 +172,17 @@ export function rotateBlockAroundZ(
   direction: RotationDirection,
 ): Block {
   const rot = direction === "ccw" ? ROT_Z_CCW : ROT_Z_CW;
+
+  // Free-build pipe: rotate the open-axis index (X↔Y for Z-axis rotation;
+  // Z stays). Bases and defect positions ride along the rotation unchanged.
+  if (isFreeBuildPipeSpec(block.type)) {
+    const oldAxis = block.type.openAxis;
+    const newAxis: 0 | 1 | 2 =
+      oldAxis === 2 ? 2 : oldAxis === 0 ? 1 : 0;
+    const newPos = rotatePositionAroundZ(block.pos, pivot, direction, true);
+    return { pos: newPos, type: { ...block.type, openAxis: newAxis } };
+  }
+
   const isPipe = isPipeType(block.type);
 
   let newType = rotateBlockKind(block.type, rot);

--- a/gui/src/utils/daeExport.test.ts
+++ b/gui/src/utils/daeExport.test.ts
@@ -163,4 +163,24 @@ describe("round-trip: export → import", () => {
       expect(imported.get(key)!.type).toBe(type);
     }
   });
+
+  it("strips free-build pipes from exported XML (defense-in-depth)", () => {
+    const blocks = new Map<string, Block>();
+    blocks.set("0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" as Block["type"] });
+    blocks.set("0,0,1", {
+      pos: { x: 0, y: 0, z: 1 },
+      type: { kind: "fb-pipe", openAxis: 2, baseAtStart: "Z", baseAtEnd: "X", defectPositions: [0.5] },
+    });
+    blocks.set("0,0,3", { pos: { x: 0, y: 0, z: 3 }, type: "ZXZ" as Block["type"] });
+    const xml = exportBlocksToDae(blocks);
+    // The two TQEC cubes round-trip; the FB pipe must be absent.
+    const imported = parseDaeToBlocks(xml);
+    expect(imported.size).toBe(2);
+    expect(imported.has("0,0,0")).toBe(true);
+    expect(imported.has("0,0,3")).toBe(true);
+    expect(imported.has("0,0,1")).toBe(false);
+    // No `[object Object]` artifact in the XML — FB types should never have
+    // been stringified in.
+    expect(xml).not.toContain("object Object");
+  });
 });

--- a/gui/src/utils/daeExport.test.ts
+++ b/gui/src/utils/daeExport.test.ts
@@ -169,7 +169,7 @@ describe("round-trip: export → import", () => {
     blocks.set("0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" as Block["type"] });
     blocks.set("0,0,1", {
       pos: { x: 0, y: 0, z: 1 },
-      type: { kind: "fb-pipe", openAxis: 2, baseAtStart: "Z", baseAtEnd: "X", defectPositions: [0.5] },
+      type: { kind: "fb-pipe", openAxis: 2, defectPositions: [0.5], faces: ["ZX", "ZX", "ZX", "ZX"] },
     });
     blocks.set("0,0,3", { pos: { x: 0, y: 0, z: 3 }, type: "ZXZ" as Block["type"] });
     const xml = exportBlocksToDae(blocks);

--- a/gui/src/utils/daeExport.ts
+++ b/gui/src/utils/daeExport.ts
@@ -1,5 +1,5 @@
 import type { Block } from "../types";
-import { isPipeType } from "../types";
+import { isPipeType, isFreeBuildBlock } from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants matching tqec's Collada output
@@ -69,10 +69,19 @@ function stubGeometryXml(id: string): string {
  * (both use the same mod-3 grid where scale factor = 1 + pipe_length = 3).
  */
 export function exportBlocksToDae(blocks: Map<string, Block>): string {
+  // Defense-in-depth: strip free-build (non-TQEC) pieces before any DAE
+  // emission. The UI Export button is disabled when FB blocks are present;
+  // this filter is a safety net for programmatic callers.
+  if (Array.from(blocks.values()).some(isFreeBuildBlock)) {
+    blocks = new Map(
+      Array.from(blocks.entries()).filter(([, b]) => !isFreeBuildBlock(b)),
+    );
+  }
   // Collect unique block kinds
   const usedKinds = new Set<string>();
   for (const block of blocks.values()) {
-    usedKinds.add(block.type);
+    // After the filter above, block.type is always a TQEC string.
+    usedKinds.add(block.type as string);
   }
 
   // Build materials XML — always include all 4 to keep it simple
@@ -138,7 +147,9 @@ export function exportBlocksToDae(blocks: Map<string, Block>): string {
   let instanceIdx = 0;
 
   for (const block of blocks.values()) {
-    const kindLower = block.type.toLowerCase();
+    // After the FB filter at the top of this function, block.type is always
+    // a TQEC string. The cast keeps TypeScript happy under the widened union.
+    const kindLower = (block.type as string).toLowerCase();
     const nodeId = `lib_${kindLower}`;
 
     const tx = block.pos.x;

--- a/gui/src/utils/dragValidate.ts
+++ b/gui/src/utils/dragValidate.ts
@@ -4,6 +4,7 @@ import {
   hasCubeColorConflict,
   hasPipeColorConflict,
   hasYCubePipeAxisConflict,
+  isFreeBuildPipeSpec,
   isPipeType,
   isValidPos,
   posKey,
@@ -86,7 +87,7 @@ export function isMoveValid(state: MoveValidateState, delta: Position3D): boolea
     for (const nb of newBlocks) {
       const t = nb.type;
       if (isPipeType(t) && hasPipeColorConflict(t, nb.pos, lookup)) return false;
-      if (!isPipeType(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, nb.pos, lookup)) return false;
+      if (!isPipeType(t) && !isFreeBuildPipeSpec(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, nb.pos, lookup)) return false;
       if (hasYCubePipeAxisConflict(t, nb.pos, lookup)) return false;
     }
   }

--- a/gui/src/utils/flows.ts
+++ b/gui/src/utils/flows.ts
@@ -1,4 +1,5 @@
 import type { Block, Position3D, PortMeta } from "../types";
+import { isFreeBuildBlock } from "../types";
 
 export interface SurfacePiece {
   basis: "X" | "Z";
@@ -30,10 +31,16 @@ export async function computeFlows(
   blocks: Map<string, Block>,
   portMeta: Map<string, PortMeta>,
 ): Promise<FlowsResult> {
-  const blocksPayload = Array.from(blocks.values()).map((b) => ({
-    pos: [b.pos.x, b.pos.y, b.pos.z],
-    type: b.type,
-  }));
+  // Defense-in-depth: drop free-build (non-TQEC) blocks before sending to
+  // the backend. The Flows panel runs against a TQEC scene; FB pieces are
+  // already excluded from the UI when Verify is disabled, but a stale Flows
+  // result from a mixed scene shouldn't include FB types.
+  const blocksPayload = Array.from(blocks.values())
+    .filter((b) => !isFreeBuildBlock(b))
+    .map((b) => ({
+      pos: [b.pos.x, b.pos.y, b.pos.z],
+      type: b.type as string,
+    }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
     return { pos: [p.x, p.y, p.z], label: meta.label };

--- a/gui/src/utils/flows.ts
+++ b/gui/src/utils/flows.ts
@@ -43,7 +43,7 @@ export async function computeFlows(
     }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) portIO[meta.label] = meta.io;

--- a/gui/src/utils/gridPlanePassthrough.test.ts
+++ b/gui/src/utils/gridPlanePassthrough.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { shouldPassThroughGridPlane } from "./gridPlanePassthrough";
+
+const plane = new THREE.Mesh();
+const block = new THREE.Mesh();
+const port = new THREE.Mesh();
+const hit = (o: THREE.Object3D) => ({ object: o });
+
+describe("shouldPassThroughGridPlane", () => {
+  it("returns false when intersections is empty", () => {
+    expect(shouldPassThroughGridPlane([], plane)).toBe(false);
+  });
+
+  it("returns false when only the plane is hit", () => {
+    expect(shouldPassThroughGridPlane([hit(plane)], plane)).toBe(false);
+  });
+
+  it("returns true when a block is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(block)], plane)).toBe(true);
+  });
+
+  it("returns true when a port ghost is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(port)], plane)).toBe(true);
+  });
+
+  it("returns false when planeMesh is null (e.g., pre-mount frame)", () => {
+    expect(shouldPassThroughGridPlane([hit(block)], null)).toBe(false);
+  });
+});

--- a/gui/src/utils/gridPlanePassthrough.ts
+++ b/gui/src/utils/gridPlanePassthrough.ts
@@ -1,0 +1,31 @@
+import type { Intersection, Object3D } from "three";
+
+/**
+ * In select mode, GridPlane should bow out of clicks/hovers when the ray also
+ * hits another interactive mesh further along (a block or port ghost). Without
+ * this, the invisible plane at Three.js y=0 swallows clicks meant for blocks
+ * placed at TQEC z<0 (below the plane) when the camera looks down from above.
+ *
+ * Click chain (perspective, camera tilted down):
+ *
+ *   camera                  After fix:
+ *     │                       plane sees a non-plane hit in e.intersections
+ *     ▼                       → returns without stopProp/clearSelection
+ *   [GridPlane y=0]           → BlockInstances.handleClick runs
+ *     │                       → sub-ground block gets selected
+ *     ▼
+ *   [Block | Port]
+ *
+ * Returns true if any intersection's object is not the plane itself, meaning
+ * the next handler in the chain should own the event.
+ *
+ * Relies on the project convention that decorative meshes use raycast={noRaycast}
+ * so e.intersections only contains actually-clickable meshes.
+ */
+export function shouldPassThroughGridPlane(
+  intersections: ReadonlyArray<Pick<Intersection, "object">>,
+  planeMesh: Object3D | null,
+): boolean {
+  if (!planeMesh) return false;
+  return intersections.some((i) => i.object !== planeMesh);
+}

--- a/gui/src/utils/groundShadow.test.ts
+++ b/gui/src/utils/groundShadow.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  ELEVATION_FALLOFF_FLOOR,
+  GROUND_EPSILON,
+  INVALID_LINE_COLOR,
+  INVALID_LINE_OPACITY,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_LINE_OPACITY,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+  elevationFactor,
+  shadowVisuals,
+  shouldRenderShadow,
+} from "./groundShadow";
+
+describe("shouldRenderShadow", () => {
+  it.each<[number, boolean, string]>([
+    [0, false, "exactly on ground"],
+    [GROUND_EPSILON, false, "exactly at GROUND_EPSILON"],
+    [0.001, true, "just above epsilon"],
+    [1, true, "z=1 cube above ground"],
+    [30, true, "very tall block"],
+    [-1, false, "below ground (defensive)"],
+    [-0.5, false, "Y-cube below ground (defensive)"],
+  ])("z=%s -> %s (%s)", (z, expected) => {
+    expect(shouldRenderShadow({ x: 0, y: 0, z })).toBe(expected);
+  });
+});
+
+describe("elevationFactor", () => {
+  it("returns 1 at z=0 (no fade below z=1)", () => {
+    expect(elevationFactor(0)).toBe(1);
+  });
+
+  it("returns 1 at z=1 (full opacity baseline)", () => {
+    expect(elevationFactor(1)).toBe(1);
+  });
+
+  it("decreases monotonically between z=1 and z=30", () => {
+    let prev = elevationFactor(1);
+    for (let z = 2; z <= 30; z++) {
+      const cur = elevationFactor(z);
+      expect(cur).toBeLessThanOrEqual(prev);
+      prev = cur;
+    }
+  });
+
+  it("hits the floor at high z and stays there", () => {
+    // Pure formula at z=30 = 1/3.32 = 0.301, just above floor.
+    // Floor engages around z=30.17. Test slightly past that point.
+    expect(elevationFactor(31)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(50)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(100)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("floors at ELEVATION_FALLOFF_FLOOR even at z=10000", () => {
+    expect(elevationFactor(10000)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("z=8 ~ 0.61 (sanity-check the curve)", () => {
+    expect(elevationFactor(8)).toBeCloseTo(0.6410, 3);
+  });
+
+  it("z=16 ~ 0.45", () => {
+    expect(elevationFactor(16)).toBeCloseTo(0.4545, 3);
+  });
+});
+
+describe("shadowVisuals", () => {
+  describe("footprint sizing", () => {
+    it("centers a 1x1 cube at (pos.x + 0.5, -(pos.y + 0.5))", () => {
+      const v = shadowVisuals({ x: 3, y: 6, z: 2 }, "XZZ", true);
+      expect(v.cx).toBe(3.5);
+      expect(v.cz).toBe(-6.5);
+    });
+
+    it("uses 2x1 footprint for X-open pipe (OZX): cx offset 1, cz offset 0.5", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "OZX", true);
+      // OZX is [2, 1, 1] in TQEC -> ground footprint sx=2, sy=1
+      expect(v.cx).toBe(1);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x2 footprint for Y-open pipe (ZOX): cx offset 0.5, cz offset 1", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZOX", true);
+      // ZOX is [1, 2, 1] in TQEC -> ground footprint sx=1, sy=2
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-1);
+    });
+
+    it("uses 1x1 footprint for Z-open pipe (ZXO)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZXO", true);
+      // ZXO is [1, 1, 2] in TQEC -> ground footprint sx=1, sy=1 (z is open axis)
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x1 footprint for Y half-cube (sz=0.5 ignored for ground)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+  });
+
+  describe("lineLen", () => {
+    it("uses pos.z (block bottom), not pos.z + sz (block top)", () => {
+      // Y half-cube at z=2: top is at 2.5, but lineLen must use 2.
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.lineLen).toBeCloseTo(2 - Y_OFFSET, 6);
+    });
+
+    it("computes correctly for a tall block", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.lineLen).toBeCloseTo(8 - Y_OFFSET, 6);
+    });
+  });
+
+  describe("opacity & elevation falloff", () => {
+    it("applies falloff to valid mesh+line opacity", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * elevationFactor(8), 6);
+      expect(v.lineOpacity).toBeCloseTo(VALID_LINE_OPACITY * elevationFactor(8), 6);
+    });
+
+    it("does NOT apply falloff when valid=false (full strength)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 30 }, "XZZ", false);
+      expect(v.meshOpacity).toBe(INVALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(INVALID_LINE_OPACITY);
+    });
+
+    it("at z=1, valid mesh opacity == VALID_MESH_OPACITY (no fade)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 1 }, "XZZ", true);
+      expect(v.meshOpacity).toBe(VALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(VALID_LINE_OPACITY);
+    });
+
+    it("at high z, valid mesh opacity hits floor (30% of base)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 50 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * ELEVATION_FALLOFF_FLOOR, 6);
+    });
+  });
+
+  describe("colors", () => {
+    it("uses #000/#000 for valid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", true);
+      expect(v.meshColor).toBe(VALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(VALID_LINE_COLOR);
+    });
+
+    it("uses #ff5555/#ff0000 for invalid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", false);
+      expect(v.meshColor).toBe(INVALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(INVALID_LINE_COLOR);
+    });
+  });
+});

--- a/gui/src/utils/groundShadow.ts
+++ b/gui/src/utils/groundShadow.ts
@@ -1,0 +1,77 @@
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+
+export const GROUND_EPSILON = 1e-4;
+export const Y_OFFSET = 0.01;
+export const ELEVATION_FALLOFF_FLOOR = 0.30;
+
+// Match DragGhost's red palette for invalid:
+//   shadow color #ff5555 (DragGhost mesh, gui/src/components/DragGhost.tsx:23)
+//   line   color #ff0000 (DragGhost edges, gui/src/components/DragGhost.tsx:30)
+export const VALID_MESH_OPACITY = 0.28;
+export const INVALID_MESH_OPACITY = 0.30;
+export const VALID_LINE_OPACITY = 0.22;
+export const INVALID_LINE_OPACITY = 0.28;
+
+export const VALID_SHADOW_COLOR = 0x000000;
+export const INVALID_SHADOW_COLOR = 0xff5555;
+export const VALID_LINE_COLOR = 0x000000;
+export const INVALID_LINE_COLOR = 0xff0000;
+
+/** True when the block is sufficiently above the ground to deserve a shadow. */
+export function shouldRenderShadow(pos: Position3D): boolean {
+  return pos.z > GROUND_EPSILON;
+}
+
+/**
+ * Elevation falloff factor. Asymptotic, floored at ELEVATION_FALLOFF_FLOOR
+ * so the shadow always remains visible even on very tall TQEC graphs.
+ *  z=1  -> 1.00   (full)
+ *  z=8  -> 0.64
+ *  z=16 -> 0.45
+ *  z=30 -> 0.30   (floor)
+ */
+export function elevationFactor(z: number): number {
+  const raw = 1 / (1 + Math.max(0, z - 1) * 0.08);
+  return Math.max(raw, ELEVATION_FALLOFF_FLOOR);
+}
+
+export interface ShadowVisuals {
+  cx: number;
+  cz: number;
+  lineLen: number;
+  meshOpacity: number;
+  lineOpacity: number;
+  meshColor: number;
+  lineColor: number;
+}
+
+/**
+ * Derive everything a GroundShadowAbsolute needs to render from inputs.
+ *
+ * Coordinate convention: TQEC pos.z is the block's bottom in three.js Y
+ * (since tqecToThree maps TQEC Z -> three.js Y and adds sz/2 from the base).
+ * The shadow's ground-plane center is offset by sx/2, sy/2 from pos in the
+ * XZ plane (with TQEC Y negated to match three.js -Z).
+ *
+ * NOTE: caller is responsible for the shouldRenderShadow gate; this fn
+ * computes visuals unconditionally so tests can exercise the math at z=0.
+ */
+export function shadowVisuals(
+  pos: Position3D,
+  blockType: BlockType,
+  valid: boolean,
+): ShadowVisuals {
+  const [sx, sy] = blockTqecSize(blockType);
+  // Valid shadows fade with elevation; invalid stays full strength so the
+  // conflict signal remains legible at any height.
+  const fade = valid ? elevationFactor(pos.z) : 1;
+  return {
+    cx: pos.x + sx / 2,
+    cz: -(pos.y + sy / 2),
+    lineLen: pos.z - Y_OFFSET,
+    meshOpacity: (valid ? VALID_MESH_OPACITY : INVALID_MESH_OPACITY) * fade,
+    lineOpacity: (valid ? VALID_LINE_OPACITY : INVALID_LINE_OPACITY) * fade,
+    meshColor: valid ? VALID_SHADOW_COLOR : INVALID_SHADOW_COLOR,
+    lineColor: valid ? VALID_LINE_COLOR : INVALID_LINE_COLOR,
+  };
+}

--- a/gui/src/utils/sceneShare.test.ts
+++ b/gui/src/utils/sceneShare.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { Block } from "../types";
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import {
+  buildShareUrl,
+  decodeSnapshotFromHash,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+  parseSceneHashParam,
+} from "./sceneShare";
+
+function snapshot(
+  blocks: Array<[string, Block]> = [],
+  portMeta: SceneSnapshotV1["portMeta"] = [],
+  portPositions: string[] = [],
+): SceneSnapshotV1 {
+  return { v: 1, blocks, portMeta, portPositions };
+}
+
+describe("parseSceneHashParam", () => {
+  it("extracts the scene parameter from various hash forms", () => {
+    expect(parseSceneHashParam("#scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("?scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#foo=1&scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#scene=abc&foo=1")).toBe("abc");
+    expect(parseSceneHashParam("https://x.test/app#scene=abc")).toBe("abc");
+  });
+
+  it("returns null when no scene param is present", () => {
+    expect(parseSceneHashParam("")).toBe(null);
+    expect(parseSceneHashParam("#")).toBe(null);
+    expect(parseSceneHashParam("#otherkey=value")).toBe(null);
+    expect(parseSceneHashParam("scenefoo=bar")).toBe(null);
+  });
+});
+
+describe("buildShareUrl", () => {
+  it("appends the encoded payload to the supplied base", () => {
+    expect(buildShareUrl("xyz", "https://app.test/")).toBe(
+      "https://app.test/#scene=xyz",
+    );
+  });
+});
+
+const compressionAvailable = isCompressionStreamSupported();
+const skipIfNoCompression = compressionAvailable ? describe : describe.skip;
+
+skipIfNoCompression("encode/decode round-trip", () => {
+  it("round-trips an empty scene", async () => {
+    const original = snapshot();
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a small scene with port meta and ranks", async () => {
+    const blocks: Array<[string, Block]> = [
+      ["0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" }],
+      ["3,0,0", { pos: { x: 3, y: 0, z: 0 }, type: "OZX" }],
+      ["6,0,0", { pos: { x: 6, y: 0, z: 0 }, type: "ZXZ" }],
+    ];
+    const original = snapshot(
+      blocks,
+      [
+        ["0,0,0", { label: "P1", io: "in", rank: 0 }],
+        ["6,0,0", { label: "P2", io: "out", rank: 1 }],
+      ],
+      ["0,0,0", "6,0,0"],
+    );
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a 200-block scene and produces base64url-safe output", async () => {
+    const blocks: Array<[string, Block]> = [];
+    for (let i = 0; i < 200; i++) {
+      const x = (i % 20) * 3;
+      const z = Math.floor(i / 20) * 3;
+      blocks.push([`${x},0,${z}`, { pos: { x, y: 0, z }, type: "XZZ" }]);
+    }
+    const original = snapshot(blocks);
+    const encoded = await encodeSnapshotToHashParam(original);
+    expect(/^[A-Za-z0-9_-]+$/.test(encoded)).toBe(true);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("returns null for a malformed base64 payload", async () => {
+    expect(await decodeSnapshotFromHash("#scene=!!!not-base64")).toBe(null);
+  });
+
+  it("returns null when valid base64 is not deflate-compressed", async () => {
+    expect(await decodeSnapshotFromHash("#scene=aGVsbG8")).toBe(null);
+  });
+
+  it("returns null when the decoded JSON has the wrong shape", async () => {
+    const wrongShape = await encodeSnapshotToHashParam({
+      v: 1,
+      blocks: "not-an-array" as unknown as never,
+      portMeta: [],
+      portPositions: [],
+    } as SceneSnapshotV1);
+    expect(await decodeSnapshotFromHash(`#scene=${wrongShape}`)).toBe(null);
+  });
+
+  it("returns null when there is no scene param", async () => {
+    expect(await decodeSnapshotFromHash("#nothing-here")).toBe(null);
+  });
+});

--- a/gui/src/utils/sceneShare.ts
+++ b/gui/src/utils/sceneShare.ts
@@ -1,0 +1,99 @@
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import { isSceneSnapshotV1 } from "./sceneSnapshot";
+
+export const SCENE_HASH_KEY = "scene";
+
+const COMPRESSION_FORMAT = "deflate-raw" as const;
+
+export function isCompressionStreamSupported(): boolean {
+  return (
+    typeof CompressionStream !== "undefined" &&
+    typeof DecompressionStream !== "undefined"
+  );
+}
+
+async function runStream(
+  input: Uint8Array,
+  transform: GenericTransformStream,
+): Promise<Uint8Array> {
+  const writer = transform.writable.getWriter();
+  // Swallow writer-side rejections so they don't become unhandled. The
+  // canonical error surface is the readable side, which the caller awaits.
+  writer.write(input).catch(() => {});
+  writer.close().catch(() => {});
+  const buf = await new Response(transform.readable).arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+async function compress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new CompressionStream(COMPRESSION_FORMAT));
+}
+
+async function decompress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new DecompressionStream(COMPRESSION_FORMAT));
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  // Chunk to keep apply() argument count safe across engines.
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+  const padded = s.replaceAll("-", "+").replaceAll("_", "/");
+  const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const binary = atob(padded + pad);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export async function encodeSnapshotToHashParam(
+  snapshot: SceneSnapshotV1,
+): Promise<string> {
+  const json = JSON.stringify(snapshot);
+  const compressed = await compress(new TextEncoder().encode(json));
+  return bytesToBase64Url(compressed);
+}
+
+/**
+ * Accepts any of: "#scene=xyz", "scene=xyz", "?scene=xyz", "&scene=xyz",
+ * or a full URL containing "scene=xyz". Returns the value, or null if
+ * no `scene` parameter is present.
+ */
+export function parseSceneHashParam(hashOrUrl: string): string | null {
+  const re = /(?:^|[#?&])scene=([^&]*)/;
+  const match = re.exec(hashOrUrl);
+  if (!match || !match[1]) return null;
+  return match[1];
+}
+
+export async function decodeSnapshotFromHash(
+  hashOrUrl: string,
+): Promise<SceneSnapshotV1 | null> {
+  const param = parseSceneHashParam(hashOrUrl);
+  if (!param) return null;
+  try {
+    const bytes = base64UrlToBytes(param);
+    const decompressed = await decompress(bytes);
+    const json = new TextDecoder().decode(decompressed);
+    const parsed: unknown = JSON.parse(json);
+    if (!isSceneSnapshotV1(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function buildShareUrl(hashParam: string, base?: string): string {
+  const b =
+    base ??
+    (typeof window !== "undefined"
+      ? window.location.origin + window.location.pathname + window.location.search
+      : "");
+  return `${b}#${SCENE_HASH_KEY}=${hashParam}`;
+}

--- a/gui/src/utils/sceneSnapshot.ts
+++ b/gui/src/utils/sceneSnapshot.ts
@@ -1,0 +1,69 @@
+import type { Block, PortMeta } from "../types";
+import { useBlockStore } from "../stores/blockStore";
+
+export const SCENE_SCHEMA_VERSION = 1;
+
+export interface SceneSnapshotV1 {
+  v: 1;
+  blocks: Array<[string, Block]>;
+  portMeta: Array<[string, PortMeta]>;
+  portPositions: string[];
+}
+
+export function captureSnapshot(): SceneSnapshotV1 {
+  const s = useBlockStore.getState();
+  return {
+    v: 1,
+    blocks: Array.from(s.blocks.entries()),
+    portMeta: Array.from(s.portMeta.entries()),
+    portPositions: Array.from(s.portPositions),
+  };
+}
+
+export function snapshotIsEmpty(snapshot: SceneSnapshotV1): boolean {
+  return snapshot.blocks.length === 0;
+}
+
+export function isSceneSnapshotV1(value: unknown): value is SceneSnapshotV1 {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<SceneSnapshotV1>;
+  if (v.v !== 1) return false;
+  if (!Array.isArray(v.blocks) || !Array.isArray(v.portMeta) || !Array.isArray(v.portPositions)) {
+    return false;
+  }
+  for (const entry of v.blocks) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const block = entry[1] as Partial<Block> | undefined;
+    if (!block || typeof block !== "object") return false;
+    if (typeof block.type !== "string") return false;
+    if (!block.pos || typeof block.pos !== "object") return false;
+    const { x, y, z } = block.pos;
+    if (typeof x !== "number" || typeof y !== "number" || typeof z !== "number") return false;
+  }
+  for (const entry of v.portMeta) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const meta = entry[1] as Partial<PortMeta> | undefined;
+    if (!meta || typeof meta.label !== "string") return false;
+    if (meta.io !== "in" && meta.io !== "out") return false;
+  }
+  for (const p of v.portPositions) {
+    if (typeof p !== "string") return false;
+  }
+  return true;
+}
+
+export type ApplyMode = "load" | "hydrate";
+
+export function applySnapshot(snapshot: SceneSnapshotV1, mode: ApplyMode = "hydrate"): void {
+  const store = useBlockStore.getState();
+  const blocks = new Map<string, Block>(snapshot.blocks);
+  if (mode === "load") store.loadBlocks(blocks);
+  else store.hydrateBlocks(blocks);
+  useBlockStore.setState({
+    portMeta: new Map(snapshot.portMeta),
+    portPositions: new Set(snapshot.portPositions),
+  });
+  useBlockStore.getState().ensurePortLabels();
+}

--- a/gui/src/utils/validate.test.ts
+++ b/gui/src/utils/validate.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { validateDiagram } from "./validate";
+import type { Block, FreeBuildPipeSpec } from "../types";
+
+const FB_SPEC: FreeBuildPipeSpec = {
+  kind: "fb-pipe",
+  openAxis: 2,
+  baseAtStart: "Z",
+  baseAtEnd: "X",
+  defectPositions: [0.5],
+};
+
+describe("validateDiagram", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ valid: true, errors: [] }),
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("strips free-build blocks from the request payload (defense-in-depth)", async () => {
+    const blocks = new Map<string, Block>();
+    blocks.set("0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" as Block["type"] });
+    blocks.set("0,0,1", { pos: { x: 0, y: 0, z: 1 }, type: FB_SPEC });
+    blocks.set("0,0,3", { pos: { x: 0, y: 0, z: 3 }, type: "ZXZ" as Block["type"] });
+
+    await validateDiagram(blocks);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    const init = call[1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { blocks: Array<{ pos: number[]; type: string }> };
+    // Only the two TQEC cubes should be in the payload.
+    expect(body.blocks).toHaveLength(2);
+    const types = body.blocks.map((b) => b.type).sort();
+    expect(types).toEqual(["XZZ", "ZXZ"]);
+    // No `[object Object]` artifact — FB pipes should never be stringified
+    // into the request body.
+    expect(init.body).not.toContain("object Object");
+  });
+
+  it("passes through TQEC-only scenes unchanged", async () => {
+    const blocks = new Map<string, Block>();
+    blocks.set("0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" as Block["type"] });
+    blocks.set("0,0,3", { pos: { x: 0, y: 0, z: 3 }, type: "ZXZ" as Block["type"] });
+
+    await validateDiagram(blocks);
+
+    const call = fetchMock.mock.calls[0];
+    const init = call[1] as RequestInit;
+    const body = JSON.parse(init.body as string) as { blocks: unknown[] };
+    expect(body.blocks).toHaveLength(2);
+  });
+});

--- a/gui/src/utils/validate.test.ts
+++ b/gui/src/utils/validate.test.ts
@@ -5,9 +5,8 @@ import type { Block, FreeBuildPipeSpec } from "../types";
 const FB_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 2,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["XZ", "XZ", "XZ", "XZ"],
 };
 
 describe("validateDiagram", () => {

--- a/gui/src/utils/validate.ts
+++ b/gui/src/utils/validate.ts
@@ -1,4 +1,5 @@
 import type { Block } from "../types";
+import { isFreeBuildBlock } from "../types";
 
 export interface ValidationErrorItem {
   position: [number, number, number] | null;
@@ -13,10 +14,15 @@ export interface ValidationResult {
 export async function validateDiagram(
   blocks: Map<string, Block>,
 ): Promise<ValidationResult> {
-  const payload = Array.from(blocks.values()).map((b) => ({
-    pos: [b.pos.x, b.pos.y, b.pos.z],
-    type: b.type,
-  }));
+  // Defense-in-depth: drop free-build (non-TQEC) pieces before sending to the
+  // backend. The Verify button is disabled when FB blocks are present; this
+  // filter is a safety net for programmatic callers.
+  const payload = Array.from(blocks.values())
+    .filter((b) => !isFreeBuildBlock(b))
+    .map((b) => ({
+      pos: [b.pos.x, b.pos.y, b.pos.z],
+      type: b.type as string,
+    }));
 
   try {
     const res = await fetch("/api/validate", {

--- a/gui/src/utils/zx.test.ts
+++ b/gui/src/utils/zx.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { Block, BlockType, PipeType } from "../types";
+import { filterFreeBuildPipes } from "./zx";
+
+function makeBlocks(entries: Array<{ x: number; y: number; z: number; type: BlockType }>) {
+  const m = new Map<string, Block>();
+  for (const e of entries) {
+    m.set(`${e.x},${e.y},${e.z}`, { pos: { x: e.x, y: e.y, z: e.z }, type: e.type });
+  }
+  return m;
+}
+
+describe("filterFreeBuildPipes", () => {
+  it("keeps a fully color-consistent cube–pipe–cube line intact", () => {
+    // OXZ pipe (axis 1='X', axis 2='Z'); ZXZ cubes both ends agree.
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "ZXZ" as BlockType },
+      { x: 1, y: 0, z: 0, type: "OXZ" as BlockType },
+      { x: 3, y: 0, z: 0, type: "ZXZ" as BlockType },
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(0);
+    expect(kept).toHaveLength(3);
+  });
+
+  it("drops a pipe whose colors disagree with adjacent cubes", () => {
+    // OZX pipe needs axis 1='Z', axis 2='X'; cube XZZ has axis 2='Z' → mismatch.
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "XZZ" as BlockType },
+      { x: 1, y: 0, z: 0, type: "OZX" as PipeType as BlockType },
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(1);
+    expect(kept.map((b) => b.type)).toEqual(["XZZ"]);
+  });
+
+  it("only drops the mismatched pipe, keeps a valid sibling pipe", () => {
+    // Valid cube/pipe along +X and a separate mismatched pipe attached to a
+    // different cube along +Y.
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "ZXZ" as BlockType },
+      { x: 1, y: 0, z: 0, type: "OXZ" as BlockType }, // valid
+      { x: 3, y: 0, z: 0, type: "ZXZ" as BlockType },
+      { x: 9, y: 0, z: 0, type: "XZZ" as BlockType },
+      { x: 9, y: 1, z: 0, type: "ZOX" as PipeType as BlockType }, // mismatch
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(1);
+    expect(kept).toHaveLength(4);
+    expect(kept.find((b) => b.pos.x === 9 && b.pos.y === 1)).toBeUndefined();
+  });
+
+  it("never excludes cubes", () => {
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "XZZ" as BlockType },
+      { x: 3, y: 0, z: 0, type: "ZXZ" as BlockType },
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(0);
+    expect(kept).toHaveLength(2);
+  });
+});

--- a/gui/src/utils/zx.ts
+++ b/gui/src/utils/zx.ts
@@ -73,7 +73,7 @@ export async function computeZX(
     }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) {

--- a/gui/src/utils/zx.ts
+++ b/gui/src/utils/zx.ts
@@ -1,4 +1,5 @@
 import type { Block, Position3D, PortMeta } from "../types";
+import { isFreeBuildBlock } from "../types";
 
 export type ZXVertexKind = "Z" | "X" | "H" | "BOUNDARY";
 
@@ -62,10 +63,14 @@ export async function computeZX(
   simplify: boolean,
   extract: boolean = false,
 ): Promise<ZXResult> {
-  const blocksPayload = Array.from(blocks.values()).map((b) => ({
-    pos: [b.pos.x, b.pos.y, b.pos.z],
-    type: b.type,
-  }));
+  // Defense-in-depth: drop free-build (non-TQEC) blocks before sending to
+  // the backend. ZX requires a TQEC scene; FB pieces don't have a ZX semantic.
+  const blocksPayload = Array.from(blocks.values())
+    .filter((b) => !isFreeBuildBlock(b))
+    .map((b) => ({
+      pos: [b.pos.x, b.pos.y, b.pos.z],
+      type: b.type as string,
+    }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
     return { pos: [p.x, p.y, p.z], label: meta.label };

--- a/gui/src/utils/zx.ts
+++ b/gui/src/utils/zx.ts
@@ -1,5 +1,5 @@
+import { hasPipeColorConflict, isFreeBuildBlock, isPipeType } from "../types";
 import type { Block, Position3D, PortMeta } from "../types";
-import { isFreeBuildBlock } from "../types";
 
 export type ZXVertexKind = "Z" | "X" | "H" | "BOUNDARY";
 
@@ -50,11 +50,37 @@ export interface ZXResult {
   circuit: ZXCircuit | null;
   circuit_error: string | null;
   error: string | null;
+  /** Pipes whose colors don't agree with adjacent cubes — silently dropped
+   *  from the /api/zx payload so TQEC validation can still succeed on the
+   *  rest of the diagram. Zero when none were dropped. */
+  excludedFreeBuildPipes: number;
 }
 
 function posFromKey(key: string): Position3D {
   const [x, y, z] = key.split(",").map(Number);
   return { x, y, z };
+}
+
+/**
+ * Drop pipes that disagree with adjacent cube colors. These are "free build"
+ * pipes — the rest of the diagram is still TQEC-valid, so we ship the subset
+ * to /api/zx and report how many we excluded so the panel can surface a
+ * notice.
+ */
+export function filterFreeBuildPipes(blocks: Map<string, Block>): {
+  kept: Block[];
+  excluded: number;
+} {
+  const kept: Block[] = [];
+  let excluded = 0;
+  for (const b of blocks.values()) {
+    if (isPipeType(b.type) && hasPipeColorConflict(b.type, b.pos, blocks)) {
+      excluded++;
+      continue;
+    }
+    kept.push(b);
+  }
+  return { kept, excluded };
 }
 
 export async function computeZX(
@@ -63,14 +89,19 @@ export async function computeZX(
   simplify: boolean,
   extract: boolean = false,
 ): Promise<ZXResult> {
-  // Defense-in-depth: drop free-build (non-TQEC) blocks before sending to
-  // the backend. ZX requires a TQEC scene; FB pieces don't have a ZX semantic.
-  const blocksPayload = Array.from(blocks.values())
-    .filter((b) => !isFreeBuildBlock(b))
-    .map((b) => ({
-      pos: [b.pos.x, b.pos.y, b.pos.z],
-      type: b.type as string,
-    }));
+  // Two filters compose. First drop free-build (non-TQEC) blocks — they have
+  // no ZX semantic and the backend can't model them. Then run the color-
+  // conflict filter on the TQEC remainder to catch mismatched TQEC pipes
+  // (e.g. placed under "Ignore color rules"); the count surfaces in the panel.
+  const tqecOnly = new Map<string, Block>();
+  for (const [k, b] of blocks) {
+    if (!isFreeBuildBlock(b)) tqecOnly.set(k, b);
+  }
+  const { kept, excluded } = filterFreeBuildPipes(tqecOnly);
+  const blocksPayload = kept.map((b) => ({
+    pos: [b.pos.x, b.pos.y, b.pos.z],
+    type: b.type as string,
+  }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
     return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
@@ -102,9 +133,11 @@ export async function computeZX(
         circuit: null,
         circuit_error: null,
         error: `Server error: ${res.status}`,
+        excludedFreeBuildPipes: excluded,
       };
     }
-    return (await res.json()) as ZXResult;
+    const json = (await res.json()) as Omit<ZXResult, "excludedFreeBuildPipes">;
+    return { ...json, excludedFreeBuildPipes: excluded };
   } catch {
     return {
       ok: false,
@@ -115,6 +148,7 @@ export async function computeZX(
       circuit: null,
       circuit_error: null,
       error: "ZX server unavailable. Start with: npm run dev:backend",
+      excludedFreeBuildPipes: excluded,
     };
   }
 }

--- a/gui/vitest.config.ts
+++ b/gui/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });

--- a/server.py
+++ b/server.py
@@ -56,6 +56,10 @@ class BlockInput(BaseModel):
 class PortLabelInput(BaseModel):
     pos: list[float]
     label: str
+    # User-defined display rank from the Ports table. Lower ranks come first.
+    # When provided, the /api/zx endpoint sorts the extracted circuit's qubit
+    # register by this value so it matches the order shown in the GUI.
+    rank: int | None = None
 
 
 class ValidateRequest(BaseModel):
@@ -450,8 +454,26 @@ async def flows(req: FlowsRequest) -> FlowsResponse:
             error="Diagram has no open ports",
         )
 
-    inputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "in"]
-    outputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "out"]
+    # Sort by user-defined rank from the Ports table (matches /api/zx) so the
+    # qubit-register position when this diagram is interpreted as a circuit
+    # follows the GUI order. Unranked ports fall through to TQEC's
+    # alphabetical order.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _flows_sort_key(label: str) -> tuple[int, str]:
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    inputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "in"),
+        key=_flows_sort_key,
+    )
+    outputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "out"),
+        key=_flows_sort_key,
+    )
 
     try:
         surfaces = graph.find_correlation_surfaces()
@@ -535,6 +557,21 @@ async def zx(req: ZXRequest) -> ZXResponse:
             io = req.port_io.get(cube.label, "in")
             (output_vs if io == "out" else input_vs).append(v)
 
+    # Sort input/output vertex lists by user-defined rank from the Ports table
+    # so the extracted circuit's qubit register matches the GUI order.
+    # Unranked ports sort last, then alphabetically by label.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _port_sort_key(v: int) -> tuple[int, str]:
+        label = port_label_by_vertex.get(v, "")
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    input_vs.sort(key=_port_sort_key)
+    output_vs.sort(key=_port_sort_key)
+
     # Register boundary vertices as pyzx inputs/outputs (required by
     # pyzx.extract_circuit, harmless otherwise).
     if input_vs:
@@ -549,8 +586,13 @@ async def zx(req: ZXRequest) -> ZXResponse:
     if req.simplify:
         pyzx.simplify.full_reduce(pzx.g)
         # normalize() places inputs/outputs at sensible (qubit, row) — required
-        # before extract_circuit and nicer for display.
-        pzx.g.normalize()
+        # before extract_circuit and nicer for display. Skip it when only
+        # outputs are set: pyzx.normalize() invokes auto_detect_io() whenever
+        # num_inputs() == 0, which clobbers our explicit outputs and raises
+        # TypeError on boundary vertices that share a row with their neighbor
+        # (issue #221). Frontend falls back to a circle layout in that case.
+        if pzx.g.num_inputs() > 0 or pzx.g.num_outputs() == 0:
+            pzx.g.normalize()
 
     circuit_info: ZXCircuit | None = None
     circuit_error: str | None = None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -378,6 +378,54 @@ class TestZXEndpoint:
         assert simplified["simplified"] is True
         assert len(simplified["vertices"]) <= len(raw["vertices"])
 
+    def test_simplify_with_all_output_ports(self):
+        # Regression for #221: full_reduce + normalize raised TypeError when
+        # every port was marked 'out', because pyzx auto_detect_io fires
+        # whenever num_inputs() == 0 and can't classify boundary vertices that
+        # share a row with their neighbor.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "out", "P2": "out"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+        assert result["simplified"] is True
+        # Both output boundaries should survive full_reduce.
+        assert len(result["vertices"]) == 2
+
+    def test_simplify_with_all_input_ports(self):
+        # Sister case to test_simplify_with_all_output_ports: locks in that
+        # all-input diagrams keep working, since pyzx's auto_detect_io guard
+        # only triggers when num_inputs() == 0.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "in", "P2": "in"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+
     def test_invalid_diagram_returns_error(self):
         # Mismatched pipe colors -> tqec validation error surfaces
         result = self._run(
@@ -675,6 +723,74 @@ class TestZXEndpoint:
         assert result["ok"] is True
         labels = {v["label"] for v in result["vertices"] if v["label"]}
         assert labels == {"a", "b"}
+
+    def test_extract_qubit_register_follows_port_rank(self):
+        # Two parallel identity chains → 2 inputs, 2 outputs. The qubit-index
+        # of each input is determined by the user-defined rank on PortLabelInput
+        # (matching the Ports table order), not by alphabetical label sort.
+        # Swapping the ranks must swap which port maps to qubit 0.
+        blocks = [
+            # Chain 1 at y=0
+            BlockInput(pos=[0, 0, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 0, 0], type="OXZ"),
+            BlockInput(pos=[1, 0, 0], type="OXZ"),
+            # Chain 2 at y=3
+            BlockInput(pos=[0, 3, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 3, 0], type="OXZ"),
+            BlockInput(pos=[1, 3, 0], type="OXZ"),
+        ]
+        port_io = {"a_in": "in", "a_out": "out", "b_in": "in", "b_out": "out"}
+
+        def qubit_of_input_label(result: dict, label: str) -> int:
+            # After extract, vertex pos is [row, 0, -qubit]; inputs land at the
+            # smallest row in the layout. Find the vertex carrying `label` and
+            # return its qubit index.
+            for v in result["vertices"]:
+                if v["label"] == label and v["pos"] is not None:
+                    return int(round(-v["pos"][2]))
+            raise AssertionError(f"no vertex labelled {label!r}")
+
+        # Case A: rank a_in=0, b_in=1 → a_in is qubit 0, b_in is qubit 1.
+        port_labels_a = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=0),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=1),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_a = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_a,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_a["ok"] is True, result_a
+        assert result_a["circuit_error"] is None, result_a["circuit_error"]
+        assert qubit_of_input_label(result_a, "a_in") == 0
+        assert qubit_of_input_label(result_a, "b_in") == 1
+
+        # Case B: swap input ranks → b_in is now qubit 0, a_in is qubit 1.
+        port_labels_b = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=1),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=0),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_b = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_b,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_b["ok"] is True, result_b
+        assert result_b["circuit_error"] is None, result_b["circuit_error"]
+        assert qubit_of_input_label(result_b, "a_in") == 1
+        assert qubit_of_input_label(result_b, "b_in") == 0
 
     def test_extract_without_outputs_errors(self):
         result = self._run(


### PR DESCRIPTION
## Summary
- Adds **free-build pipes**: non-TQEC color-swap pipes parameterized by Y-defect positions (excluded from `.dae` export and TQEC validation, gated behind a freeBuild toggle).
- Ships 4 toolbar presets — full-swap **Z→X / X→Z** (all 4 walls flip at the midpoint) and half-swap **Z→X½ / X→Z½** (only one opposite-wall pair flips, the other stays solid).
- Snaps to ports/cubes the same way regular pipes do, and participates in attached-pipe accounting so cube cascade-deletes and port conversions correctly account for FB pipes.
- Refactors `createYDefectEdges` to walk per-defect basis segments — corner cylinders only span runs where adjacent walls hold different bases, and ring segments only cover walls whose closed axis actually swaps.

## Test plan
- [ ] Toggle freeBuild in settings, place full-swap and half-swap pipes off ports/cubes/empty grid in build and edit modes
- [ ] Verify Y-defect overlay shows full-length corner cylinders + 4-segment ring on full-swap pipes, and half-length corners + 2-segment ring on half-swap pipes
- [ ] Cascade-delete a cube with FB pipes attached; verify pipes are removed
- [ ] Confirm `.dae` export still excludes FB pipes (TQEC graphs round-trip clean)

🧙 Built with [WOZCODE](https://wozcode.com)