### PR TITLE
fix: free-build pipe snap-to-cube + half-H mirror presets

### DIFF
--- a/.github/workflows/fly-deploy-dev.yml
+++ b/.github/workflows/fly-deploy-dev.yml
@@ -1,0 +1,35 @@
+name: Dev Deploy
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency: deploy-dev-group
+    steps:
+      - uses: actions/checkout@v6
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only --config fly.dev.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+
+  smoke-test:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe dev for HTTP 200
+        run: |
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" https://piper-draw-dev.fly.dev/)
+            if [ "$code" = "200" ]; then
+              echo "OK: got 200"
+              exit 0
+            fi
+            echo "attempt $i: got $code, retrying in 10s..."
+            sleep 10
+          done
+          echo "FAIL: dev never returned 200"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 ## Branching strategy
 
 - **`dev`** is the integration branch. All pull requests should target `dev`.
-- **`main`** is the stable/release branch. Changes are merged from `dev` into `main` for releases.
+  Merges to `dev` auto-deploy to <https://piper-draw-dev.walruscomputing.com>.
+- **`main`** is the stable/release branch. Changes are merged from `dev` into
+  `main` for releases. Merges to `main` auto-deploy to
+  <https://piper-draw.walruscomputing.com>.
 
 ## How to contribute
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: build the Vite/React frontend
 FROM node:22-slim AS frontend
+ARG VITE_UMAMI_WEBSITE_ID
+ENV VITE_UMAMI_WEBSITE_ID=${VITE_UMAMI_WEBSITE_ID}
 WORKDIR /app/gui
 COPY gui/package.json gui/package-lock.json ./
 RUN npm ci

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,0 +1,21 @@
+# Fly.io config for the piper-draw dev release (deploys from the `dev` branch).
+# Mirrors fly.toml; only `app` differs.
+
+app = "piper-draw-dev"
+primary_region = "ams"
+
+[build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "0d67b9da-dff1-45c2-844d-06b45ff00ff8"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,8 @@ app = "piper-draw"
 primary_region = "ams"
 
 [build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "c9fe90a4-6296-4b2d-b0bc-6b272b01786c"
 
 [http_service]
   internal_port = 8000

--- a/gui/index.html
+++ b/gui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Piper Draw</title>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="c9fe90a4-6296-4b2d-b0bc-6b272b01786c"></script>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="%VITE_UMAMI_WEBSITE_ID%"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@react-three/test-renderer": "^9.1.0",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1408,6 +1409,18 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-three/test-renderer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@react-three/test-renderer/-/test-renderer-9.1.0.tgz",
+      "integrity": "sha512-bLjG+cdpVW69wG1W3TuziHrHvA1JQbLesYddY94QMaFF8yzpgwovWK8hGaHWBET1dvsCPIOWVNYHbKAbRj2xSg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-three/fiber": ">=9.0.0",
+        "react": "^19.0.0",
+        "three": ">=0.156"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@react-three/test-renderer": "^9.1.0",
     "@types/three": "^0.184.0",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.1.2",

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -52,6 +52,15 @@ import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 import { downloadPng } from "./utils/photoExport";
 import { downloadDae } from "./utils/daeExport";
+import {
+  applySnapshot,
+  type SceneSnapshotV1,
+} from "./utils/sceneSnapshot";
+import {
+  decodeSnapshotFromHash,
+  parseSceneHashParam,
+} from "./utils/sceneShare";
+import { SharedSceneBanner } from "./components/SharedSceneBanner";
 import { isEditableTarget } from "./utils/editableFocus";
 import {
   ISO_INITIAL_ZOOM,
@@ -497,6 +506,8 @@ export default function App() {
   const [helpOpen, setHelpOpen] = useState(
     () => typeof localStorage !== 'undefined' && !localStorage.getItem('piperDraw.seenIntro'),
   );
+  const [sharedSceneBanner, setSharedSceneBanner] =
+    useState<{ previousSnapshot: SceneSnapshotV1 } | null>(null);
   const threeStateRef = useRef<ThreeState | null>(null);
   const photoRequest = useBlockStore((s) => s.photoRequest);
   const flowsPanelOpen = useBlockStore((s) => s.flowsPanelOpen);
@@ -896,36 +907,69 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(AUTOSAVE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          useBlockStore.getState().hydrateBlocks(new Map<string, Block>(parsed));
+    function readAutosaveSnapshot(): SceneSnapshotV1 {
+      const snapshot: SceneSnapshotV1 = { v: 1, blocks: [], portMeta: [], portPositions: [] };
+      try {
+        const raw = localStorage.getItem(AUTOSAVE_KEY);
+        if (raw) {
+          const parsed: unknown = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            snapshot.blocks = parsed as SceneSnapshotV1["blocks"];
+          }
         }
+      } catch {
+        localStorage.removeItem(AUTOSAVE_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_KEY);
-    }
-    try {
-      const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
-      if (rawMeta) {
-        const parsed = JSON.parse(rawMeta) as {
-          portMeta?: Array<[string, { label: string; io: "in" | "out" }]>;
-          portPositions?: string[];
-        };
-        const store = useBlockStore.getState();
-        if (parsed.portMeta) {
-          useBlockStore.setState({ portMeta: new Map(parsed.portMeta) });
+      try {
+        const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
+        if (rawMeta) {
+          const parsed = JSON.parse(rawMeta) as {
+            portMeta?: SceneSnapshotV1["portMeta"];
+            portPositions?: string[];
+          };
+          if (parsed.portMeta) snapshot.portMeta = parsed.portMeta;
+          if (parsed.portPositions) snapshot.portPositions = parsed.portPositions;
         }
-        if (parsed.portPositions) {
-          useBlockStore.setState({ portPositions: new Set(parsed.portPositions) });
-        }
-        store.ensurePortLabels();
+      } catch {
+        localStorage.removeItem(AUTOSAVE_META_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_META_KEY);
+      return snapshot;
     }
+
+    function clearShareHash() {
+      if (typeof window === "undefined") return;
+      if (parseSceneHashParam(window.location.hash)) {
+        history.replaceState(null, "", window.location.pathname + window.location.search);
+      }
+    }
+
+    const sharedHash = parseSceneHashParam(window.location.hash);
+    if (!sharedHash) {
+      applySnapshot(readAutosaveSnapshot(), "hydrate");
+      return;
+    }
+
+    const autosaveSnapshot = readAutosaveSnapshot();
+    let cancelled = false;
+    void (async () => {
+      const shared = await decodeSnapshotFromHash(window.location.hash);
+      if (cancelled) return;
+      if (shared) {
+        applySnapshot(shared, "hydrate");
+        clearShareHash();
+        const hadAutosave =
+          autosaveSnapshot.blocks.length > 0 || autosaveSnapshot.portPositions.length > 0;
+        if (hadAutosave) {
+          setSharedSceneBanner({ previousSnapshot: autosaveSnapshot });
+        }
+      } else {
+        applySnapshot(autosaveSnapshot, "hydrate");
+        clearShareHash();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -1013,6 +1057,16 @@ export default function App() {
         onOpenKeybindEditor={setKeybindEditorMode}
       />
       <ValidationToast toolbarRef={toolbarRef} controlsRef={controlsRef} />
+      {sharedSceneBanner && (
+        <SharedSceneBanner
+          previousSnapshot={sharedSceneBanner.previousSnapshot}
+          onRestore={(snapshot) => {
+            applySnapshot(snapshot, "load");
+            setSharedSceneBanner(null);
+          }}
+          onDismiss={() => setSharedSceneBanner(null)}
+        />
+      )}
       <button
         onClick={() => setHelpOpen(true)}
         onPointerDown={(e) => e.stopPropagation()}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -26,6 +26,7 @@ import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
 import { SelectModePointer, type ThreeState } from "./components/SelectModePointer";
 import { DragGhost } from "./components/DragGhost";
+import { DragShadow } from "./components/DragShadow";
 import { NavControlsModifier } from "./components/NavControlsModifier";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
 import { FlowsPanel } from "./components/FlowsPanel";
@@ -1072,6 +1073,7 @@ export default function App() {
         {!photoRequest && <LocatePulseHighlight />}
         {!photoRequest && !flowVizMode && <SelectionHighlights />}
         {!photoRequest && !flowVizMode && <DragGhost />}
+        {!photoRequest && !flowVizMode && <DragShadow />}
         {!photoRequest && !flowVizMode && <BuildCursor />}
         {!photoRequest && !flowVizMode && <OpenPipeGhosts />}
       {!photoRequest && (flowsPanelOpen || zxPanelOpen || flowVizMode) && <PortLabels3D />}

--- a/gui/src/components/BlockInstances.logic.test.ts
+++ b/gui/src/components/BlockInstances.logic.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { Vector3 } from "three";
+import {
+  decidePlaceModeClick,
+  decidePlaceModeHover,
+  resolveFBSpecFromFace,
+  resolvePipeTypeFromFace,
+  type PlaceModeState,
+} from "./BlockInstances.logic";
+import {
+  buildSpatialIndex,
+  FB_PRESETS,
+  isFreeBuildPipeSpec,
+  posKey,
+} from "../types";
+import type { Block, BlockType, CubeType, FBPreset, PipeVariant, Position3D } from "../types";
+import type { ArmedTool } from "../stores/blockStore";
+
+const FB_SWAP_ZX: FBPreset = FB_PRESETS.find((p) => p.id === "swap-zx")!;
+
+function block(pos: Position3D, type: BlockType): Block {
+  return { pos, type };
+}
+
+function makeState(opts: {
+  armedTool: ArmedTool;
+  cubeType?: CubeType | "Y";
+  pipeVariant?: PipeVariant | null;
+  fbPreset?: FBPreset | null;
+  freeBuild?: boolean;
+  blocks?: Block[];
+}): PlaceModeState {
+  const blockMap = new Map<string, Block>();
+  for (const b of opts.blocks ?? []) blockMap.set(posKey(b.pos), b);
+  return {
+    armedTool: opts.armedTool,
+    cubeType: opts.cubeType ?? "XZZ",
+    pipeVariant: opts.pipeVariant ?? null,
+    fbPreset: opts.fbPreset ?? null,
+    freeBuild: opts.freeBuild ?? false,
+    blocks: blockMap,
+    spatialIndex: buildSpatialIndex(blockMap),
+  };
+}
+
+describe("decidePlaceModeHover — armedTool === 'cube'", () => {
+  it("returns cube-replace ghost when cubeType differs from hovered.type", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(intent.pos).toEqual({ x: 0, y: 0, z: 0 });
+    expect(intent.type).toBe("XZZ");
+    expect(intent.invalid).toBe(false);
+    expect(intent.replace).toBe(true);
+  });
+
+  it("clears ghost when cubeType === hovered.type (face-based fallback fails on cube-pipe-slot mismatch)", () => {
+    // adj = (1,0,0) is a pipe slot, not a valid cube position, so face-based clears.
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("clear");
+  });
+
+});
+
+describe("decidePlaceModeHover — armedTool === 'pipe' + fbPreset (FB snap regression)", () => {
+  it("never enters cube-replace; returns FB pipe ghost in adj slot regardless of cubeType", () => {
+    // Before the fix this case rendered a CUBE ghost at the cube position.
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ", // different from hovered.type — would have triggered cube-replace
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(isFreeBuildPipeSpec(intent.type)).toBe(true);
+    expect(intent.pos).toEqual({ x: 1, y: 0, z: 0 });
+    expect(intent.invalid).toBe(false);
+  });
+
+  it("places FB pipe in adj slot for every face direction tested (cube hover)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const cases: { normal: Vector3; expected: Position3D }[] = [
+      { normal: new Vector3(1, 0, 0), expected: { x: 1, y: 0, z: 0 } },
+      { normal: new Vector3(-1, 0, 0), expected: { x: -2, y: 0, z: 0 } },
+      { normal: new Vector3(0, 1, 0), expected: { x: 0, y: 0, z: 1 } },
+      { normal: new Vector3(0, 0, 1), expected: { x: 0, y: -2, z: 0 } },
+    ];
+    for (const { normal, expected } of cases) {
+      const intent = decidePlaceModeHover(state, cube, normal);
+      expect(intent.kind).toBe("ghost");
+      if (intent.kind !== "ghost") continue;
+      expect(intent.pos).toEqual(expected);
+      expect(isFreeBuildPipeSpec(intent.type)).toBe(true);
+    }
+  });
+
+  it("clears when face resolution fails (no faceNormal)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, null);
+    expect(intent.kind).toBe("clear");
+  });
+});
+
+describe("decidePlaceModeHover — armedTool === 'pipe' + pipeVariant (TQEC)", () => {
+  it("returns TQEC pipe ghost in adj slot", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(intent.pos).toEqual({ x: 1, y: 0, z: 0 });
+    // X-open ZX pipe at this slot is "OZX"
+    expect(intent.type).toBe("OZX");
+  });
+
+  it("adj slot matches the FB-equivalent path (parity)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const tqecState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const fbState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    for (const normal of [
+      new Vector3(1, 0, 0),
+      new Vector3(-1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, 0, 1),
+    ]) {
+      const tqec = decidePlaceModeHover(tqecState, cube, normal);
+      const fb = decidePlaceModeHover(fbState, cube, normal);
+      expect(tqec.kind).toBe("ghost");
+      expect(fb.kind).toBe("ghost");
+      if (tqec.kind !== "ghost" || fb.kind !== "ghost") continue;
+      expect(fb.pos).toEqual(tqec.pos);
+    }
+  });
+});
+
+describe("decidePlaceModeClick", () => {
+  it("returns place-at hovered.pos when cube tool replaces a different-type cube", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const action = decidePlaceModeClick(state, cube, new Vector3(1, 0, 0));
+    expect(action).toEqual({ kind: "place-at", pos: cube.pos });
+  });
+
+  it("FB-armed click on a different-type cube places at adj pipe slot, not at cube pos (REGRESSION)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const action = decidePlaceModeClick(state, cube, new Vector3(1, 0, 0));
+    expect(action).toEqual({ kind: "place-at", pos: { x: 1, y: 0, z: 0 } });
+  });
+
+  it("returns noop when no face normal and no cube-replace path applies", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const action = decidePlaceModeClick(state, cube, null);
+    expect(action).toEqual({ kind: "noop" });
+  });
+
+  it("FB-click adj position equals TQEC-click adj position for the same hover (parity)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const tqecState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const fbState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    for (const normal of [
+      new Vector3(1, 0, 0),
+      new Vector3(-1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, 0, 1),
+    ]) {
+      const tqec = decidePlaceModeClick(tqecState, cube, normal);
+      const fb = decidePlaceModeClick(fbState, cube, normal);
+      expect(tqec.kind).toBe("place-at");
+      expect(fb.kind).toBe("place-at");
+      if (tqec.kind !== "place-at" || fb.kind !== "place-at") continue;
+      expect(fb.pos).toEqual(tqec.pos);
+    }
+  });
+});
+
+// Sanity: the resolution helpers are re-exported from the logic module so
+// other components (OpenPipeGhosts) can import from one place. Cover the
+// re-exports so the surface is stable.
+describe("resolution helpers (sanity)", () => {
+  it("resolveFBSpecFromFace returns a valid pipe slot", () => {
+    const r = resolveFBSpecFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), FB_SWAP_ZX);
+    expect(r).not.toBeNull();
+    expect(r!.adj).toEqual({ x: 1, y: 0, z: 0 });
+    expect(r!.spec.openAxis).toBe(0);
+  });
+
+  it("resolvePipeTypeFromFace agrees with FB on adj slot", () => {
+    const tqec = resolvePipeTypeFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), "ZX");
+    expect(tqec).toBe("OZX");
+  });
+});

