### PR TITLE
feat: deploy dev branch to piper-draw-dev.walruscomputing.com

### DIFF
--- a/.github/workflows/fly-deploy-dev.yml
+++ b/.github/workflows/fly-deploy-dev.yml
@@ -1,0 +1,35 @@
+name: Dev Deploy
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency: deploy-dev-group
+    steps:
+      - uses: actions/checkout@v6
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only --config fly.dev.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+
+  smoke-test:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe dev for HTTP 200
+        run: |
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" https://piper-draw-dev.fly.dev/)
+            if [ "$code" = "200" ]; then
+              echo "OK: got 200"
+              exit 0
+            fi
+            echo "attempt $i: got $code, retrying in 10s..."
+            sleep 10
+          done
+          echo "FAIL: dev never returned 200"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 ## Branching strategy
 
 - **`dev`** is the integration branch. All pull requests should target `dev`.
-- **`main`** is the stable/release branch. Changes are merged from `dev` into `main` for releases.
+  Merges to `dev` auto-deploy to <https://piper-draw-dev.walruscomputing.com>.
+- **`main`** is the stable/release branch. Changes are merged from `dev` into
+  `main` for releases. Merges to `main` auto-deploy to
+  <https://piper-draw.walruscomputing.com>.
 
 ## How to contribute
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: build the Vite/React frontend
 FROM node:22-slim AS frontend
+ARG VITE_UMAMI_WEBSITE_ID
+ENV VITE_UMAMI_WEBSITE_ID=${VITE_UMAMI_WEBSITE_ID}
 WORKDIR /app/gui
 COPY gui/package.json gui/package-lock.json ./
 RUN npm ci

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,0 +1,19 @@
+# Fly.io config for the piper-draw dev release (deploys from the `dev` branch).
+# Mirrors fly.toml; only `app` differs.
+
+app = "piper-draw-dev"
+primary_region = "ams"
+
+[build]
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -5,6 +5,8 @@ app = "piper-draw-dev"
 primary_region = "ams"
 
 [build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "0d67b9da-dff1-45c2-844d-06b45ff00ff8"
 
 [http_service]
   internal_port = 8000

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,8 @@ app = "piper-draw"
 primary_region = "ams"
 
 [build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "c9fe90a4-6296-4b2d-b0bc-6b272b01786c"
 
 [http_service]
   internal_port = 8000

--- a/gui/index.html
+++ b/gui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Piper Draw</title>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="c9fe90a4-6296-4b2d-b0bc-6b272b01786c"></script>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="%VITE_UMAMI_WEBSITE_ID%"></script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- New Fly.io app config `fly.dev.toml` for a second app `piper-draw-dev` (mirrors `fly.toml`, only the app name differs).
- New `.github/workflows/fly-deploy-dev.yml` that auto-deploys on push to `dev` and smoke-tests the URL. Authenticates with a separate `FLY_API_TOKEN_DEV` secret so it can stay app-scoped without touching prod.
- `CONTRIBUTING.md` documents the new branch-to-URL mapping.

Production pipeline (`fly-deploy.yml`) is unchanged. Before this works end-to-end, the `piper-draw-dev` Fly app must exist, the `FLY_API_TOKEN_DEV` GitHub secret must be set, and a CNAME for `piper-draw-dev.walruscomputing.com → piper-draw-dev.fly.dev` must be added at the DNS provider.

## Test plan
- [ ] CI: `Dev Deploy` workflow runs on this branch's first push to `dev` and both `deploy` + `smoke-test` jobs pass.
- [ ] `curl -I https://piper-draw-dev.fly.dev/` returns `200`.
- [ ] After cert + DNS: `curl -I https://piper-draw-dev.walruscomputing.com/` returns `200` with a valid TLS cert.
- [ ] Production `piper-draw.walruscomputing.com` still serves `main` and the original `Main CI + Deploy` workflow did not run on the `dev` push.

🧙 Built with [WOZCODE](https://wozcode.com)