### PR TITLE
fix: allow selecting blocks below the ground plane from above

### DIFF
--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -18,6 +18,7 @@ import {
 } from "../types";
 import type { CubeType, Position3D, ViewMode } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
+import { shouldPassThroughGridPlane } from "../utils/gridPlanePassthrough";
 import { snapIsoPos, isoGridMeshTransform } from "../utils/isoView";
 
 const PLANE_SIZE = 1000;
@@ -61,6 +62,21 @@ export function GridPlane() {
   });
 
   const handlePointerMove = (e: ThreeEvent<PointerEvent>) => {
+    // Pass-through (pointer/paste only): when a block/port is also under the
+    // cursor, return early without stopProp so the block's onPointerMove sets
+    // hoveredGridPos. Done before any setHoveredGridPos call so we don't write
+    // the plane cell and let the block immediately overwrite it (one-frame
+    // flash on stacked hits).
+    if (mode === "edit") {
+      const s = useBlockStore.getState();
+      if (
+        !s.xHeld &&
+        (s.armedTool === "pointer" || s.armedTool === "paste") &&
+        shouldPassThroughGridPlane(e.intersections, meshRef.current)
+      ) {
+        return;
+      }
+    }
     e.stopPropagation();
     if (mode !== "edit") { setHoveredGridPos(null); return; }
 
@@ -120,17 +136,31 @@ export function GridPlane() {
   };
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {
-    e.stopPropagation();
-    if (e.delta > 2) return; // ignore drags
-    if (mode !== "edit") return;
+    if (e.delta > 2) { e.stopPropagation(); return; } // ignore drags
+    if (mode !== "edit") { e.stopPropagation(); return; }
 
     const store = useBlockStore.getState();
     // X-held delete on empty grid is a no-op.
-    if (store.xHeld) return;
+    if (store.xHeld) { e.stopPropagation(); return; }
+
     if (store.armedTool === "pointer") {
+      // Pass-through: when the click ray also hits a block or port ghost
+      // further along, let that handler own the event so sub-ground blocks
+      // (TQEC z<0) can be selected from above.
+      //
+      // NOTE: this couples deselect-on-empty-click policy to GridPlane. Any
+      // future clickable scene mesh must either opt out of raycast (the
+      // raycast={noRaycast} convention used by decoratives) or call
+      // e.stopPropagation() in its own onClick. Otherwise deselection would
+      // silently stop working through that mesh.
+      if (shouldPassThroughGridPlane(e.intersections, meshRef.current)) return;
+      e.stopPropagation();
       store.clearSelection();
       return;
     }
+    // Paste / port / placement: the plane is the intended target, so we
+    // always consume the click here.
+    e.stopPropagation();
     // Paste tool: commit the clipboard at the snapped hover cell, then
     // return to pointer (commitPaste sets armedTool="pointer").
     if (store.armedTool === "paste") {

--- a/gui/src/utils/gridPlanePassthrough.test.ts
+++ b/gui/src/utils/gridPlanePassthrough.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { shouldPassThroughGridPlane } from "./gridPlanePassthrough";
+
+const plane = new THREE.Mesh();
+const block = new THREE.Mesh();
+const port = new THREE.Mesh();
+const hit = (o: THREE.Object3D) => ({ object: o });
+
+describe("shouldPassThroughGridPlane", () => {
+  it("returns false when intersections is empty", () => {
+    expect(shouldPassThroughGridPlane([], plane)).toBe(false);
+  });
+
+  it("returns false when only the plane is hit", () => {
+    expect(shouldPassThroughGridPlane([hit(plane)], plane)).toBe(false);
+  });
+
+  it("returns true when a block is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(block)], plane)).toBe(true);
+  });
+
+  it("returns true when a port ghost is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(port)], plane)).toBe(true);
+  });
+
+  it("returns false when planeMesh is null (e.g., pre-mount frame)", () => {
+    expect(shouldPassThroughGridPlane([hit(block)], null)).toBe(false);
+  });
+});

--- a/gui/src/utils/gridPlanePassthrough.ts
+++ b/gui/src/utils/gridPlanePassthrough.ts
@@ -1,0 +1,31 @@
+import type { Intersection, Object3D } from "three";
+
+/**
+ * In select mode, GridPlane should bow out of clicks/hovers when the ray also
+ * hits another interactive mesh further along (a block or port ghost). Without
+ * this, the invisible plane at Three.js y=0 swallows clicks meant for blocks
+ * placed at TQEC z<0 (below the plane) when the camera looks down from above.
+ *
+ * Click chain (perspective, camera tilted down):
+ *
+ *   camera                  After fix:
+ *     │                       plane sees a non-plane hit in e.intersections
+ *     ▼                       → returns without stopProp/clearSelection
+ *   [GridPlane y=0]           → BlockInstances.handleClick runs
+ *     │                       → sub-ground block gets selected
+ *     ▼
+ *   [Block | Port]
+ *
+ * Returns true if any intersection's object is not the plane itself, meaning
+ * the next handler in the chain should own the event.
+ *
+ * Relies on the project convention that decorative meshes use raycast={noRaycast}
+ * so e.intersections only contains actually-clickable meshes.
+ */
+export function shouldPassThroughGridPlane(
+  intersections: ReadonlyArray<Pick<Intersection, "object">>,
+  planeMesh: Object3D | null,
+): boolean {
+  if (!planeMesh) return false;
+  return intersections.some((i) => i.object !== planeMesh);
+}


### PR DESCRIPTION
## Summary

In select mode (edit + pointer), clicking a block placed at TQEC z<0 from a camera tilted to look down used to clear the selection instead of selecting the block — the invisible GridPlane mesh at Three.js y=0 swallowed the click before BlockInstances saw it. GridPlane's onClick and onPointerMove now bow out (no stopProp, no hover write) when r3f's `e.intersections` contains a block or port hit beyond the plane, letting the next handler in the distance-ordered chain own the event. Pure-function helper `shouldPassThroughGridPlane` extracted to `gui/src/utils/gridPlanePassthrough.ts` with 5 unit tests covering empty / plane-only / plane+block / plane+port / null-mesh cases. Symmetric: also fixes camera-below-plane-looking-up.

## Test plan

- [x] `npm test` — all 380 tests pass (5 new)
- [x] `npm run lint` — no new errors
- [x] `npm run build` — clean typecheck + bundle
- [ ] Manual: place a cube, drag it to z=-3 with shift+drag or nudgeDown, tilt camera down, click the cube — should toggle selected
- [ ] Manual: with a sub-ground block under cursor, hover in pointer mode — `hoveredGridPos` reflects the block's cell, no flash
- [ ] Manual: empty-plane click still clears selection (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)