--- a/gui/src/components/BlockInstances.logic.ts
+++ b/gui/src/components/BlockInstances.logic.ts
@@ -1,0 +1,224 @@
+import * as THREE from "three";
+import type {
+  Block,
+  BlockType,
+  CubeType,
+  FBPreset,
+  FreeBuildPipeSpec,
+  PipeVariant,
+  Position3D,
+  SpatialIndex,
+} from "../types";
+import {
+  getAdjacentPos,
+  hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
+  hasYCubePipeAxisConflict,
+  isPipeType,
+  isValidPipePos,
+  isValidPos,
+  pipeAxisFromPos,
+  posKey,
+  resolvePipeType,
+  VARIANT_AXIS_MAP,
+} from "../types";
+import type { ArmedTool } from "../stores/blockStore";
+
+// FB-aware face-resolution helpers. Pure: no React, no zustand.
+
+export function resolvePipeTypeFromFace(
+  srcPos: Position3D,
+  srcType: BlockType,
+  normal: THREE.Vector3,
+  variant: PipeVariant,
+): BlockType | null {
+  for (const candidateType of VARIANT_AXIS_MAP[variant]) {
+    const probe = getAdjacentPos(srcPos, srcType, normal, candidateType);
+    if (!isValidPipePos(probe)) continue;
+    const resolved = resolvePipeType(variant, probe);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+export function resolveFBSpecFromFace(
+  srcPos: Position3D,
+  srcType: BlockType,
+  normal: THREE.Vector3,
+  preset: FBPreset,
+): { adj: Position3D; spec: FreeBuildPipeSpec } | null {
+  for (const ax of [0, 1, 2] as const) {
+    const candidate: FreeBuildPipeSpec = { ...preset.spec, openAxis: ax };
+    const adj = getAdjacentPos(srcPos, srcType, normal, candidate);
+    if (!isValidPipePos(adj)) continue;
+    const tqecAxis = pipeAxisFromPos(adj);
+    if (tqecAxis === null) continue;
+    return { adj, spec: { ...preset.spec, openAxis: tqecAxis } };
+  }
+  return null;
+}
+
+// Snapshot the handlers project from the store before calling the decision
+// functions. Keeping the surface explicit means the logic is unit-testable
+// without instantiating a real store, and it documents exactly which fields
+// drive place-mode behaviour.
+export type PlaceModeState = {
+  armedTool: ArmedTool;
+  cubeType: CubeType | "Y";
+  pipeVariant: PipeVariant | null;
+  fbPreset: FBPreset | null;
+  freeBuild: boolean;
+  blocks: Map<string, Block>;
+  spatialIndex: SpatialIndex;
+};
+
+export type HoverIntent =
+  | {
+      kind: "ghost";
+      pos: Position3D;
+      type: BlockType;
+      invalid: boolean;
+      reason?: string;
+      replace: boolean;
+    }
+  | { kind: "clear" };
+
+export type ClickAction =
+  | { kind: "place-at"; pos: Position3D }
+  | { kind: "noop" };
+
+type Verdict =
+  | { kind: "ok"; replace: boolean }
+  | { kind: "invalid"; reason?: string; replace: boolean }
+  | { kind: "hidden" };
+
+function classifyTarget(
+  state: PlaceModeState,
+  pos: Position3D,
+  type: BlockType,
+  existingKey: string | undefined,
+): Verdict {
+  const existing = existingKey ? state.blocks.get(existingKey) : undefined;
+  const replace = !!(existing && existing.type !== type);
+  if (hasBlockOverlap(pos, type, state.blocks, state.spatialIndex, existingKey)) {
+    return { kind: "invalid", replace };
+  }
+  if (existing && existing.type === type) {
+    return { kind: "hidden" };
+  }
+  if (!state.freeBuild) {
+    if (isPipeType(type) && hasPipeColorConflict(type, pos, state.blocks)) {
+      return { kind: "invalid", reason: "Pipe colors don't match the adjacent cube", replace };
+    }
+    if (
+      !isPipeType(type) &&
+      type !== "Y" &&
+      hasCubeColorConflict(type as CubeType, pos, state.blocks)
+    ) {
+      return { kind: "invalid", reason: "Cube colors don't match the adjacent pipe", replace };
+    }
+    if (hasYCubePipeAxisConflict(type, pos, state.blocks)) {
+      return {
+        kind: "invalid",
+        reason: "Y cube cannot be next to an X-open or Y-open pipe",
+        replace,
+      };
+    }
+  }
+  return { kind: "ok", replace };
+}
+
+function resolveFaceDestination(
+  state: PlaceModeState,
+  hovered: Block,
+  normal: THREE.Vector3,
+): { dst: BlockType; adj: Position3D } | null {
+  if (state.fbPreset) {
+    const r = resolveFBSpecFromFace(hovered.pos, hovered.type, normal, state.fbPreset);
+    if (!r) return null;
+    return { dst: r.spec, adj: r.adj };
+  }
+  if (state.pipeVariant) {
+    const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, normal, state.pipeVariant);
+    if (!resolved) return null;
+    const adj = getAdjacentPos(hovered.pos, hovered.type, normal, resolved);
+    return { dst: resolved, adj };
+  }
+  // Cube tool: place adjacent cube of the chosen cubeType.
+  const dst: BlockType = state.cubeType;
+  const adj = getAdjacentPos(hovered.pos, hovered.type, normal, dst);
+  return { dst, adj };
+}
+
+export function decidePlaceModeHover(
+  state: PlaceModeState,
+  hovered: Block,
+  faceNormal: THREE.Vector3 | null,
+): HoverIntent {
+  // Cube-replace runs only when the cube tool is armed. The gate makes
+  // FB-armed and TQEC-pipe-armed paths fall through to face-based placement
+  // regardless of cubeType's value.
+  if (state.armedTool === "cube") {
+    const replaceType = state.cubeType;
+    if (isValidPos(hovered.pos, replaceType) && replaceType !== hovered.type) {
+      const verdict = classifyTarget(state, hovered.pos, replaceType, posKey(hovered.pos));
+      if (verdict.kind === "ok") {
+        return {
+          kind: "ghost",
+          pos: hovered.pos,
+          type: replaceType,
+          invalid: false,
+          replace: verdict.replace,
+        };
+      }
+      if (verdict.kind === "invalid") {
+        return {
+          kind: "ghost",
+          pos: hovered.pos,
+          type: replaceType,
+          invalid: true,
+          reason: verdict.reason,
+          replace: verdict.replace,
+        };
+      }
+      // hidden falls through to face-based placement.
+    }
+  }
+
+  if (!faceNormal) return { kind: "clear" };
+  const resolved = resolveFaceDestination(state, hovered, faceNormal);
+  if (!resolved) return { kind: "clear" };
+  const { dst, adj } = resolved;
+  if (!isValidPos(adj, dst)) return { kind: "clear" };
+  const adjKey = posKey(adj);
+  const existingKey = state.blocks.has(adjKey) ? adjKey : undefined;
+  const verdict = classifyTarget(state, adj, dst, existingKey);
+  if (verdict.kind === "hidden") return { kind: "clear" };
+  return {
+    kind: "ghost",
+    pos: adj,
+    type: dst,
+    invalid: verdict.kind === "invalid",
+    reason: verdict.kind === "invalid" ? verdict.reason : undefined,
+    replace: verdict.replace,
+  };
+}
+
+export function decidePlaceModeClick(
+  state: PlaceModeState,
+  clicked: Block,
+  faceNormal: THREE.Vector3 | null,
+): ClickAction {
+  if (state.armedTool === "cube") {
+    const replaceType = state.cubeType;
+    if (isValidPos(clicked.pos, replaceType) && replaceType !== clicked.type) {
+      return { kind: "place-at", pos: clicked.pos };
+    }
+  }
+
+  if (!faceNormal) return { kind: "noop" };
+  const resolved = resolveFaceDestination(state, clicked, faceNormal);
+  if (!resolved) return { kind: "noop" };
+  return { kind: "place-at", pos: resolved.adj };
+}

--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -8,23 +8,30 @@ import {
   createBlockGeometry,
   createBlockEdges,
   blockThreeSize,
-  hasBlockOverlap,
-  hasCubeColorConflict,
-  hasPipeColorConflict,
-  hasYCubePipeAxisConflict,
-  isValidPipePos,
-  isValidPos,
   isPipeType,
   isFreeBuildPipeSpec,
-  pipeAxisFromPos,
-  resolvePipeType,
-  getAdjacentPos,
-  posKey,
   blockTypeCacheKey,
-  VARIANT_AXIS_MAP,
+  posKey,
 } from "../types";
-import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant, FBPreset, FreeBuildPipeSpec } from "../types";
+import type { Block, BlockType, FaceMask } from "../types";
+import {
+  decidePlaceModeClick,
+  decidePlaceModeHover,
+  type PlaceModeState,
+} from "./BlockInstances.logic";
 import { posInActiveSlice } from "../utils/isoView";
+
+function snapshotPlaceMode(store: ReturnType<typeof useBlockStore.getState>): PlaceModeState {
+  return {
+    armedTool: store.armedTool,
+    cubeType: store.cubeType,
+    pipeVariant: store.pipeVariant,
+    fbPreset: store.fbPreset,
+    freeBuild: store.freeBuild,
+    blocks: store.blocks,
+    spatialIndex: store.spatialIndex,
+  };
+}
 
 const DIMMED_OPACITY = 0.18;
 const DIMMED_EDGE_OPACITY = 0.25;
@@ -45,45 +52,6 @@ const dimmedEdgeLineMaterial = new THREE.LineBasicMaterial({
   opacity: DIMMED_EDGE_OPACITY,
   depthWrite: false,
 });
-
-// eslint-disable-next-line react-refresh/only-export-components
-export function resolvePipeTypeFromFace(
-  srcPos: Position3D,
-  srcType: BlockType,
-  normal: THREE.Vector3,
-  variant: PipeVariant,
-): BlockType | null {
-  for (const candidateType of VARIANT_AXIS_MAP[variant]) {
-    const probe = getAdjacentPos(srcPos, srcType, normal, candidateType);
-    if (!isValidPipePos(probe)) continue;
-    const resolved = resolvePipeType(variant, probe);
-    if (resolved) return resolved;
-  }
-  return null;
-}
-
-// FB analogue of resolvePipeTypeFromFace. Iterates candidate open-axis values
-// to find a face-adjacent slot that lands on a valid pipe position, then sets
-// the spec's openAxis to match the slot's TQEC axis. Mirrors the placement
-// invariant in addBlock — the preset's template openAxis is overridden by
-// pipeAxisFromPos at placement time.
-// eslint-disable-next-line react-refresh/only-export-components
-export function resolveFBSpecFromFace(
-  srcPos: Position3D,
-  srcType: BlockType,
-  normal: THREE.Vector3,
-  preset: FBPreset,
-): { adj: Position3D; spec: FreeBuildPipeSpec } | null {
-  for (const ax of [0, 1, 2] as const) {
-    const candidate: FreeBuildPipeSpec = { ...preset.spec, openAxis: ax };
-    const adj = getAdjacentPos(srcPos, srcType, normal, candidate);
-    if (!isValidPipePos(adj)) continue;
-    const tqecAxis = pipeAxisFromPos(adj);
-    if (tqecAxis === null) continue;
-    return { adj, spec: { ...preset.spec, openAxis: tqecAxis } };
-  }
-  return null;
-}
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function getCachedGeometry(blockType: BlockType, hiddenFaces: FaceMask): THREE.BufferGeometry {
@@ -267,71 +235,13 @@ function TypedInstances({
       // either removes the cube or does nothing (and sets a warning).
       store.setHoveredGridPos(null);
     } else {
-      // Place mode: check if we can replace the hovered block itself
-      const hovered = b[e.instanceId];
-      let replaceType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
-        const resolved = resolvePipeType(store.pipeVariant, hovered.pos);
-        if (resolved) replaceType = resolved;
-      }
-      if (isValidPos(hovered.pos, replaceType) && replaceType !== hovered.type) {
-        const hovKey = posKey(hovered.pos);
-        if (hasBlockOverlap(hovered.pos, replaceType, store.blocks, store.spatialIndex, hovKey)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, undefined, true);
-        } else if (!store.freeBuild && isPipeType(replaceType) && hasPipeColorConflict(replaceType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Pipe colors don't match the adjacent cube", true);
-        } else if (!store.freeBuild && !isPipeType(replaceType) && replaceType !== "Y" && hasCubeColorConflict(replaceType as CubeType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Cube colors don't match the adjacent pipe", true);
-        } else if (!store.freeBuild && hasYCubePipeAxisConflict(replaceType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Y cube cannot be next to an X-open or Y-open pipe", true);
-        } else {
-          store.setHoveredGridPos(hovered.pos, replaceType, false, undefined, true);
-        }
-        return;
-      }
-
-      if (!e.face) return;
-
-      // Determine the destination block type for adjacent placement
-      let dstType: BlockType = store.cubeType;
-      if (store.fbPreset) {
-        const r = resolveFBSpecFromFace(hovered.pos, hovered.type, e.face.normal, store.fbPreset);
-        if (!r) {
-          store.setHoveredGridPos(null);
-          return;
-        }
-        dstType = r.spec;
-      } else if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, e.face.normal, store.pipeVariant);
-        if (!resolved) {
-          store.setHoveredGridPos(null);
-          return;
-        }
-        dstType = resolved;
-      }
-
-      const adj = getAdjacentPos(hovered.pos, hovered.type, e.face.normal, dstType);
-
-      if (!isValidPos(adj, dstType)) {
+      // Place mode: pure decision logic lives in BlockInstances.logic.ts so
+      // the cube-replace gate and FB/TQEC pipe paths are unit-testable.
+      const intent = decidePlaceModeHover(snapshotPlaceMode(store), b[e.instanceId], e.face?.normal ?? null);
+      if (intent.kind === "clear") {
         store.setHoveredGridPos(null);
-        return;
-      }
-      const adjKey = posKey(adj);
-      const existingKey = store.blocks.has(adjKey) ? adjKey : undefined;
-      const adjReplace = !!(existingKey && store.blocks.get(existingKey)!.type !== dstType);
-      if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex, existingKey)) {
-        store.setHoveredGridPos(adj, dstType, true, undefined, adjReplace);
-      } else if (existingKey && store.blocks.get(existingKey)!.type === dstType) {
-        // Same type — no replacement needed, hide ghost
-        store.setHoveredGridPos(null);
-      } else if (!store.freeBuild && isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube", adjReplace);
-      } else if (!store.freeBuild && !isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Cube colors don't match the adjacent pipe", adjReplace);
-      } else if (!store.freeBuild && hasYCubePipeAxisConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Y cube cannot be next to an X-open or Y-open pipe", adjReplace);
       } else {
-        store.setHoveredGridPos(adj, dstType, false, undefined, adjReplace);
+        store.setHoveredGridPos(intent.pos, intent.type, intent.invalid, intent.reason, intent.replace);
       }
     }
   };
@@ -366,42 +276,14 @@ function TypedInstances({
       store.commitPaste();
       return;
     }
-    {
-      // Port-conversion tool: click on a cube to remove it (leaving a port
-      // if a pipe was attached). Never falls through to pipe-placement.
-      if (armed === "port") {
-        store.convertBlockToPort(b[e.instanceId].pos);
-        return;
-      }
-      // Place mode: try replacing the clicked block if the selected type
-      // is valid at the clicked block's position
-      const clicked = b[e.instanceId];
-      let replaceType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
-        const resolved = resolvePipeType(store.pipeVariant, clicked.pos);
-        if (resolved) replaceType = resolved;
-      }
-      if (isValidPos(clicked.pos, replaceType) && replaceType !== clicked.type) {
-        store.addBlock(clicked.pos);
-        return;
-      }
-
-      if (!e.face) return;
-
-      let dstType: BlockType = store.cubeType;
-      if (store.fbPreset) {
-        const r = resolveFBSpecFromFace(clicked.pos, clicked.type, e.face.normal, store.fbPreset);
-        if (!r) return;
-        dstType = r.spec;
-      } else if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(clicked.pos, clicked.type, e.face.normal, store.pipeVariant);
-        if (!resolved) return;
-        dstType = resolved;
-      }
-
-      const adj = getAdjacentPos(clicked.pos, clicked.type, e.face.normal, dstType);
-      store.addBlock(adj);
+    // Port-conversion tool: click on a cube to remove it (leaving a port
+    // if a pipe was attached). Never falls through to pipe-placement.
+    if (armed === "port") {
+      store.convertBlockToPort(b[e.instanceId].pos);
+      return;
     }
+    const action = decidePlaceModeClick(snapshotPlaceMode(store), b[e.instanceId], e.face?.normal ?? null);
+    if (action.kind === "place-at") store.addBlock(action.pos);
   };
 
   if (blocks.length === 0) return null;

--- a/gui/src/components/DragShadow.test.tsx
+++ b/gui/src/components/DragShadow.test.tsx
@@ -1,0 +1,162 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block } from "../types";
+import { DragShadow, MAX_SHADOWS } from "./DragShadow";
+
+function meshColor(node: { instance: unknown }): number {
+  return ((node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial).color.getHex();
+}
+
+function mk(pos: { x: number; y: number; z: number }, type: Block["type"] = "XZZ"): Block {
+  return { pos, type };
+}
+
+function setup(opts: {
+  blocks?: Array<[string, Block]>;
+  selected?: string[];
+  dragDelta?: { x: number; y: number; z: number } | null;
+  dragValid?: boolean;
+}) {
+  useBlockStore.setState(
+    {
+      blocks: new Map(opts.blocks ?? []),
+      selectedKeys: new Set(opts.selected ?? []),
+      dragDelta: opts.dragDelta ?? null,
+      dragValid: opts.dragValid ?? true,
+      isDraggingSelection: opts.dragDelta != null,
+    },
+    false,
+  );
+}
+
+beforeEach(() => {
+  // Hard reset all fields DragShadow reads, plus closely-related drag state.
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      selectedKeys: new Set(),
+      dragDelta: null,
+      dragValid: true,
+      isDraggingSelection: false,
+    },
+    false,
+  );
+});
+
+describe("<DragShadow>", () => {
+  it("renders nothing with empty selection", async () => {
+    setup({});
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("renders one shadow per elevated selected block at rest, none for z=0 blocks", async () => {
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["0,0,3", mk({ x: 0, y: 0, z: 3 })],
+        ["3,0,3", mk({ x: 3, y: 0, z: 3 })],
+      ],
+      selected: ["0,0,0", "0,0,3", "3,0,3"],
+      dragDelta: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // Two elevated blocks -> two GroundShadowAbsolute groups.
+    expect(r.scene.findAllByType("Group")).toHaveLength(2);
+  });
+
+  it("renders nothing if all selected blocks are on the ground", async () => {
+    setup({
+      blocks: [["0,0,0", mk({ x: 0, y: 0, z: 0 })]],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("uses shifted positions when dragDelta is non-zero", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 6, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const group = r.scene.findByType("Group");
+    // Shifted block at (6, 0, 3) -> ground center cx = 6.5, cz = -0.5
+    expect(group.instance.position.x).toBeCloseTo(6.5);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+
+  it("treats {0,0,0} dragDelta as at-rest mode (no shift, neutral validity)", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 0, y: 0, z: 0 },
+      dragValid: false, // would turn red if drag mode kicked in
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // At-rest -> always-valid -> black mesh, not red
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0x000000);
+  });
+
+  it("renders red shadows when dragValid=false during a real drag", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 3, y: 0, z: 0 },
+      dragValid: false,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0xff5555);
+  });
+
+  it("caps at MAX_SHADOWS for huge selections", async () => {
+    const blocks: Array<[string, Block]> = [];
+    const selected: string[] = [];
+    // Build 250 elevated blocks, all selected
+    for (let i = 0; i < 250; i++) {
+      const key = `${i * 3},0,3`;
+      blocks.push([key, mk({ x: i * 3, y: 0, z: 3 })]);
+      selected.push(key);
+    }
+    setup({ blocks, selected });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(MAX_SHADOWS);
+  });
+
+  it("applies yBlockZOffset to at-rest Y-cube under a pipe (visually lifted)", async () => {
+    // Y-cube at logical z=0 with a pipe at z=1 above it -> visually lifted by 0.5
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")], // Z-open pipe above
+      ],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // With the lift, the Y-cube's effective z is 0.5 -> shadow appears.
+    expect(r.scene.findAllByType("Group")).toHaveLength(1);
+    const line = r.scene.findByType("LineSegments");
+    // Line len = 0.5 - Y_OFFSET ≈ 0.49
+    expect(line.instance.scale.y).toBeCloseTo(0.49, 2);
+  });
+
+  it("does NOT apply yBlockZOffset during drag (mirrors DragGhost behavior)", async () => {
+    // Y-cube being dragged from z=0 to z=3. During drag we use shifted logical
+    // pos (z=3), no lift even if a pipe sits at z=4 in the destination.
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["3,0,4", mk({ x: 3, y: 0, z: 4 }, "ZXO")], // pipe at destination top
+      ],
+      selected: ["0,0,0"],
+      dragDelta: { x: 3, y: 0, z: 3 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const line = r.scene.findByType("LineSegments");
+    // Pure shifted z=3, line len = 3 - Y_OFFSET ≈ 2.99
+    expect(line.instance.scale.y).toBeCloseTo(2.99, 2);
+  });
+});

--- a/gui/src/components/DragShadow.tsx
+++ b/gui/src/components/DragShadow.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import { useBlockStore } from "../stores/blockStore";
+import { yBlockZOffset } from "../types";
+import type { Block, Position3D } from "../types";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+export const MAX_SHADOWS = 200;
+
+export function DragShadow() {
+  const dragDelta = useBlockStore((s) => s.dragDelta);
+  const dragValid = useBlockStore((s) => s.dragValid);
+  const selectedKeys = useBlockStore((s) => s.selectedKeys);
+  const blocks = useBlockStore((s) => s.blocks);
+
+  // Stable list keyed on selectedKeys/blocks (same pattern as DragGhost) so
+  // rAF-driven dragDelta/dragValid only re-render leaves.
+  const shadows = useMemo(() => {
+    const result: Array<{ key: string; block: Block }> = [];
+    for (const key of selectedKeys) {
+      const block = blocks.get(key);
+      if (!block) continue;
+      result.push({ key, block });
+      if (result.length >= MAX_SHADOWS) break;
+    }
+    return result;
+  }, [selectedKeys, blocks]);
+
+  if (shadows.length === 0) return null;
+
+  // {0,0,0} delta = at-rest mode (treated as null). Drag commits a non-zero
+  // delta the moment the pointer crosses the drag threshold.
+  const liveDelta =
+    dragDelta && (dragDelta.x !== 0 || dragDelta.y !== 0 || dragDelta.z !== 0)
+      ? dragDelta
+      : null;
+  const valid = liveDelta ? dragValid : true;
+
+  return (
+    <>
+      {shadows.map(({ key, block }) => {
+        let pos: Position3D;
+        if (liveDelta) {
+          // Drag mode: shifted logical position, no Y-cube lift (matches
+          // DragGhost which renders the dragged ghost at the logical destination).
+          pos = {
+            x: block.pos.x + liveDelta.x,
+            y: block.pos.y + liveDelta.y,
+            z: block.pos.z + liveDelta.z,
+          };
+        } else {
+          // At-rest mode: committed block is rendered by BlockInstances with
+          // yBlockZOffset applied to Y-cubes that have a pipe above. Mirror
+          // that lift here so the shadow reflects what the user actually SEES,
+          // not the bare logical z.
+          const lift = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+          pos = { ...block.pos, z: block.pos.z + lift };
+        }
+        return (
+          <GroundShadowAbsolute
+            key={key}
+            pos={pos}
+            blockType={block.type}
+            valid={valid}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/gui/src/components/FlowsPanel.tsx
+++ b/gui/src/components/FlowsPanel.tsx
@@ -221,19 +221,52 @@ export function FlowsPanel({
     if (stale && flowVizMode) setFlowVizMode(false);
   }, [stale, flowVizMode, setFlowVizMode]);
 
+  // Order port labels by user-defined rank (PortMeta.rank). Labels without a
+  // rank fall back to the server's order. This drives the column order in the
+  // generator and membership tables, i.e. the qubit-register position when
+  // the diagram is interpreted as a circuit.
+  const labelRank = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const meta of portMeta.values()) {
+      if (meta.rank !== undefined) m.set(meta.label, meta.rank);
+    }
+    return m;
+  }, [portMeta]);
+  const sortByRank = useCallback(
+    (labels: string[]): string[] => {
+      const indexed = labels.map((l, i) => ({ l, i }));
+      indexed.sort((a, b) => {
+        const ra = labelRank.get(a.l) ?? Number.POSITIVE_INFINITY;
+        const rb = labelRank.get(b.l) ?? Number.POSITIVE_INFINITY;
+        if (ra !== rb) return ra - rb;
+        return a.i - b.i;
+      });
+      return indexed.map(({ l }) => l);
+    },
+    [labelRank],
+  );
+  const orderedInputs = useMemo(
+    () => (result?.ok ? sortByRank(result.inputs) : []),
+    [result, sortByRank],
+  );
+  const orderedOutputs = useMemo(
+    () => (result?.ok ? sortByRank(result.outputs) : []),
+    [result, sortByRank],
+  );
+
   const generatorSpan = useMemo(() => {
     if (!result || !result.ok) return null;
-    const labels = [...result.inputs, ...result.outputs];
+    const labels = [...orderedInputs, ...orderedOutputs];
     const vecs = result.flows.map((flow) => {
       const pauliStr = labels
         .map((l, i) =>
-          i < result.inputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
+          i < orderedInputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
         )
         .join("");
       return pauliToSymplectic(pauliStr);
     });
-    return { labels, vecs, inputCount: result.inputs.length };
-  }, [result]);
+    return { labels, vecs, inputCount: orderedInputs.length };
+  }, [result, orderedInputs, orderedOutputs]);
 
   const addQuery = useCallback(() => {
     if (!generatorSpan) return;
@@ -475,7 +508,7 @@ export function FlowsPanel({
               <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                 <thead>
                   <tr>
-                    {result.inputs.map((label) => (
+                    {orderedInputs.map((label) => (
                       <th
                         key={`in-${label}`}
                         style={{
@@ -489,7 +522,7 @@ export function FlowsPanel({
                       </th>
                     ))}
                     <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>→</th>
-                    {result.outputs.map((label) => (
+                    {orderedOutputs.map((label) => (
                       <th
                         key={`out-${label}`}
                         style={{
@@ -521,7 +554,7 @@ export function FlowsPanel({
                           outline: isActive ? "2px solid #4a9eff" : undefined,
                         }}
                       >
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <td
                             key={`in-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -530,7 +563,7 @@ export function FlowsPanel({
                           </td>
                         ))}
                         <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <td
                             key={`out-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -610,7 +643,7 @@ export function FlowsPanel({
                   <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                     <thead>
                       <tr>
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <th
                             key={`qin-${label}`}
                             style={{
@@ -626,7 +659,7 @@ export function FlowsPanel({
                         <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>
                           →
                         </th>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <th
                             key={`qout-${label}`}
                             style={{
@@ -648,7 +681,7 @@ export function FlowsPanel({
                         const inSpan = isQueryInSpan(q);
                         return (
                           <tr key={q.id}>
-                            {result.inputs.map((label) => (
+                            {orderedInputs.map((label) => (
                               <td
                                 key={`qin-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}
@@ -660,7 +693,7 @@ export function FlowsPanel({
                               </td>
                             ))}
                             <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                            {result.outputs.map((label) => (
+                            {orderedOutputs.map((label) => (
                               <td
                                 key={`qout-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}

--- a/gui/src/components/GhostBlock.test.tsx
+++ b/gui/src/components/GhostBlock.test.tsx
@@ -1,0 +1,173 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { GhostBlock } from "./GhostBlock";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+describe("<GhostBlock>", () => {
+  it("renders nothing when hoveredGridPos is null", async () => {
+    useBlockStore.setState({ hoveredGridPos: null }, false);
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in build mode", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, mode: "build" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is pointer", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "pointer" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is paste", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "paste" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders cube ghost only (no shadow) at ground level", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 0 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // The ghost itself is one positioned group + inner scaled group; no second
+    // GroundShadowAbsolute group because z=0 -> shouldRenderShadow false.
+    const groups = r.scene.findAllByType("Group");
+    // 1 outer positioned group + 1 inner scaled group = 2 (no shadow group)
+    expect(groups.length).toBe(2);
+  });
+
+  it("renders cube ghost + GroundShadowAbsolute at z=2", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    const groups = r.scene.findAllByType("Group");
+    // ghost outer + ghost inner-scaled + GroundShadowAbsolute world-positioned group = 3
+    expect(groups.length).toBe(3);
+    // 2 LineSegments: ghost-block edges (existing) + shadow projection line (new).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("Y-cube placement preview at z=0 with pipe above gets a lifted shadow", async () => {
+    // A Z-open pipe sits at z=1 directly above the hovered Y placement at z=0.
+    // yBlockZOffset returns 0.5 → effective z = 0.5 → shadow renders.
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 0 },
+        armedTool: "cube",
+        cubeType: "Y",
+        blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Without the yBlockZOffset adjustment, no shadow would render (logical z=0).
+    // With it, effective z=0.5 → shadow + line appear. 2 LineSegments total:
+    // ghost-block edges + shadow projection line.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("port placement preview at z=2 renders port ghost + GroundShadow", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "port" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Port ghost positioned group + GroundShadowAbsolute group = 2
+    const groups = r.scene.findAllByType("Group");
+    expect(groups.length).toBe(2);
+    // port-ghost edges (existing) + shadow line (new) = 2 LineSegments.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("isInvalid hover at z=2 renders red shadow (invalid color)", async () => {
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        hoveredInvalid: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Both the ghost edges and the shadow line render in red for invalid hover.
+    // GhostBlock uses #ff0000 lineMaterial; GroundShadowAbsolute uses #ff0000.
+    // Assert all LineSegments are red.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
+  });
+
+  it("isDelete (xHeld in edit mode) renders delete preview but NO shadow", async () => {
+    // xHeld + edit mode = isDelete. We render the existing block being targeted
+    // for removal in red, but explicitly do NOT add a ground shadow (it's a
+    // "remove this" cue, not a "place here" cue).
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        xHeld: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Delete branch renders only a mesh (no edges). No shadow either.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(0);
+  });
+});

--- a/gui/src/components/GhostBlock.tsx
+++ b/gui/src/components/GhostBlock.tsx
@@ -13,6 +13,7 @@ import { isoTopThreeAxis } from "../utils/isoFoldOut";
 import type { ThreeAxis } from "../utils/isoFoldOut";
 import { getCachedGeometry, getCachedEdges, getCachedFullBox } from "./BlockInstances";
 import { FoldOutCubeFaces } from "./FoldOutCube";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
 
 const noRaycast = () => {};
 
@@ -116,16 +117,19 @@ function GhostBlockInner() {
   if (armedTool === "port" && mode === "edit" && !xHeld) {
     const [x, y, z] = tqecToThree(hoveredGridPos, "XZZ");
     return (
-      <group position={[x, y, z]}>
-        <mesh raycast={noRaycast}>
-          <primitive object={portGhostBox} attach="geometry" />
-          <primitive object={portGhostMaterial} attach="material" />
-        </mesh>
-        <lineSegments raycast={noRaycast}>
-          <primitive object={portGhostEdges} attach="geometry" />
-          <primitive object={validLineMaterial} attach="material" />
-        </lineSegments>
-      </group>
+      <>
+        <group position={[x, y, z]}>
+          <mesh raycast={noRaycast}>
+            <primitive object={portGhostBox} attach="geometry" />
+            <primitive object={portGhostMaterial} attach="material" />
+          </mesh>
+          <lineSegments raycast={noRaycast}>
+            <primitive object={portGhostEdges} attach="geometry" />
+            <primitive object={validLineMaterial} attach="material" />
+          </lineSegments>
+        </group>
+        <GroundShadowAbsolute pos={hoveredGridPos} blockType="XZZ" valid />
+      </>
     );
   }
 
@@ -178,39 +182,54 @@ function GhostBlockInner() {
     (CUBE_TYPES as readonly string[]).includes(activeType);
   const foldTopAxis: ThreeAxis = viewMode.kind === "iso" ? isoTopThreeAxis(viewMode.axis) : 0;
 
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // a Y-cube placement preview lifted by an above pipe still gets a shadow
+  // whose projection line reaches the rendered block bottom. No shadow for
+  // delete previews — that's a "remove this" cue, not a "place here" cue.
+  const shadowPos = { ...hoveredGridPos, z: hoveredGridPos.z + zo };
+
   return (
-    <group position={[x, y, z]}>
-      {isDelete ? (
-        <mesh scale={1.01} raycast={noRaycast}>
-          <primitive object={getCachedFullBox(activeType)} attach="geometry" />
-          <primitive object={deleteMaterial} attach="material" />
-        </mesh>
-      ) : (
-        <group scale={scale}>
-          {!showFoldOutCube && (
-            <>
-              <mesh>
-                <primitive object={ghostGeometry} attach="geometry" />
-                <primitive object={meshMat} attach="material" />
-              </mesh>
-              <lineSegments>
-                <primitive object={ghostEdges} attach="geometry" />
-                <primitive object={lineMat} attach="material" />
+    <>
+      <group position={[x, y, z]}>
+        {isDelete ? (
+          <mesh scale={1.01} raycast={noRaycast}>
+            <primitive object={getCachedFullBox(activeType)} attach="geometry" />
+            <primitive object={deleteMaterial} attach="material" />
+          </mesh>
+        ) : (
+          <group scale={scale}>
+            {!showFoldOutCube && (
+              <>
+                <mesh>
+                  <primitive object={ghostGeometry} attach="geometry" />
+                  <primitive object={meshMat} attach="material" />
+                </mesh>
+                <lineSegments>
+                  <primitive object={ghostEdges} attach="geometry" />
+                  <primitive object={lineMat} attach="material" />
+                </lineSegments>
+              </>
+            )}
+            {fullPipeEdges && (
+              <lineSegments scale={1.04} renderOrder={999}>
+                <primitive object={fullPipeEdges} attach="geometry" />
+                <primitive object={depthPipeOutlineMaterial} attach="material" />
               </lineSegments>
-            </>
-          )}
-          {fullPipeEdges && (
-            <lineSegments scale={1.04} renderOrder={999}>
-              <primitive object={fullPipeEdges} attach="geometry" />
-              <primitive object={depthPipeOutlineMaterial} attach="material" />
-            </lineSegments>
-          )}
-          {showFoldOutCube && (
-            <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
-          )}
-        </group>
+            )}
+            {showFoldOutCube && (
+              <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
+            )}
+          </group>
+        )}
+      </group>
+      {!isDelete && (
+        <GroundShadowAbsolute
+          pos={shadowPos}
+          blockType={activeType}
+          valid={!isInvalid}
+        />
       )}
-    </group>
+    </>
   );
 }
 

--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -18,6 +18,7 @@ import {
 } from "../types";
 import type { CubeType, Position3D, ViewMode } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
+import { shouldPassThroughGridPlane } from "../utils/gridPlanePassthrough";
 import { snapIsoPos, isoGridMeshTransform } from "../utils/isoView";
 
 const PLANE_SIZE = 1000;
@@ -61,6 +62,21 @@ export function GridPlane() {
   });
 
   const handlePointerMove = (e: ThreeEvent<PointerEvent>) => {
+    // Pass-through (pointer/paste only): when a block/port is also under the
+    // cursor, return early without stopProp so the block's onPointerMove sets
+    // hoveredGridPos. Done before any setHoveredGridPos call so we don't write
+    // the plane cell and let the block immediately overwrite it (one-frame
+    // flash on stacked hits).
+    if (mode === "edit") {
+      const s = useBlockStore.getState();
+      if (
+        !s.xHeld &&
+        (s.armedTool === "pointer" || s.armedTool === "paste") &&
+        shouldPassThroughGridPlane(e.intersections, meshRef.current)
+      ) {
+        return;
+      }
+    }
     e.stopPropagation();
     if (mode !== "edit") { setHoveredGridPos(null); return; }
 
@@ -120,17 +136,31 @@ export function GridPlane() {
   };
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {
-    e.stopPropagation();
-    if (e.delta > 2) return; // ignore drags
-    if (mode !== "edit") return;
+    if (e.delta > 2) { e.stopPropagation(); return; } // ignore drags
+    if (mode !== "edit") { e.stopPropagation(); return; }
 
     const store = useBlockStore.getState();
     // X-held delete on empty grid is a no-op.
-    if (store.xHeld) return;
+    if (store.xHeld) { e.stopPropagation(); return; }
+
     if (store.armedTool === "pointer") {
+      // Pass-through: when the click ray also hits a block or port ghost
+      // further along, let that handler own the event so sub-ground blocks
+      // (TQEC z<0) can be selected from above.
+      //
+      // NOTE: this couples deselect-on-empty-click policy to GridPlane. Any
+      // future clickable scene mesh must either opt out of raycast (the
+      // raycast={noRaycast} convention used by decoratives) or call
+      // e.stopPropagation() in its own onClick. Otherwise deselection would
+      // silently stop working through that mesh.
+      if (shouldPassThroughGridPlane(e.intersections, meshRef.current)) return;
+      e.stopPropagation();
       store.clearSelection();
       return;
     }
+    // Paste / port / placement: the plane is the intended target, so we
+    // always consume the click here.
+    e.stopPropagation();
     // Paste tool: commit the clipboard at the snapped hover cell, then
     // return to pointer (commitPaste sets armedTool="pointer").
     if (store.armedTool === "paste") {

--- a/gui/src/components/GroundShadowAbsolute.test.tsx
+++ b/gui/src/components/GroundShadowAbsolute.test.tsx
@@ -1,0 +1,103 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+import {
+  INVALID_LINE_COLOR,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+} from "../utils/groundShadow";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+function meshMaterial(node: { instance: unknown }): THREE.MeshBasicMaterial {
+  return (node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial;
+}
+function lineMaterial(node: { instance: unknown }): THREE.LineBasicMaterial {
+  return (node.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+}
+
+describe("<GroundShadowAbsolute>", () => {
+  it("renders nothing when on the ground (z=0)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 0 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing when below ground (defensive)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: -1 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders a group + mesh + line for an elevated cube", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 3, y: 6, z: 2 }} blockType="XZZ" valid />,
+    );
+    const groups = r.scene.findAllByType("Group");
+    expect(groups).toHaveLength(1);
+    const group = groups[0];
+    // World-space group at (cx, 0, cz) = (3.5, 0, -6.5)
+    expect(group.instance.position.x).toBeCloseTo(3.5);
+    expect(group.instance.position.y).toBeCloseTo(0);
+    expect(group.instance.position.z).toBeCloseTo(-6.5);
+    // Mesh + line live inside the group
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(1);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(1);
+  });
+
+  it("rotates mesh -PI/2 around X (lays plane flat) and lifts by Y_OFFSET", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="XZZ" valid />,
+    );
+    const mesh = r.scene.findByType("Mesh");
+    expect(mesh.instance.rotation.x).toBeCloseTo(-Math.PI / 2);
+    expect(mesh.instance.position.y).toBeCloseTo(Y_OFFSET);
+  });
+
+  it("scales line to (1, lineLen, 1) so the unit-vertical geom spans block bottom", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 5 }} blockType="XZZ" valid />,
+    );
+    const line = r.scene.findByType("LineSegments");
+    expect(line.instance.scale.x).toBe(1);
+    expect(line.instance.scale.y).toBeCloseTo(5 - Y_OFFSET);
+    expect(line.instance.scale.z).toBe(1);
+  });
+
+  it("uses valid colors and full opacity at z=1 (no fade)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 1 }} blockType="XZZ" valid />,
+    );
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
+    expect(meshMat.color.getHex()).toBe(VALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(VALID_LINE_COLOR);
+    expect(meshMat.opacity).toBeCloseTo(VALID_MESH_OPACITY);
+  });
+
+  it("uses invalid red colors and full (non-faded) opacity when valid=false", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 30 }} blockType="XZZ" valid={false} />,
+    );
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
+    expect(meshMat.color.getHex()).toBe(INVALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(INVALID_LINE_COLOR);
+    // Invalid skips elevation falloff: full base opacity even at z=30
+    expect(meshMat.opacity).toBe(INVALID_MESH_OPACITY);
+  });
+
+  it("respects pipe footprint dims (X-open pipe centers at offset 1, 0.5)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="OZX" valid />,
+    );
+    const group = r.scene.findByType("Group");
+    expect(group.instance.position.x).toBeCloseTo(1);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+});

--- a/gui/src/components/GroundShadowAbsolute.tsx
+++ b/gui/src/components/GroundShadowAbsolute.tsx
@@ -1,0 +1,94 @@
+import * as THREE from "three";
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+import { shadowVisuals, shouldRenderShadow, Y_OFFSET } from "../utils/groundShadow";
+
+// PERF NOTE: Per-instance materials (inline JSX) chosen for simplicity and
+// per-elevation opacity. Worst case ~800 materials in flight at MAX_SHADOWS=200
+// across 4 call sites — fine at typical scale. If perf becomes a problem at
+// extreme selection sizes, swap for InstancedMesh + per-instance opacity
+// vertex attribute. See TODOS.md (perf-shadows).
+
+const noRaycast = () => {};
+
+const planeCache = new Map<string, THREE.PlaneGeometry>();
+function getPlane(sx: number, sy: number): THREE.PlaneGeometry {
+  const key = `${sx}x${sy}`;
+  let g = planeCache.get(key);
+  if (!g) {
+    g = new THREE.PlaneGeometry(sx, sy);
+    planeCache.set(key, g);
+  }
+  return g;
+}
+
+const lineGeom = new THREE.BufferGeometry().setFromPoints([
+  new THREE.Vector3(0, 0, 0),
+  new THREE.Vector3(0, 1, 0),
+]);
+
+/**
+ * Ground-projected shadow + vertical anchor line for an elevated block.
+ *
+ * WORLD-SPACE COMPONENT — the `Absolute` suffix is a contract.
+ *
+ * This component positions itself in WORLD coordinates derived from `pos`.
+ * Do NOT render it inside a positioned `<group>` wrapper — the positions will
+ * compound and the shadow will end up at the wrong cell on the ground.
+ *
+ * Correct (rendered as a sibling of the positioned ghost):
+ *   return <>
+ *     <group position={[x, y, z]}><mesh>...</mesh></group>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />
+ *   </>;
+ *
+ * Wrong (nested — positions compound, shadow ends up offset by [x, y, z]):
+ *   return <group position={[x, y, z]}>
+ *     <mesh>...</mesh>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />   // <-- bug
+ *   </group>;
+ */
+export function GroundShadowAbsolute({
+  pos,
+  blockType,
+  valid,
+}: {
+  pos: Position3D;
+  blockType: BlockType;
+  valid: boolean;
+}) {
+  if (!shouldRenderShadow(pos)) return null;
+  const [sx, sy] = blockTqecSize(blockType);
+  const v = shadowVisuals(pos, blockType, valid);
+
+  return (
+    <group position={[v.cx, 0, v.cz]}>
+      <mesh
+        position={[0, Y_OFFSET, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        geometry={getPlane(sx, sy)}
+        raycast={noRaycast}
+      >
+        <meshBasicMaterial
+          color={v.meshColor}
+          transparent
+          opacity={v.meshOpacity}
+          depthWrite={false}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      <lineSegments
+        position={[0, Y_OFFSET, 0]}
+        scale={[1, v.lineLen, 1]}
+        geometry={lineGeom}
+        raycast={noRaycast}
+      >
+        <lineBasicMaterial
+          color={v.lineColor}
+          transparent
+          opacity={v.lineOpacity}
+          depthWrite={false}
+        />
+      </lineSegments>
+    </group>
+  );
+}

--- a/gui/src/components/OpenPipeGhosts.tsx
+++ b/gui/src/components/OpenPipeGhosts.tsx
@@ -15,7 +15,7 @@ import {
   getAdjacentPos,
   getAllPortPositions,
 } from "../types";
-import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "./BlockInstances";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "./BlockInstances.logic";
 import type { Position3D, BlockType, CubeType } from "../types";
 
 // Sentinel cube type for sizing/face-normal calculations on a port (which has

--- a/gui/src/components/PasteGhost.test.tsx
+++ b/gui/src/components/PasteGhost.test.tsx
@@ -1,0 +1,159 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { PasteGhost } from "./PasteGhost";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+function setPaste(opts: {
+  clipboard?: Map<string, Block> | null;
+  hoveredGridPos?: Position3D | null;
+  blocks?: Map<string, Block>;
+}) {
+  useBlockStore.setState(
+    {
+      armedTool: "paste",
+      mode: "edit",
+      clipboard: opts.clipboard ?? null,
+      hoveredGridPos: opts.hoveredGridPos ?? null,
+      blocks: opts.blocks ?? new Map(),
+    },
+    false,
+  );
+}
+
+describe("<PasteGhost>", () => {
+  it("renders nothing when armedTool is not paste", async () => {
+    useBlockStore.setState(
+      {
+        armedTool: "cube",
+        clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+        hoveredGridPos: { x: 3, y: 0, z: 0 },
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing with empty/null clipboard", async () => {
+    setPaste({ clipboard: null, hoveredGridPos: { x: 0, y: 0, z: 0 } });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing without a hovered grid pos", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+      hoveredGridPos: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders one paste-ghost per clipboard entry at z=0 (no shadows)", async () => {
+    setPaste({
+      clipboard: new Map([
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["3,0,0", mk({ x: 3, y: 0, z: 0 })],
+      ]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 2 ghost meshes; ghost edges (LineSegments) for each = 2 LineSegments.
+    // No shadows because z=0.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("renders shadow + projection line for elevated paste-ghost block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 1 ghost mesh + 1 shadow mesh = 2; ghost edges + shadow line = 2 LineSegments.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("turns shadow red when paste collides with existing block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]), // collision
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // Both ghost edges and shadow line should be red on collision.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
+  });
+
+  it("Y-cube paste at z=0 with pipe above gets a lifted shadow", async () => {
+    // Clipboard contains a Y-cube at z=0; paste destination has a pipe at z=1
+    // directly above. yBlockZOffset returns 0.5 -> shadow renders.
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // ghost edges + shadow line = 2 LineSegments (shadow renders thanks to yBlockZOffset).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("caps clipboard at 200 entries (MAX_PASTE_SHADOWS)", async () => {
+    // Build a clipboard with 250 elevated blocks
+    const big = new Map<string, Block>();
+    for (let i = 0; i < 250; i++) {
+      big.set(`${i * 3},0,3`, mk({ x: i * 3, y: 0, z: 3 }));
+    }
+    setPaste({
+      clipboard: big,
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 200 paste-ghost meshes + 200 shadow meshes = 400 total.
+    // 200 ghost edges + 200 shadow lines = 400 LineSegments.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(400);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(400);
+  });
+});

--- a/gui/src/components/PasteGhost.tsx
+++ b/gui/src/components/PasteGhost.tsx
@@ -4,6 +4,9 @@ import { useBlockStore } from "../stores/blockStore";
 import { tqecToThree, yBlockZOffset, isValidPos } from "../types";
 import type { Block, Position3D } from "../types";
 import { getCachedGeometry, getCachedEdges } from "./BlockInstances";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+const MAX_PASTE_SHADOWS = 200;
 
 const noRaycast = () => {};
 
@@ -57,7 +60,7 @@ export function PasteGhost() {
 
   const entries = useMemo(() => {
     if (!clipboard) return null;
-    return Array.from(clipboard.values());
+    return Array.from(clipboard.values()).slice(0, MAX_PASTE_SHADOWS);
   }, [clipboard]);
 
   if (mode !== "edit" || armedTool !== "paste" || !hoveredGridPos || !entries) {
@@ -103,17 +106,23 @@ function PasteGhostBlock({
   const [x, y, z] = tqecToThree(worldPos, block.type, zo);
   const meshMat = collides ? invalidMaterial : pasteMaterial;
   const lineMat = collides ? invalidLineMaterial : pasteLineMaterial;
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // shadow + projection line align with what the user sees.
+  const shadowPos = { ...worldPos, z: worldPos.z + zo };
 
   return (
-    <group position={[x, y, z]}>
-      <mesh raycast={noRaycast}>
-        <primitive object={geometry} attach="geometry" />
-        <primitive object={meshMat} attach="material" />
-      </mesh>
-      <lineSegments raycast={noRaycast}>
-        <primitive object={edges} attach="geometry" />
-        <primitive object={lineMat} attach="material" />
-      </lineSegments>
-    </group>
+    <>
+      <group position={[x, y, z]}>
+        <mesh raycast={noRaycast}>
+          <primitive object={geometry} attach="geometry" />
+          <primitive object={meshMat} attach="material" />
+        </mesh>
+        <lineSegments raycast={noRaycast}>
+          <primitive object={edges} attach="geometry" />
+          <primitive object={lineMat} attach="material" />
+        </lineSegments>
+      </group>
+      <GroundShadowAbsolute pos={shadowPos} blockType={block.type} valid={!collides} />
+    </>
   );
 }

--- a/gui/src/components/PortsTable.tsx
+++ b/gui/src/components/PortsTable.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
 import { useLocateStore } from "../stores/locateStore";
-import { getAllPortPositions, posKey, tqecToThree, type Position3D } from "../types";
+import { getOrderedPortPositions, posKey, tqecToThree, type Position3D } from "../types";
 import { animateCamera } from "../utils/cameraAnim";
 
 function PortLabelInput({
@@ -72,6 +72,19 @@ function LocateIcon() {
   );
 }
 
+function GripIcon() {
+  return (
+    <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+      <circle cx="3" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="11" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="11" r="1.1" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function PortsTable({
   controlsRef,
 }: {
@@ -83,9 +96,13 @@ export function PortsTable({
   const portPositions = useBlockStore((s) => s.portPositions);
   const setPortLabel = useBlockStore((s) => s.setPortLabel);
   const setPortIO = useBlockStore((s) => s.setPortIO);
+  const reorderPort = useBlockStore((s) => s.reorderPort);
+
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
 
   const portList = useMemo(() => {
-    const positions = getAllPortPositions(blocks, portPositions);
+    const positions = getOrderedPortPositions(blocks, portPositions, portMeta);
     return positions.map((pos) => {
       const key = posKey(pos);
       const meta = portMeta.get(key);
@@ -119,56 +136,105 @@ export function PortsTable({
           No open ports. Add open pipes or place port markers.
         </div>
       )}
-      {portList.map(({ pos, key, meta }) => (
-        <div
-          key={key}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            marginBottom: 4,
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => handleLocate(pos)}
-            aria-label="Locate port"
-            title="Locate port"
+      {portList.map(({ pos, key, meta }, index) => {
+        const isDragging = dragIndex === index;
+        const showDropAbove =
+          dragIndex !== null && overIndex === index && index < dragIndex;
+        const showDropBelow =
+          dragIndex !== null && overIndex === index && index > dragIndex;
+        return (
+          <div
+            key={key}
+            onDragOver={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              if (overIndex !== index) setOverIndex(index);
+            }}
+            onDrop={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              if (dragIndex !== index) reorderPort(dragIndex, index);
+              setDragIndex(null);
+              setOverIndex(null);
+            }}
             style={{
-              background: "none",
-              border: "none",
-              padding: 2,
-              cursor: "pointer",
-              color: "#666",
-              display: "inline-flex",
+              display: "flex",
               alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
+              gap: 6,
+              marginBottom: 4,
+              padding: "2px 0",
+              opacity: isDragging ? 0.4 : 1,
+              borderTop: showDropAbove ? "2px solid #4a9eff" : "2px solid transparent",
+              borderBottom: showDropBelow ? "2px solid #4a9eff" : "2px solid transparent",
             }}
           >
-            <LocateIcon />
-          </button>
-          <PortLabelInput
-            pos={pos}
-            label={meta?.label ?? ""}
-            onCommit={setPortLabel}
-          />
-          <select
-            value={meta?.io ?? "in"}
-            onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
-            style={{ fontSize: 12, padding: "2px 4px" }}
-          >
-            <option value="in">in</option>
-            <option value="out">out</option>
-          </select>
-          <span
-            title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
-            style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
-          >
-            {pos.x / 3},{pos.y / 3},{pos.z / 3}
-          </span>
-        </div>
-      ))}
+            <span
+              draggable
+              onDragStart={(e) => {
+                setDragIndex(index);
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", String(index));
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setOverIndex(null);
+              }}
+              aria-label="Drag to reorder"
+              title="Drag to reorder"
+              style={{
+                cursor: "grab",
+                color: "#aaa",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                padding: "0 2px",
+              }}
+            >
+              <GripIcon />
+            </span>
+            <button
+              type="button"
+              onClick={() => handleLocate(pos)}
+              aria-label="Locate port"
+              title="Locate port"
+              style={{
+                background: "none",
+                border: "none",
+                padding: 2,
+                cursor: "pointer",
+                color: "#666",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <LocateIcon />
+            </button>
+            <PortLabelInput
+              pos={pos}
+              label={meta?.label ?? ""}
+              onCommit={setPortLabel}
+            />
+            <select
+              value={meta?.io ?? "in"}
+              onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
+              style={{ fontSize: 12, padding: "2px 4px" }}
+            >
+              <option value="in">in</option>
+              <option value="out">out</option>
+            </select>
+            <span
+              title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
+              style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
+            >
+              {pos.x / 3},{pos.y / 3},{pos.z / 3}
+            </span>
+          </div>
+        );
+      })}
     </section>
   );
 }

--- a/gui/src/components/SharedSceneBanner.tsx
+++ b/gui/src/components/SharedSceneBanner.tsx
@@ -1,0 +1,70 @@
+import type { SceneSnapshotV1 } from "../utils/sceneSnapshot";
+
+export function SharedSceneBanner({
+  previousSnapshot,
+  onRestore,
+  onDismiss,
+}: {
+  previousSnapshot: SceneSnapshotV1;
+  onRestore: (snapshot: SceneSnapshotV1) => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        top: 12,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1100,
+        background: "#fff8d6",
+        border: "1px solid #d8c46a",
+        borderRadius: 6,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+        padding: "8px 12px",
+        fontFamily: "sans-serif",
+        fontSize: 13,
+        color: "#5b4a00",
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <span>Loaded a shared scene. Your previous work is still saved.</span>
+      <button
+        onClick={() => onRestore(previousSnapshot)}
+        style={{
+          fontSize: 12,
+          padding: "4px 10px",
+          border: "1px solid #b89a30",
+          borderRadius: 4,
+          background: "#fff",
+          cursor: "pointer",
+          color: "#5b4a00",
+        }}
+      >
+        Restore previous
+      </button>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+        style={{
+          fontSize: 14,
+          width: 22,
+          height: 22,
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          color: "#7a6300",
+          padding: 0,
+          lineHeight: 1,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -6,6 +6,12 @@ import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPo
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
+import {
+  buildShareUrl,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+} from "../utils/sceneShare";
+import { captureSnapshot } from "../utils/sceneSnapshot";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
 import { evalCoordExpr } from "../utils/parseCoordExpr";
 import { usePreviewImages } from "./PreviewRenderer";
@@ -1108,7 +1114,15 @@ function FileMenu({
   const [templates, setTemplates] = useState<TemplateEntry[] | null>(null);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [loadingFile, setLoadingFile] = useState<string | null>(null);
+  const [shareStatus, setShareStatus] = useState<"idle" | "copied" | "too-long" | "error">("idle");
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const compressionSupported = isCompressionStreamSupported();
+
+  // ~6 KB total URL — Twitter/X and most chat clients are well above this,
+  // but very long URLs choke older SMS, some embeds, and the URL bar in
+  // older browsers. Past this we surface the .dae export instead.
+  const SHARE_URL_MAX_LEN = 6144;
 
   useEffect(() => {
     if (!open) return;
@@ -1157,6 +1171,52 @@ function FileMenu({
     cursor: disabled ? "default" : "pointer",
     whiteSpace: "nowrap",
   });
+
+  const onShare = async () => {
+    if (!compressionSupported || blocksEmpty) return;
+    if (shareTimeoutRef.current !== null) {
+      clearTimeout(shareTimeoutRef.current);
+      shareTimeoutRef.current = null;
+    }
+    try {
+      const snapshot = captureSnapshot();
+      const encoded = await encodeSnapshotToHashParam(snapshot);
+      const url = buildShareUrl(encoded);
+      if (url.length > SHARE_URL_MAX_LEN) {
+        setShareStatus("too-long");
+      } else {
+        await navigator.clipboard.writeText(url);
+        setShareStatus("copied");
+      }
+    } catch {
+      setShareStatus("error");
+    }
+    shareTimeoutRef.current = setTimeout(() => {
+      setShareStatus("idle");
+      setOpen(false);
+      shareTimeoutRef.current = null;
+    }, 1600);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (shareTimeoutRef.current !== null) clearTimeout(shareTimeoutRef.current);
+    };
+  }, []);
+
+  let shareLabel = "Share link";
+  let shareTitle = "Copy a link that loads this exact scene";
+  if (!compressionSupported) {
+    shareTitle = "Share link is unsupported in this browser (needs CompressionStream)";
+  } else if (shareStatus === "copied") {
+    shareLabel = "Link copied!";
+  } else if (shareStatus === "too-long") {
+    shareLabel = "Too large — use Export";
+    shareTitle = "Scene is too big for a URL; use Export to send a .dae file instead";
+  } else if (shareStatus === "error") {
+    shareLabel = "Could not copy";
+  }
+  const shareDisabled = blocksEmpty || !compressionSupported;
 
   return (
     <div ref={wrapRef} style={{ position: "relative" }}>
@@ -1214,6 +1274,16 @@ function FileMenu({
             style={item(blocksEmpty)}
           >
             Export
+          </button>
+          <button
+            onClick={() => {
+              void onShare();
+            }}
+            disabled={shareDisabled}
+            title={shareTitle}
+            style={item(shareDisabled)}
+          >
+            {shareLabel}
           </button>
           <button
             onClick={() => {

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -636,7 +636,7 @@ export function Toolbar({
               onPointerDown={() => {
                 if (mode !== "edit") return;
                 if (selectedCubeSlotInfo != null) return;
-                setCubeType(ct as BlockType);
+                setCubeType(ct);
                 setPaletteDragging(true);
               }}
               onClick={() => {
@@ -648,7 +648,7 @@ export function Toolbar({
                   cycleSelectedType(1, { kind: "cube", type: ct });
                   return;
                 }
-                setCubeType(ct as BlockType);
+                setCubeType(ct);
               }}
               style={blockBtnStyle(
                 (mode === "edit" && armedTool === "cube" && cubeType === ct) ||

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { useBlockStore } from "./blockStore";
 import type { Block } from "../types";
-import { buildSpatialIndex } from "../types";
+import { buildSpatialIndex, FB_PRESETS } from "../types";
 
 function reset() {
   useBlockStore.setState({
@@ -13,6 +13,7 @@ function reset() {
     mode: "edit",
     cubeType: "XZZ",
     pipeVariant: null,
+    fbPreset: null,
     armedTool: "cube",
     xHeld: false,
     portWarning: null,
@@ -583,6 +584,31 @@ describe("blockStore", () => {
       useBlockStore.getState().setPlacePort(true);
       useBlockStore.getState().setPlacePort(false);
       expect(useBlockStore.getState().armedTool).toBe("pointer");
+    });
+  });
+
+  // cubeType used to be silently rewritten to a PipeType by setPipeVariant
+  // and left untouched by setFBPreset. That asymmetry caused the FB-pipe
+  // snap-to-cube bug: when cubeType was a real CubeType while an FB preset
+  // was armed, the cube-replace branch in BlockInstances fired against the
+  // hovered cube position. The fix is for cubeType to be owned exclusively
+  // by the cube tool and persist across pipe-mode arming.
+  describe("cubeType ownership", () => {
+    it("setPipeVariant does NOT overwrite cubeType (FB snap regression)", () => {
+      useBlockStore.getState().setCubeType("ZXZ");
+      useBlockStore.getState().setPipeVariant("ZX");
+      expect(useBlockStore.getState().cubeType).toBe("ZXZ");
+      expect(useBlockStore.getState().armedTool).toBe("pipe");
+      expect(useBlockStore.getState().pipeVariant).toBe("ZX");
+    });
+
+    it("setFBPreset does NOT overwrite cubeType", () => {
+      useBlockStore.getState().setCubeType("ZXZ");
+      const swapZx = FB_PRESETS.find((p) => p.id === "swap-zx")!;
+      useBlockStore.getState().setFBPreset(swapZx);
+      expect(useBlockStore.getState().cubeType).toBe("ZXZ");
+      expect(useBlockStore.getState().armedTool).toBe("pipe");
+      expect(useBlockStore.getState().fbPreset?.id).toBe("swap-zx");
     });
   });
 

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1283,6 +1283,62 @@ describe("blockStore", () => {
     });
   });
 
+  describe("reorderPort", () => {
+    function seedFourPorts() {
+      useBlockStore.setState({
+        blocks: new Map(),
+        portPositions: new Set(["0,0,0", "3,0,0", "6,0,0", "9,0,0"]),
+        portMeta: new Map(),
+      });
+      useBlockStore.getState().ensurePortLabels();
+    }
+
+    function ranksByX(): Record<number, number | undefined> {
+      const out: Record<number, number | undefined> = {};
+      for (const [k, m] of useBlockStore.getState().portMeta) {
+        const x = Number(k.split(",")[0]);
+        out[x] = m.rank;
+      }
+      return out;
+    }
+
+    it("ensurePortLabels assigns sequential ranks 0..N-1 in spatial order", () => {
+      seedFourPorts();
+      // Spatial sort is by x ascending → ranks should match the x order.
+      expect(ranksByX()).toEqual({ 0: 0, 3: 1, 6: 2, 9: 3 });
+    });
+
+    it("moves a port forward and rewrites all ranks to 0..N-1", () => {
+      seedFourPorts();
+      // Move the port at index 3 (x=9) to index 0.
+      useBlockStore.getState().reorderPort(3, 0);
+      expect(ranksByX()).toEqual({ 9: 0, 0: 1, 3: 2, 6: 3 });
+    });
+
+    it("moves a port backward and rewrites all ranks", () => {
+      seedFourPorts();
+      // Move the port at index 0 (x=0) to index 2.
+      useBlockStore.getState().reorderPort(0, 2);
+      expect(ranksByX()).toEqual({ 3: 0, 6: 1, 0: 2, 9: 3 });
+    });
+
+    it("is a no-op when from === to", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(2, 2);
+      // Object identity preserved (set returned `state` unchanged).
+      expect(useBlockStore.getState().portMeta).toBe(before);
+    });
+
+    it("is a no-op when indices are out of range", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(-1, 2);
+      useBlockStore.getState().reorderPort(0, 99);
+      expect(useBlockStore.getState().portMeta).toBe(before);
+    });
+  });
+
   describe("copy / paste", () => {
     it("copySelection snapshots selected blocks normalized to origin", () => {
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -53,11 +53,6 @@ export type ArmedTool = "pointer" | "cube" | "pipe" | "port" | "paste";
 
 const MAX_HISTORY = 100;
 
-/** Canonical X-open PipeType for each variant, used as cubeType fallback. */
-const PIPE_VARIANT_CANONICAL: Record<PipeVariant, BlockType> = {
-  ZX: "OZX", XZ: "OXZ", ZXH: "OZXH", XZH: "OXZH",
-};
-
 // ---------------------------------------------------------------------------
 // Command-based undo — stores the operation, not a full state snapshot.
 // Add/remove commands are O(1) memory; clear saves the full map (rare).
@@ -143,7 +138,7 @@ interface BlockStore {
    * Drag / Drop mode, regardless of the currently armed tool.
    */
   xHeld: boolean;
-  cubeType: BlockType;
+  cubeType: CubeType | "Y";
   pipeVariant: PipeVariant | null;
   /**
    * Currently selected free-build pipe preset. When non-null, placement
@@ -228,7 +223,7 @@ interface BlockStore {
   setMode: (mode: Mode) => void;
   setArmedTool: (tool: ArmedTool) => void;
   setXHeld: (held: boolean) => void;
-  setCubeType: (cubeType: BlockType) => void;
+  setCubeType: (cubeType: CubeType | "Y") => void;
   setPipeVariant: (variant: PipeVariant) => void;
   setFBPreset: (preset: FBPreset | null) => void;
   setPlacePort: (on: boolean) => void;
@@ -792,7 +787,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   }),
   setXHeld: (held) => set({ xHeld: held, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),
   setCubeType: (cubeType) => set({ cubeType, armedTool: "cube", pipeVariant: null, fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
-  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], armedTool: "pipe", fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
+  setPipeVariant: (variant) => set({ pipeVariant: variant, armedTool: "pipe", fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
   setFBPreset: (preset) => set({
     fbPreset: preset,
     pipeVariant: null,

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -8,6 +8,7 @@ import type {
 import {
   posKey,
   getAllPortPositions,
+  getOrderedPortPositions,
   defaultPortIO,
   hasBlockOverlap,
   hasCubeColorConflict,
@@ -291,6 +292,12 @@ interface BlockStore {
   ensurePortLabels: () => void;
   setPortLabel: (pos: Position3D, label: string) => void;
   setPortIO: (pos: Position3D, io: PortIO) => void;
+  /**
+   * Reorder ports by moving the port at `fromIndex` (in the current
+   * user-ordered port list) to `toIndex`, then rewriting all ranks
+   * 0..N-1 so the array indices match the stored ranks.
+   */
+  reorderPort: (fromIndex: number, toIndex: number) => void;
   setFlowsPanelOpen: (open: boolean) => void;
   toggleFlowsPanel: () => void;
 
@@ -3439,7 +3446,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       for (const k of stale) next.delete(k);
 
       const used = new Set<string>();
-      for (const meta of next.values()) used.add(meta.label);
+      let maxRank = -1;
+      for (const meta of next.values()) {
+        used.add(meta.label);
+        if (meta.rank !== undefined && meta.rank > maxRank) maxRank = meta.rank;
+      }
       let nextId = 1;
       const allocLabel = (): string => {
         while (used.has(`P${nextId}`)) nextId++;
@@ -3449,9 +3460,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       };
 
       for (const pos of missing) {
+        maxRank += 1;
         next.set(posKey(pos), {
           label: allocLabel(),
           io: defaultPortIO(pos, state.blocks),
+          rank: maxRank,
         });
       }
       return { portMeta: next };
@@ -3493,6 +3506,34 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       if (!existing || existing.io === io) return state;
       const next = new Map(state.portMeta);
       next.set(key, { ...existing, io });
+      return { portMeta: next };
+    }),
+
+  reorderPort: (fromIndex, toIndex) =>
+    set((state) => {
+      const ordered = getOrderedPortPositions(
+        state.blocks,
+        state.portPositions,
+        state.portMeta,
+      );
+      if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= ordered.length ||
+        toIndex >= ordered.length
+      ) {
+        return state;
+      }
+      const keys = ordered.map(posKey);
+      const [moved] = keys.splice(fromIndex, 1);
+      keys.splice(toIndex, 0, moved);
+
+      const next = new Map(state.portMeta);
+      keys.forEach((k, i) => {
+        const m = next.get(k);
+        if (m && m.rank !== i) next.set(k, { ...m, rank: i });
+      });
       return { portMeta: next };
     }),
 

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -23,7 +23,7 @@ import {
   FB_PRESETS,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
-import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
 
 const Z_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
@@ -242,6 +242,19 @@ describe("FB_PRESETS", () => {
     expect(halfZx!.spec.baseAtEnd).toBe("X");
     expect(halfXz!.spec.baseAtStart).toBe("X");
     expect(halfXz!.spec.baseAtEnd).toBe("Z");
+  });
+
+  it("ships the mirror half-swap presets (the 'other' face pair flips)", () => {
+    const halfZxH = FB_PRESETS.find((p) => p.id === "half-zx-h");
+    const halfXzH = FB_PRESETS.find((p) => p.id === "half-xz-h");
+    expect(halfZxH).toBeDefined();
+    expect(halfXzH).toBeDefined();
+    expect(halfZxH!.spec.swapAxes).toBe("second");
+    expect(halfXzH!.spec.swapAxes).toBe("second");
+    expect(halfZxH!.spec.baseAtStart).toBe("Z");
+    expect(halfZxH!.spec.baseAtEnd).toBe("X");
+    expect(halfXzH!.spec.baseAtStart).toBe("X");
+    expect(halfXzH!.spec.baseAtEnd).toBe("Z");
   });
 });
 

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, CUBE_TYPES, PIPE_TYPES } from "./index";
-import type { PipeType, CubeType } from "./index";
+import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, CUBE_TYPES, PIPE_TYPES } from "./index";
+import type { PipeType, CubeType, PortMeta } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
 
@@ -600,5 +600,62 @@ describe("createYDefectEdges", () => {
     // Sanity: hiding everything yields zero edges.
     const all = FACE_POS_X | FACE_NEG_X | FACE_POS_Y | FACE_NEG_Y | FACE_POS_Z | FACE_NEG_Z;
     expect(edgeCount(createYDefectEdges("XZZ", all))).toBe(0);
+  });
+});
+
+describe("getOrderedPortPositions", () => {
+  const explicitPorts = new Set([
+    "0,0,0",
+    "3,0,0",
+    "6,0,0",
+    "9,0,0",
+  ]);
+  const blocks = new Map<
+    string,
+    { pos: { x: number; y: number; z: number }; type: BlockType }
+  >();
+
+  it("falls back to spatial sort when no ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["3,0,0", { label: "P1", io: "in" }],
+      ["0,0,0", { label: "P2", io: "in" }],
+      ["9,0,0", { label: "P3", io: "in" }],
+      ["6,0,0", { label: "P4", io: "in" }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 3, 6, 9]);
+  });
+
+  it("orders ports by rank when ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["0,0,0", { label: "P1", io: "in", rank: 3 }],
+      ["3,0,0", { label: "P2", io: "in", rank: 1 }],
+      ["6,0,0", { label: "P3", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P4", io: "in", rank: 2 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([6, 3, 9, 0]);
+  });
+
+  it("places ranked ports before unranked ones; unranked sort spatially", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["9,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["3,0,0", { label: "P2", io: "in" }],
+      ["0,0,0", { label: "P3", io: "in" }],
+      // P4 at (6,0,0) has no PortMeta entry at all — also unranked.
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([9, 0, 3, 6]);
+  });
+
+  it("breaks ties between equal ranks by spatial order", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["6,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["0,0,0", { label: "P2", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P3", io: "in", rank: 1 }],
+      ["3,0,0", { label: "P4", io: "in", rank: 1 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 6, 3, 9]);
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -109,6 +109,13 @@ export type PortIO = "in" | "out";
 export interface PortMeta {
   label: string;
   io: PortIO;
+  /**
+   * User-defined display order, used by the Ports table and Stabilizer Flows
+   * panel to determine the qubit-register position of each port. Lower ranks
+   * sort first; ports without a rank fall back to spatial sort and appear
+   * after ranked ports.
+   */
+  rank?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -1403,6 +1410,28 @@ export function getAllPortPositions(
 
   result.sort((a, b) => a.x - b.x || a.y - b.y || a.z - b.z);
   return result;
+}
+
+/**
+ * Like `getAllPortPositions`, but ordered by user-defined `PortMeta.rank`
+ * with spatial sort as fallback for any port without a rank. This is the
+ * order shown in the Ports table and used to position qubits in the
+ * Stabilizer Flows table when interpreted as a circuit.
+ */
+export function getOrderedPortPositions(
+  blocks: Map<string, Block>,
+  explicitPorts: Set<string>,
+  portMeta: Map<string, PortMeta>,
+): Position3D[] {
+  const positions = getAllPortPositions(blocks, explicitPorts);
+  return positions.slice().sort((a, b) => {
+    const ra = portMeta.get(posKey(a))?.rank;
+    const rb = portMeta.get(posKey(b))?.rank;
+    const ka = ra ?? Number.POSITIVE_INFINITY;
+    const kb = rb ?? Number.POSITIVE_INFINITY;
+    if (ka !== kb) return ka - kb;
+    return a.x - b.x || a.y - b.y || a.z - b.z;
+  });
 }
 
 /**

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -118,7 +118,7 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
   },
   {
     id: "half-zx",
-    label: "Z→X½",
+    label: "Z→X½ⱽ",
     spec: {
       kind: "fb-pipe",
       openAxis: 2,
@@ -130,7 +130,7 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
   },
   {
     id: "half-xz",
-    label: "X→Z½",
+    label: "X→Z½ⱽ",
     spec: {
       kind: "fb-pipe",
       openAxis: 2,
@@ -138,6 +138,30 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
       baseAtEnd: "Z",
       defectPositions: [0.5],
       swapAxes: "first",
+    },
+  },
+  {
+    id: "half-zx-h",
+    label: "Z→X½ʰ",
+    spec: {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "Z",
+      baseAtEnd: "X",
+      defectPositions: [0.5],
+      swapAxes: "second",
+    },
+  },
+  {
+    id: "half-xz-h",
+    label: "X→Z½ʰ",
+    spec: {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "X",
+      baseAtEnd: "Z",
+      defectPositions: [0.5],
+      swapAxes: "second",
     },
   },
 ];
@@ -149,13 +173,13 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
  */
 export type Placeable =
   | { kind: "port" }
-  | { kind: "cube"; cubeType: BlockType }
+  | { kind: "cube"; cubeType: CubeType | "Y" }
   | { kind: "pipe"; variant: PipeVariant };
 
 export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
   { kind: "port" },
-  ...CUBE_TYPES.map((t) => ({ kind: "cube" as const, cubeType: t as BlockType })),
-  { kind: "cube" as const, cubeType: "Y" as BlockType },
+  ...CUBE_TYPES.map((t) => ({ kind: "cube" as const, cubeType: t })),
+  { kind: "cube" as const, cubeType: "Y" as const },
   ...PIPE_VARIANTS.map((v) => ({ kind: "pipe" as const, variant: v })),
 ];
 
@@ -165,7 +189,7 @@ export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
  */
 export function currentPlaceableIndex(
   armedTool: "pointer" | "cube" | "pipe" | "port" | "paste",
-  cubeType: BlockType,
+  cubeType: CubeType | "Y",
   pipeVariant: PipeVariant | null,
 ): number {
   if (armedTool === "pointer" || armedTool === "paste") return -1;

--- a/gui/src/utils/flows.ts
+++ b/gui/src/utils/flows.ts
@@ -36,7 +36,7 @@ export async function computeFlows(
   }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) portIO[meta.label] = meta.io;

--- a/gui/src/utils/gridPlanePassthrough.test.ts
+++ b/gui/src/utils/gridPlanePassthrough.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { shouldPassThroughGridPlane } from "./gridPlanePassthrough";
+
+const plane = new THREE.Mesh();
+const block = new THREE.Mesh();
+const port = new THREE.Mesh();
+const hit = (o: THREE.Object3D) => ({ object: o });
+
+describe("shouldPassThroughGridPlane", () => {
+  it("returns false when intersections is empty", () => {
+    expect(shouldPassThroughGridPlane([], plane)).toBe(false);
+  });
+
+  it("returns false when only the plane is hit", () => {
+    expect(shouldPassThroughGridPlane([hit(plane)], plane)).toBe(false);
+  });
+
+  it("returns true when a block is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(block)], plane)).toBe(true);
+  });
+
+  it("returns true when a port ghost is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(port)], plane)).toBe(true);
+  });
+
+  it("returns false when planeMesh is null (e.g., pre-mount frame)", () => {
+    expect(shouldPassThroughGridPlane([hit(block)], null)).toBe(false);
+  });
+});

--- a/gui/src/utils/gridPlanePassthrough.ts
+++ b/gui/src/utils/gridPlanePassthrough.ts
@@ -1,0 +1,31 @@
+import type { Intersection, Object3D } from "three";
+
+/**
+ * In select mode, GridPlane should bow out of clicks/hovers when the ray also
+ * hits another interactive mesh further along (a block or port ghost). Without
+ * this, the invisible plane at Three.js y=0 swallows clicks meant for blocks
+ * placed at TQEC z<0 (below the plane) when the camera looks down from above.
+ *
+ * Click chain (perspective, camera tilted down):
+ *
+ *   camera                  After fix:
+ *     │                       plane sees a non-plane hit in e.intersections
+ *     ▼                       → returns without stopProp/clearSelection
+ *   [GridPlane y=0]           → BlockInstances.handleClick runs
+ *     │                       → sub-ground block gets selected
+ *     ▼
+ *   [Block | Port]
+ *
+ * Returns true if any intersection's object is not the plane itself, meaning
+ * the next handler in the chain should own the event.
+ *
+ * Relies on the project convention that decorative meshes use raycast={noRaycast}
+ * so e.intersections only contains actually-clickable meshes.
+ */
+export function shouldPassThroughGridPlane(
+  intersections: ReadonlyArray<Pick<Intersection, "object">>,
+  planeMesh: Object3D | null,
+): boolean {
+  if (!planeMesh) return false;
+  return intersections.some((i) => i.object !== planeMesh);
+}

--- a/gui/src/utils/groundShadow.test.ts
+++ b/gui/src/utils/groundShadow.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  ELEVATION_FALLOFF_FLOOR,
+  GROUND_EPSILON,
+  INVALID_LINE_COLOR,
+  INVALID_LINE_OPACITY,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_LINE_OPACITY,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+  elevationFactor,
+  shadowVisuals,
+  shouldRenderShadow,
+} from "./groundShadow";
+
+describe("shouldRenderShadow", () => {
+  it.each<[number, boolean, string]>([
+    [0, false, "exactly on ground"],
+    [GROUND_EPSILON, false, "exactly at GROUND_EPSILON"],
+    [0.001, true, "just above epsilon"],
+    [1, true, "z=1 cube above ground"],
+    [30, true, "very tall block"],
+    [-1, false, "below ground (defensive)"],
+    [-0.5, false, "Y-cube below ground (defensive)"],
+  ])("z=%s -> %s (%s)", (z, expected) => {
+    expect(shouldRenderShadow({ x: 0, y: 0, z })).toBe(expected);
+  });
+});
+
+describe("elevationFactor", () => {
+  it("returns 1 at z=0 (no fade below z=1)", () => {
+    expect(elevationFactor(0)).toBe(1);
+  });
+
+  it("returns 1 at z=1 (full opacity baseline)", () => {
+    expect(elevationFactor(1)).toBe(1);
+  });
+
+  it("decreases monotonically between z=1 and z=30", () => {
+    let prev = elevationFactor(1);
+    for (let z = 2; z <= 30; z++) {
+      const cur = elevationFactor(z);
+      expect(cur).toBeLessThanOrEqual(prev);
+      prev = cur;
+    }
+  });
+
+  it("hits the floor at high z and stays there", () => {
+    // Pure formula at z=30 = 1/3.32 = 0.301, just above floor.
+    // Floor engages around z=30.17. Test slightly past that point.
+    expect(elevationFactor(31)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(50)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(100)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("floors at ELEVATION_FALLOFF_FLOOR even at z=10000", () => {
+    expect(elevationFactor(10000)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("z=8 ~ 0.61 (sanity-check the curve)", () => {
+    expect(elevationFactor(8)).toBeCloseTo(0.6410, 3);
+  });
+
+  it("z=16 ~ 0.45", () => {
+    expect(elevationFactor(16)).toBeCloseTo(0.4545, 3);
+  });
+});
+
+describe("shadowVisuals", () => {
+  describe("footprint sizing", () => {
+    it("centers a 1x1 cube at (pos.x + 0.5, -(pos.y + 0.5))", () => {
+      const v = shadowVisuals({ x: 3, y: 6, z: 2 }, "XZZ", true);
+      expect(v.cx).toBe(3.5);
+      expect(v.cz).toBe(-6.5);
+    });
+
+    it("uses 2x1 footprint for X-open pipe (OZX): cx offset 1, cz offset 0.5", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "OZX", true);
+      // OZX is [2, 1, 1] in TQEC -> ground footprint sx=2, sy=1
+      expect(v.cx).toBe(1);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x2 footprint for Y-open pipe (ZOX): cx offset 0.5, cz offset 1", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZOX", true);
+      // ZOX is [1, 2, 1] in TQEC -> ground footprint sx=1, sy=2
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-1);
+    });
+
+    it("uses 1x1 footprint for Z-open pipe (ZXO)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZXO", true);
+      // ZXO is [1, 1, 2] in TQEC -> ground footprint sx=1, sy=1 (z is open axis)
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x1 footprint for Y half-cube (sz=0.5 ignored for ground)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+  });
+
+  describe("lineLen", () => {
+    it("uses pos.z (block bottom), not pos.z + sz (block top)", () => {
+      // Y half-cube at z=2: top is at 2.5, but lineLen must use 2.
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.lineLen).toBeCloseTo(2 - Y_OFFSET, 6);
+    });
+
+    it("computes correctly for a tall block", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.lineLen).toBeCloseTo(8 - Y_OFFSET, 6);
+    });
+  });
+
+  describe("opacity & elevation falloff", () => {
+    it("applies falloff to valid mesh+line opacity", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * elevationFactor(8), 6);
+      expect(v.lineOpacity).toBeCloseTo(VALID_LINE_OPACITY * elevationFactor(8), 6);
+    });
+
+    it("does NOT apply falloff when valid=false (full strength)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 30 }, "XZZ", false);
+      expect(v.meshOpacity).toBe(INVALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(INVALID_LINE_OPACITY);
+    });
+
+    it("at z=1, valid mesh opacity == VALID_MESH_OPACITY (no fade)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 1 }, "XZZ", true);
+      expect(v.meshOpacity).toBe(VALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(VALID_LINE_OPACITY);
+    });
+
+    it("at high z, valid mesh opacity hits floor (30% of base)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 50 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * ELEVATION_FALLOFF_FLOOR, 6);
+    });
+  });
+
+  describe("colors", () => {
+    it("uses #000/#000 for valid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", true);
+      expect(v.meshColor).toBe(VALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(VALID_LINE_COLOR);
+    });
+
+    it("uses #ff5555/#ff0000 for invalid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", false);
+      expect(v.meshColor).toBe(INVALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(INVALID_LINE_COLOR);
+    });
+  });
+});

--- a/gui/src/utils/groundShadow.ts
+++ b/gui/src/utils/groundShadow.ts
@@ -1,0 +1,77 @@
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+
+export const GROUND_EPSILON = 1e-4;
+export const Y_OFFSET = 0.01;
+export const ELEVATION_FALLOFF_FLOOR = 0.30;
+
+// Match DragGhost's red palette for invalid:
+//   shadow color #ff5555 (DragGhost mesh, gui/src/components/DragGhost.tsx:23)
+//   line   color #ff0000 (DragGhost edges, gui/src/components/DragGhost.tsx:30)
+export const VALID_MESH_OPACITY = 0.28;
+export const INVALID_MESH_OPACITY = 0.30;
+export const VALID_LINE_OPACITY = 0.22;
+export const INVALID_LINE_OPACITY = 0.28;
+
+export const VALID_SHADOW_COLOR = 0x000000;
+export const INVALID_SHADOW_COLOR = 0xff5555;
+export const VALID_LINE_COLOR = 0x000000;
+export const INVALID_LINE_COLOR = 0xff0000;
+
+/** True when the block is sufficiently above the ground to deserve a shadow. */
+export function shouldRenderShadow(pos: Position3D): boolean {
+  return pos.z > GROUND_EPSILON;
+}
+
+/**
+ * Elevation falloff factor. Asymptotic, floored at ELEVATION_FALLOFF_FLOOR
+ * so the shadow always remains visible even on very tall TQEC graphs.
+ *  z=1  -> 1.00   (full)
+ *  z=8  -> 0.64
+ *  z=16 -> 0.45
+ *  z=30 -> 0.30   (floor)
+ */
+export function elevationFactor(z: number): number {
+  const raw = 1 / (1 + Math.max(0, z - 1) * 0.08);
+  return Math.max(raw, ELEVATION_FALLOFF_FLOOR);
+}
+
+export interface ShadowVisuals {
+  cx: number;
+  cz: number;
+  lineLen: number;
+  meshOpacity: number;
+  lineOpacity: number;
+  meshColor: number;
+  lineColor: number;
+}
+
+/**
+ * Derive everything a GroundShadowAbsolute needs to render from inputs.
+ *
+ * Coordinate convention: TQEC pos.z is the block's bottom in three.js Y
+ * (since tqecToThree maps TQEC Z -> three.js Y and adds sz/2 from the base).
+ * The shadow's ground-plane center is offset by sx/2, sy/2 from pos in the
+ * XZ plane (with TQEC Y negated to match three.js -Z).
+ *
+ * NOTE: caller is responsible for the shouldRenderShadow gate; this fn
+ * computes visuals unconditionally so tests can exercise the math at z=0.
+ */
+export function shadowVisuals(
+  pos: Position3D,
+  blockType: BlockType,
+  valid: boolean,
+): ShadowVisuals {
+  const [sx, sy] = blockTqecSize(blockType);
+  // Valid shadows fade with elevation; invalid stays full strength so the
+  // conflict signal remains legible at any height.
+  const fade = valid ? elevationFactor(pos.z) : 1;
+  return {
+    cx: pos.x + sx / 2,
+    cz: -(pos.y + sy / 2),
+    lineLen: pos.z - Y_OFFSET,
+    meshOpacity: (valid ? VALID_MESH_OPACITY : INVALID_MESH_OPACITY) * fade,
+    lineOpacity: (valid ? VALID_LINE_OPACITY : INVALID_LINE_OPACITY) * fade,
+    meshColor: valid ? VALID_SHADOW_COLOR : INVALID_SHADOW_COLOR,
+    lineColor: valid ? VALID_LINE_COLOR : INVALID_LINE_COLOR,
+  };
+}

--- a/gui/src/utils/sceneShare.test.ts
+++ b/gui/src/utils/sceneShare.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { Block } from "../types";
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import {
+  buildShareUrl,
+  decodeSnapshotFromHash,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+  parseSceneHashParam,
+} from "./sceneShare";
+
+function snapshot(
+  blocks: Array<[string, Block]> = [],
+  portMeta: SceneSnapshotV1["portMeta"] = [],
+  portPositions: string[] = [],
+): SceneSnapshotV1 {
+  return { v: 1, blocks, portMeta, portPositions };
+}
+
+describe("parseSceneHashParam", () => {
+  it("extracts the scene parameter from various hash forms", () => {
+    expect(parseSceneHashParam("#scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("?scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#foo=1&scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#scene=abc&foo=1")).toBe("abc");
+    expect(parseSceneHashParam("https://x.test/app#scene=abc")).toBe("abc");
+  });
+
+  it("returns null when no scene param is present", () => {
+    expect(parseSceneHashParam("")).toBe(null);
+    expect(parseSceneHashParam("#")).toBe(null);
+    expect(parseSceneHashParam("#otherkey=value")).toBe(null);
+    expect(parseSceneHashParam("scenefoo=bar")).toBe(null);
+  });
+});
+
+describe("buildShareUrl", () => {
+  it("appends the encoded payload to the supplied base", () => {
+    expect(buildShareUrl("xyz", "https://app.test/")).toBe(
+      "https://app.test/#scene=xyz",
+    );
+  });
+});
+
+const compressionAvailable = isCompressionStreamSupported();
+const skipIfNoCompression = compressionAvailable ? describe : describe.skip;
+
+skipIfNoCompression("encode/decode round-trip", () => {
+  it("round-trips an empty scene", async () => {
+    const original = snapshot();
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a small scene with port meta and ranks", async () => {
+    const blocks: Array<[string, Block]> = [
+      ["0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" }],
+      ["3,0,0", { pos: { x: 3, y: 0, z: 0 }, type: "OZX" }],
+      ["6,0,0", { pos: { x: 6, y: 0, z: 0 }, type: "ZXZ" }],
+    ];
+    const original = snapshot(
+      blocks,
+      [
+        ["0,0,0", { label: "P1", io: "in", rank: 0 }],
+        ["6,0,0", { label: "P2", io: "out", rank: 1 }],
+      ],
+      ["0,0,0", "6,0,0"],
+    );
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a 200-block scene and produces base64url-safe output", async () => {
+    const blocks: Array<[string, Block]> = [];
+    for (let i = 0; i < 200; i++) {
+      const x = (i % 20) * 3;
+      const z = Math.floor(i / 20) * 3;
+      blocks.push([`${x},0,${z}`, { pos: { x, y: 0, z }, type: "XZZ" }]);
+    }
+    const original = snapshot(blocks);
+    const encoded = await encodeSnapshotToHashParam(original);
+    expect(/^[A-Za-z0-9_-]+$/.test(encoded)).toBe(true);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("returns null for a malformed base64 payload", async () => {
+    expect(await decodeSnapshotFromHash("#scene=!!!not-base64")).toBe(null);
+  });
+
+  it("returns null when valid base64 is not deflate-compressed", async () => {
+    expect(await decodeSnapshotFromHash("#scene=aGVsbG8")).toBe(null);
+  });
+
+  it("returns null when the decoded JSON has the wrong shape", async () => {
+    const wrongShape = await encodeSnapshotToHashParam({
+      v: 1,
+      blocks: "not-an-array" as unknown as never,
+      portMeta: [],
+      portPositions: [],
+    } as SceneSnapshotV1);
+    expect(await decodeSnapshotFromHash(`#scene=${wrongShape}`)).toBe(null);
+  });
+
+  it("returns null when there is no scene param", async () => {
+    expect(await decodeSnapshotFromHash("#nothing-here")).toBe(null);
+  });
+});

--- a/gui/src/utils/sceneShare.ts
+++ b/gui/src/utils/sceneShare.ts
@@ -1,0 +1,99 @@
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import { isSceneSnapshotV1 } from "./sceneSnapshot";
+
+export const SCENE_HASH_KEY = "scene";
+
+const COMPRESSION_FORMAT = "deflate-raw" as const;
+
+export function isCompressionStreamSupported(): boolean {
+  return (
+    typeof CompressionStream !== "undefined" &&
+    typeof DecompressionStream !== "undefined"
+  );
+}
+
+async function runStream(
+  input: Uint8Array,
+  transform: GenericTransformStream,
+): Promise<Uint8Array> {
+  const writer = transform.writable.getWriter();
+  // Swallow writer-side rejections so they don't become unhandled. The
+  // canonical error surface is the readable side, which the caller awaits.
+  writer.write(input).catch(() => {});
+  writer.close().catch(() => {});
+  const buf = await new Response(transform.readable).arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+async function compress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new CompressionStream(COMPRESSION_FORMAT));
+}
+
+async function decompress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new DecompressionStream(COMPRESSION_FORMAT));
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  // Chunk to keep apply() argument count safe across engines.
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+  const padded = s.replaceAll("-", "+").replaceAll("_", "/");
+  const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const binary = atob(padded + pad);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export async function encodeSnapshotToHashParam(
+  snapshot: SceneSnapshotV1,
+): Promise<string> {
+  const json = JSON.stringify(snapshot);
+  const compressed = await compress(new TextEncoder().encode(json));
+  return bytesToBase64Url(compressed);
+}
+
+/**
+ * Accepts any of: "#scene=xyz", "scene=xyz", "?scene=xyz", "&scene=xyz",
+ * or a full URL containing "scene=xyz". Returns the value, or null if
+ * no `scene` parameter is present.
+ */
+export function parseSceneHashParam(hashOrUrl: string): string | null {
+  const re = /(?:^|[#?&])scene=([^&]*)/;
+  const match = re.exec(hashOrUrl);
+  if (!match || !match[1]) return null;
+  return match[1];
+}
+
+export async function decodeSnapshotFromHash(
+  hashOrUrl: string,
+): Promise<SceneSnapshotV1 | null> {
+  const param = parseSceneHashParam(hashOrUrl);
+  if (!param) return null;
+  try {
+    const bytes = base64UrlToBytes(param);
+    const decompressed = await decompress(bytes);
+    const json = new TextDecoder().decode(decompressed);
+    const parsed: unknown = JSON.parse(json);
+    if (!isSceneSnapshotV1(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function buildShareUrl(hashParam: string, base?: string): string {
+  const b =
+    base ??
+    (typeof window !== "undefined"
+      ? window.location.origin + window.location.pathname + window.location.search
+      : "");
+  return `${b}#${SCENE_HASH_KEY}=${hashParam}`;
+}

--- a/gui/src/utils/sceneSnapshot.ts
+++ b/gui/src/utils/sceneSnapshot.ts
@@ -1,0 +1,69 @@
+import type { Block, PortMeta } from "../types";
+import { useBlockStore } from "../stores/blockStore";
+
+export const SCENE_SCHEMA_VERSION = 1;
+
+export interface SceneSnapshotV1 {
+  v: 1;
+  blocks: Array<[string, Block]>;
+  portMeta: Array<[string, PortMeta]>;
+  portPositions: string[];
+}
+
+export function captureSnapshot(): SceneSnapshotV1 {
+  const s = useBlockStore.getState();
+  return {
+    v: 1,
+    blocks: Array.from(s.blocks.entries()),
+    portMeta: Array.from(s.portMeta.entries()),
+    portPositions: Array.from(s.portPositions),
+  };
+}
+
+export function snapshotIsEmpty(snapshot: SceneSnapshotV1): boolean {
+  return snapshot.blocks.length === 0;
+}
+
+export function isSceneSnapshotV1(value: unknown): value is SceneSnapshotV1 {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<SceneSnapshotV1>;
+  if (v.v !== 1) return false;
+  if (!Array.isArray(v.blocks) || !Array.isArray(v.portMeta) || !Array.isArray(v.portPositions)) {
+    return false;
+  }
+  for (const entry of v.blocks) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const block = entry[1] as Partial<Block> | undefined;
+    if (!block || typeof block !== "object") return false;
+    if (typeof block.type !== "string") return false;
+    if (!block.pos || typeof block.pos !== "object") return false;
+    const { x, y, z } = block.pos;
+    if (typeof x !== "number" || typeof y !== "number" || typeof z !== "number") return false;
+  }
+  for (const entry of v.portMeta) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const meta = entry[1] as Partial<PortMeta> | undefined;
+    if (!meta || typeof meta.label !== "string") return false;
+    if (meta.io !== "in" && meta.io !== "out") return false;
+  }
+  for (const p of v.portPositions) {
+    if (typeof p !== "string") return false;
+  }
+  return true;
+}
+
+export type ApplyMode = "load" | "hydrate";
+
+export function applySnapshot(snapshot: SceneSnapshotV1, mode: ApplyMode = "hydrate"): void {
+  const store = useBlockStore.getState();
+  const blocks = new Map<string, Block>(snapshot.blocks);
+  if (mode === "load") store.loadBlocks(blocks);
+  else store.hydrateBlocks(blocks);
+  useBlockStore.setState({
+    portMeta: new Map(snapshot.portMeta),
+    portPositions: new Set(snapshot.portPositions),
+  });
+  useBlockStore.getState().ensurePortLabels();
+}

--- a/gui/src/utils/zx.ts
+++ b/gui/src/utils/zx.ts
@@ -68,7 +68,7 @@ export async function computeZX(
   }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) {

--- a/gui/vitest.config.ts
+++ b/gui/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });

--- a/server.py
+++ b/server.py
@@ -549,8 +549,13 @@ async def zx(req: ZXRequest) -> ZXResponse:
     if req.simplify:
         pyzx.simplify.full_reduce(pzx.g)
         # normalize() places inputs/outputs at sensible (qubit, row) — required
-        # before extract_circuit and nicer for display.
-        pzx.g.normalize()
+        # before extract_circuit and nicer for display. Skip it when only
+        # outputs are set: pyzx.normalize() invokes auto_detect_io() whenever
+        # num_inputs() == 0, which clobbers our explicit outputs and raises
+        # TypeError on boundary vertices that share a row with their neighbor
+        # (issue #221). Frontend falls back to a circle layout in that case.
+        if pzx.g.num_inputs() > 0 or pzx.g.num_outputs() == 0:
+            pzx.g.normalize()
 
     circuit_info: ZXCircuit | None = None
     circuit_error: str | None = None

--- a/server.py
+++ b/server.py
@@ -56,6 +56,10 @@ class BlockInput(BaseModel):
 class PortLabelInput(BaseModel):
     pos: list[float]
     label: str
+    # User-defined display rank from the Ports table. Lower ranks come first.
+    # When provided, the /api/zx endpoint sorts the extracted circuit's qubit
+    # register by this value so it matches the order shown in the GUI.
+    rank: int | None = None
 
 
 class ValidateRequest(BaseModel):
@@ -450,8 +454,26 @@ async def flows(req: FlowsRequest) -> FlowsResponse:
             error="Diagram has no open ports",
         )
 
-    inputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "in"]
-    outputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "out"]
+    # Sort by user-defined rank from the Ports table (matches /api/zx) so the
+    # qubit-register position when this diagram is interpreted as a circuit
+    # follows the GUI order. Unranked ports fall through to TQEC's
+    # alphabetical order.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _flows_sort_key(label: str) -> tuple[int, str]:
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    inputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "in"),
+        key=_flows_sort_key,
+    )
+    outputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "out"),
+        key=_flows_sort_key,
+    )
 
     try:
         surfaces = graph.find_correlation_surfaces()
@@ -534,6 +556,21 @@ async def zx(req: ZXRequest) -> ZXResponse:
             port_label_by_vertex[v] = cube.label
             io = req.port_io.get(cube.label, "in")
             (output_vs if io == "out" else input_vs).append(v)
+
+    # Sort input/output vertex lists by user-defined rank from the Ports table
+    # so the extracted circuit's qubit register matches the GUI order.
+    # Unranked ports sort last, then alphabetically by label.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _port_sort_key(v: int) -> tuple[int, str]:
+        label = port_label_by_vertex.get(v, "")
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    input_vs.sort(key=_port_sort_key)
+    output_vs.sort(key=_port_sort_key)
 
     # Register boundary vertices as pyzx inputs/outputs (required by
     # pyzx.extract_circuit, harmless otherwise).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -724,6 +724,74 @@ class TestZXEndpoint:
         labels = {v["label"] for v in result["vertices"] if v["label"]}
         assert labels == {"a", "b"}
 
+    def test_extract_qubit_register_follows_port_rank(self):
+        # Two parallel identity chains → 2 inputs, 2 outputs. The qubit-index
+        # of each input is determined by the user-defined rank on PortLabelInput
+        # (matching the Ports table order), not by alphabetical label sort.
+        # Swapping the ranks must swap which port maps to qubit 0.
+        blocks = [
+            # Chain 1 at y=0
+            BlockInput(pos=[0, 0, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 0, 0], type="OXZ"),
+            BlockInput(pos=[1, 0, 0], type="OXZ"),
+            # Chain 2 at y=3
+            BlockInput(pos=[0, 3, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 3, 0], type="OXZ"),
+            BlockInput(pos=[1, 3, 0], type="OXZ"),
+        ]
+        port_io = {"a_in": "in", "a_out": "out", "b_in": "in", "b_out": "out"}
+
+        def qubit_of_input_label(result: dict, label: str) -> int:
+            # After extract, vertex pos is [row, 0, -qubit]; inputs land at the
+            # smallest row in the layout. Find the vertex carrying `label` and
+            # return its qubit index.
+            for v in result["vertices"]:
+                if v["label"] == label and v["pos"] is not None:
+                    return int(round(-v["pos"][2]))
+            raise AssertionError(f"no vertex labelled {label!r}")
+
+        # Case A: rank a_in=0, b_in=1 → a_in is qubit 0, b_in is qubit 1.
+        port_labels_a = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=0),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=1),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_a = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_a,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_a["ok"] is True, result_a
+        assert result_a["circuit_error"] is None, result_a["circuit_error"]
+        assert qubit_of_input_label(result_a, "a_in") == 0
+        assert qubit_of_input_label(result_a, "b_in") == 1
+
+        # Case B: swap input ranks → b_in is now qubit 0, a_in is qubit 1.
+        port_labels_b = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=1),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=0),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_b = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_b,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_b["ok"] is True, result_b
+        assert result_b["circuit_error"] is None, result_b["circuit_error"]
+        assert qubit_of_input_label(result_b, "a_in") == 1
+        assert qubit_of_input_label(result_b, "b_in") == 0
+
     def test_extract_without_outputs_errors(self):
         result = self._run(
             ZXRequest(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -378,6 +378,54 @@ class TestZXEndpoint:
         assert simplified["simplified"] is True
         assert len(simplified["vertices"]) <= len(raw["vertices"])
 
+    def test_simplify_with_all_output_ports(self):
+        # Regression for #221: full_reduce + normalize raised TypeError when
+        # every port was marked 'out', because pyzx auto_detect_io fires
+        # whenever num_inputs() == 0 and can't classify boundary vertices that
+        # share a row with their neighbor.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "out", "P2": "out"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+        assert result["simplified"] is True
+        # Both output boundaries should survive full_reduce.
+        assert len(result["vertices"]) == 2
+
+    def test_simplify_with_all_input_ports(self):
+        # Sister case to test_simplify_with_all_output_ports: locks in that
+        # all-input diagrams keep working, since pyzx's auto_detect_io guard
+        # only triggers when num_inputs() == 0.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "in", "P2": "in"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+
     def test_invalid_diagram_returns_error(self):
         # Mismatched pipe colors -> tqec validation error surfaces
         result = self._run(


### PR DESCRIPTION
## Summary

**Half-H color-swap mirror presets.** Adds `half-zx-h` and `half-xz-h` to `FB_PRESETS` — the "other" face pair flips. Existing half presets get superscript `ⱽ` labels (`Z→X½ⱽ`); new H halves get `ʰ` (`Z→X½ʰ`). Same `defectPositions: [0.5]`, but `swapAxes: "second"` instead of `"first"`.

**Free-build pipe snap-to-cube fix.** With an FB preset armed and a real `CubeType` selected, hovering an existing cube of a different type rendered a cube ghost at the cube position instead of an FB pipe in the adjacent pipe slot. Clicking did nothing. The cube-replace branch in `BlockInstances` was firing for FB-armed events because `store.cubeType` was a real cube; the TQEC pipe path only "worked" by accident — `setPipeVariant` rewrote `cubeType` to a `PipeType` like `OZX`, which then failed `isValidPos(cubePos, "OZX")` and silently skipped the branch.

**Type-narrowing fix that closes the bug class:**
- `cubeType: BlockType → CubeType | \"Y\"` on the store. The field can no longer impersonate a pipe destination.
- Drop `cubeType: PIPE_VARIANT_CANONICAL[variant]` rewrite from `setPipeVariant`; delete the unused constant. `cubeType` is now owned exclusively by the cube tool.
- Extract place-mode hover/click decisions into pure `BlockInstances.logic.ts` and gate cube-replace on `armedTool === \"cube\"`. TQEC and FB pipe paths are symmetric by construction.
- Move `resolvePipeTypeFromFace` and `resolveFBSpecFromFace` to the logic module (already pure).

## Test Coverage

```
CODE PATHS                                            USER FLOWS
[+] BlockInstances.logic.ts                           [+] FB preset armed
  ├── decidePlaceModeHover                              ├── [★★★ TESTED] cube hover → FB ghost in adj slot
  │   ├── armedTool === \"cube\"                          ├── [★★★ TESTED] click → place-at adj
  │   │   ├── [★★ TESTED] replace ghost                 └── [★★ TESTED]  4 face directions
  │   │   └── [★★ TESTED] same-type fallthrough        [+] TQEC pipe armed
  │   ├── armedTool === \"pipe\" + fbPreset              ├── [★★ TESTED]  parity with FB on adj
  │   │   └── [★★★ TESTED REGRESSION]                  [+] cubeType ownership invariant
  │   └── armedTool === \"pipe\" + pipeVariant           ├── [★★ TESTED] setPipeVariant doesn't rewrite
  │       └── [★★ TESTED] TQEC ghost in adj             └── [★★ TESTED] setFBPreset doesn't rewrite
  └── decidePlaceModeClick (mirror)
```

Tests: 342 → 355 (+13 new). The `armedTool === 'pipe' + fbPreset (FB snap regression)` describe block is the contract for the bug fix.

## Pre-Landing Review

Ran `/review` (Pre-Landing Review): 2 informational findings, 0 critical, 0 unresolved.
- Edge case: `decidePlaceModeHover` returns `clear` when `e.face?.normal` is null (was silent preserve in original handler). In practice raycast on cube geometry always supplies a face. Not a regression worth blocking.
- Manual UI verification done by author against `npm run dev`: FB ghost lands in adjacent pipe slot regardless of which cube type was last picked.

## Verification Results

Manual verification PASS. Steps walked through in browser:
- FB preset armed + hover mismatched cube → FB pipe ghost in adjacent slot ✓
- Click → FB pipe placed at the adjacent pipe slot ✓
- TQEC pipe variant + cube hover → unchanged (TQEC pipe ghost in adj slot) ✓
- Cube tool + different-type cube → cube replacement preview still works ✓

## Test plan

- [x] `npm test` (gui): 355/355 pass — including new `BlockInstances.logic.test.ts` (13 cases) and 2 `cubeType` ownership invariant tests
- [x] `tsc -b`: clean (0 errors)
- [x] `npm run lint`: 0 errors (2 pre-existing warnings unchanged)
- [x] Manual UI verification on `npm run dev`

🧙 Built with [WOZCODE](https://wozcode.com)