### PR TITLE
feat: per-face free-build pipes + 256-variant picker panel

### DIFF
--- a/.github/workflows/fly-deploy-dev.yml
+++ b/.github/workflows/fly-deploy-dev.yml
@@ -1,0 +1,35 @@
+name: Dev Deploy
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    concurrency: deploy-dev-group
+    steps:
+      - uses: actions/checkout@v6
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy --remote-only --config fly.dev.toml
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN_DEV }}
+
+  smoke-test:
+    needs: deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Probe dev for HTTP 200
+        run: |
+          for i in 1 2 3 4 5 6; do
+            code=$(curl -sS -o /dev/null -w "%{http_code}" https://piper-draw-dev.fly.dev/)
+            if [ "$code" = "200" ]; then
+              echo "OK: got 200"
+              exit 0
+            fi
+            echo "attempt $i: got $code, retrying in 10s..."
+            sleep 10
+          done
+          echo "FAIL: dev never returned 200"
+          exit 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,10 @@
 ## Branching strategy
 
 - **`dev`** is the integration branch. All pull requests should target `dev`.
-- **`main`** is the stable/release branch. Changes are merged from `dev` into `main` for releases.
+  Merges to `dev` auto-deploy to <https://piper-draw-dev.walruscomputing.com>.
+- **`main`** is the stable/release branch. Changes are merged from `dev` into
+  `main` for releases. Merges to `main` auto-deploy to
+  <https://piper-draw.walruscomputing.com>.
 
 ## How to contribute
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Stage 1: build the Vite/React frontend
 FROM node:22-slim AS frontend
+ARG VITE_UMAMI_WEBSITE_ID
+ENV VITE_UMAMI_WEBSITE_ID=${VITE_UMAMI_WEBSITE_ID}
 WORKDIR /app/gui
 COPY gui/package.json gui/package-lock.json ./
 RUN npm ci

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,0 +1,21 @@
+# Fly.io config for the piper-draw dev release (deploys from the `dev` branch).
+# Mirrors fly.toml; only `app` differs.
+
+app = "piper-draw-dev"
+primary_region = "ams"
+
+[build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "0d67b9da-dff1-45c2-844d-06b45ff00ff8"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = "suspend"
+  auto_start_machines = true
+  min_machines_running = 1
+
+[[vm]]
+  memory = "1gb"
+  cpu_kind = "shared"
+  cpus = 1

--- a/fly.toml
+++ b/fly.toml
@@ -7,6 +7,8 @@ app = "piper-draw"
 primary_region = "ams"
 
 [build]
+  [build.args]
+    VITE_UMAMI_WEBSITE_ID = "c9fe90a4-6296-4b2d-b0bc-6b272b01786c"
 
 [http_service]
   internal_port = 8000

--- a/gui/index.html
+++ b/gui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Piper Draw</title>
-    <script defer src="https://cloud.umami.is/script.js" data-website-id="c9fe90a4-6296-4b2d-b0bc-6b272b01786c"></script>
+    <script defer src="https://cloud.umami.is/script.js" data-website-id="%VITE_UMAMI_WEBSITE_ID%"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/gui/package-lock.json
+++ b/gui/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@react-three/test-renderer": "^9.1.0",
         "@types/node": "^25.6.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1408,6 +1409,18 @@
         "react-native": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@react-three/test-renderer": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@react-three/test-renderer/-/test-renderer-9.1.0.tgz",
+      "integrity": "sha512-bLjG+cdpVW69wG1W3TuziHrHvA1JQbLesYddY94QMaFF8yzpgwovWK8hGaHWBET1dvsCPIOWVNYHbKAbRj2xSg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@react-three/fiber": ">=9.0.0",
+        "react": "^19.0.0",
+        "three": ">=0.156"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/gui/package.json
+++ b/gui/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^25.6.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@react-three/test-renderer": "^9.1.0",
     "@types/three": "^0.184.0",
     "@vitejs/plugin-react": "^6.0.1",
     "concurrently": "^9.1.2",

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -52,6 +52,15 @@ import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
 import { downloadPng } from "./utils/photoExport";
 import { downloadDae } from "./utils/daeExport";
+import {
+  applySnapshot,
+  type SceneSnapshotV1,
+} from "./utils/sceneSnapshot";
+import {
+  decodeSnapshotFromHash,
+  parseSceneHashParam,
+} from "./utils/sceneShare";
+import { SharedSceneBanner } from "./components/SharedSceneBanner";
 import { isEditableTarget } from "./utils/editableFocus";
 import {
   ISO_INITIAL_ZOOM,
@@ -497,6 +506,8 @@ export default function App() {
   const [helpOpen, setHelpOpen] = useState(
     () => typeof localStorage !== 'undefined' && !localStorage.getItem('piperDraw.seenIntro'),
   );
+  const [sharedSceneBanner, setSharedSceneBanner] =
+    useState<{ previousSnapshot: SceneSnapshotV1 } | null>(null);
   const threeStateRef = useRef<ThreeState | null>(null);
   const photoRequest = useBlockStore((s) => s.photoRequest);
   const flowsPanelOpen = useBlockStore((s) => s.flowsPanelOpen);
@@ -896,36 +907,69 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    try {
-      const raw = localStorage.getItem(AUTOSAVE_KEY);
-      if (raw) {
-        const parsed = JSON.parse(raw);
-        if (Array.isArray(parsed) && parsed.length > 0) {
-          useBlockStore.getState().hydrateBlocks(new Map<string, Block>(parsed));
+    function readAutosaveSnapshot(): SceneSnapshotV1 {
+      const snapshot: SceneSnapshotV1 = { v: 1, blocks: [], portMeta: [], portPositions: [] };
+      try {
+        const raw = localStorage.getItem(AUTOSAVE_KEY);
+        if (raw) {
+          const parsed: unknown = JSON.parse(raw);
+          if (Array.isArray(parsed)) {
+            snapshot.blocks = parsed as SceneSnapshotV1["blocks"];
+          }
         }
+      } catch {
+        localStorage.removeItem(AUTOSAVE_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_KEY);
-    }
-    try {
-      const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
-      if (rawMeta) {
-        const parsed = JSON.parse(rawMeta) as {
-          portMeta?: Array<[string, { label: string; io: "in" | "out" }]>;
-          portPositions?: string[];
-        };
-        const store = useBlockStore.getState();
-        if (parsed.portMeta) {
-          useBlockStore.setState({ portMeta: new Map(parsed.portMeta) });
+      try {
+        const rawMeta = localStorage.getItem(AUTOSAVE_META_KEY);
+        if (rawMeta) {
+          const parsed = JSON.parse(rawMeta) as {
+            portMeta?: SceneSnapshotV1["portMeta"];
+            portPositions?: string[];
+          };
+          if (parsed.portMeta) snapshot.portMeta = parsed.portMeta;
+          if (parsed.portPositions) snapshot.portPositions = parsed.portPositions;
         }
-        if (parsed.portPositions) {
-          useBlockStore.setState({ portPositions: new Set(parsed.portPositions) });
-        }
-        store.ensurePortLabels();
+      } catch {
+        localStorage.removeItem(AUTOSAVE_META_KEY);
       }
-    } catch {
-      localStorage.removeItem(AUTOSAVE_META_KEY);
+      return snapshot;
     }
+
+    function clearShareHash() {
+      if (typeof window === "undefined") return;
+      if (parseSceneHashParam(window.location.hash)) {
+        history.replaceState(null, "", window.location.pathname + window.location.search);
+      }
+    }
+
+    const sharedHash = parseSceneHashParam(window.location.hash);
+    if (!sharedHash) {
+      applySnapshot(readAutosaveSnapshot(), "hydrate");
+      return;
+    }
+
+    const autosaveSnapshot = readAutosaveSnapshot();
+    let cancelled = false;
+    void (async () => {
+      const shared = await decodeSnapshotFromHash(window.location.hash);
+      if (cancelled) return;
+      if (shared) {
+        applySnapshot(shared, "hydrate");
+        clearShareHash();
+        const hadAutosave =
+          autosaveSnapshot.blocks.length > 0 || autosaveSnapshot.portPositions.length > 0;
+        if (hadAutosave) {
+          setSharedSceneBanner({ previousSnapshot: autosaveSnapshot });
+        }
+      } else {
+        applySnapshot(autosaveSnapshot, "hydrate");
+        clearShareHash();
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -1013,6 +1057,16 @@ export default function App() {
         onOpenKeybindEditor={setKeybindEditorMode}
       />
       <ValidationToast toolbarRef={toolbarRef} controlsRef={controlsRef} />
+      {sharedSceneBanner && (
+        <SharedSceneBanner
+          previousSnapshot={sharedSceneBanner.previousSnapshot}
+          onRestore={(snapshot) => {
+            applySnapshot(snapshot, "load");
+            setSharedSceneBanner(null);
+          }}
+          onDismiss={() => setSharedSceneBanner(null)}
+        />
+      )}
       <button
         onClick={() => setHelpOpen(true)}
         onPointerDown={(e) => e.stopPropagation()}

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -30,6 +30,7 @@ import { DragShadow } from "./components/DragShadow";
 import { NavControlsModifier } from "./components/NavControlsModifier";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
 import { FlowsPanel } from "./components/FlowsPanel";
+import { FreeBuildPipeVariantsPanel } from "./components/FreeBuildPipeVariantsPanel";
 import { ZXPanel } from "./components/ZXPanel";
 import { PortLabels3D } from "./components/PortLabels3D";
 import { FoldOutCubeOverlay } from "./components/FoldOutCubeOverlay";
@@ -1115,6 +1116,7 @@ export default function App() {
       )}
       <FlowsPanel controlsRef={controlsRef} toolbarRef={toolbarRef} />
       <ZXPanel controlsRef={controlsRef} toolbarRef={toolbarRef} />
+      <FreeBuildPipeVariantsPanel />
       {showHints && <EditModeHints onCustomize={() => setKeybindEditorMode("edit")} />}
       {showHints && <BuildModeHints onCustomize={() => setKeybindEditorMode("build")} />}
       {keybindEditorMode && (

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -26,6 +26,7 @@ import { SelectionHighlights } from "./components/SelectionHighlights";
 import { BuildCursor } from "./components/BuildCursor";
 import { SelectModePointer, type ThreeState } from "./components/SelectModePointer";
 import { DragGhost } from "./components/DragGhost";
+import { DragShadow } from "./components/DragShadow";
 import { NavControlsModifier } from "./components/NavControlsModifier";
 import { OpenPipeGhosts } from "./components/OpenPipeGhosts";
 import { FlowsPanel } from "./components/FlowsPanel";
@@ -1072,6 +1073,7 @@ export default function App() {
         {!photoRequest && <LocatePulseHighlight />}
         {!photoRequest && !flowVizMode && <SelectionHighlights />}
         {!photoRequest && !flowVizMode && <DragGhost />}
+        {!photoRequest && !flowVizMode && <DragShadow />}
         {!photoRequest && !flowVizMode && <BuildCursor />}
         {!photoRequest && !flowVizMode && <OpenPipeGhosts />}
       {!photoRequest && (flowsPanelOpen || zxPanelOpen || flowVizMode) && <PortLabels3D />}

--- a/gui/src/components/BlockInstances.logic.test.ts
+++ b/gui/src/components/BlockInstances.logic.test.ts
@@ -16,7 +16,7 @@ import {
 import type { Block, BlockType, CubeType, FBPreset, PipeVariant, Position3D } from "../types";
 import type { ArmedTool } from "../stores/blockStore";
 
-const FB_SWAP_ZX: FBPreset = FB_PRESETS.find((p) => p.id === "swap-zx")!;
+const FB_FREE_PIPE: FBPreset = FB_PRESETS[0];
 
 function block(pos: Position3D, type: BlockType): Block {
   return { pos, type };
@@ -73,7 +73,7 @@ describe("decidePlaceModeHover — armedTool === 'pipe' + fbPreset (FB snap regr
     const state = makeState({
       armedTool: "pipe",
       cubeType: "XZZ", // different from hovered.type — would have triggered cube-replace
-      fbPreset: FB_SWAP_ZX,
+      fbPreset: FB_FREE_PIPE,
       freeBuild: true,
       blocks: [cube],
     });
@@ -90,7 +90,7 @@ describe("decidePlaceModeHover — armedTool === 'pipe' + fbPreset (FB snap regr
     const state = makeState({
       armedTool: "pipe",
       cubeType: "XZZ",
-      fbPreset: FB_SWAP_ZX,
+      fbPreset: FB_FREE_PIPE,
       freeBuild: true,
       blocks: [cube],
     });
@@ -114,7 +114,7 @@ describe("decidePlaceModeHover — armedTool === 'pipe' + fbPreset (FB snap regr
     const state = makeState({
       armedTool: "pipe",
       cubeType: "XZZ",
-      fbPreset: FB_SWAP_ZX,
+      fbPreset: FB_FREE_PIPE,
       freeBuild: true,
       blocks: [cube],
     });
@@ -151,7 +151,7 @@ describe("decidePlaceModeHover — armedTool === 'pipe' + pipeVariant (TQEC)", (
     const fbState = makeState({
       armedTool: "pipe",
       cubeType: "XZZ",
-      fbPreset: FB_SWAP_ZX,
+      fbPreset: FB_FREE_PIPE,
       freeBuild: true,
       blocks: [cube],
     });
@@ -184,7 +184,7 @@ describe("decidePlaceModeClick", () => {
     const state = makeState({
       armedTool: "pipe",
       cubeType: "XZZ",
-      fbPreset: FB_SWAP_ZX,
+      fbPreset: FB_FREE_PIPE,
       freeBuild: true,
       blocks: [cube],
     });
@@ -197,7 +197,7 @@ describe("decidePlaceModeClick", () => {
     const state = makeState({
       armedTool: "pipe",
       cubeType: "XZZ",
-      fbPreset: FB_SWAP_ZX,
+      fbPreset: FB_FREE_PIPE,
       freeBuild: true,
       blocks: [cube],
     });
@@ -216,7 +216,7 @@ describe("decidePlaceModeClick", () => {
     const fbState = makeState({
       armedTool: "pipe",
       cubeType: "XZZ",
-      fbPreset: FB_SWAP_ZX,
+      fbPreset: FB_FREE_PIPE,
       freeBuild: true,
       blocks: [cube],
     });
@@ -241,7 +241,7 @@ describe("decidePlaceModeClick", () => {
 // re-exports so the surface is stable.
 describe("resolution helpers (sanity)", () => {
   it("resolveFBSpecFromFace returns a valid pipe slot", () => {
-    const r = resolveFBSpecFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), FB_SWAP_ZX);
+    const r = resolveFBSpecFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), FB_FREE_PIPE);
     expect(r).not.toBeNull();
     expect(r!.adj).toEqual({ x: 1, y: 0, z: 0 });
     expect(r!.spec.openAxis).toBe(0);

--- a/gui/src/components/BlockInstances.logic.test.ts
+++ b/gui/src/components/BlockInstances.logic.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from "vitest";
+import { Vector3 } from "three";
+import {
+  decidePlaceModeClick,
+  decidePlaceModeHover,
+  resolveFBSpecFromFace,
+  resolvePipeTypeFromFace,
+  type PlaceModeState,
+} from "./BlockInstances.logic";
+import {
+  buildSpatialIndex,
+  FB_PRESETS,
+  isFreeBuildPipeSpec,
+  posKey,
+} from "../types";
+import type { Block, BlockType, CubeType, FBPreset, PipeVariant, Position3D } from "../types";
+import type { ArmedTool } from "../stores/blockStore";
+
+const FB_SWAP_ZX: FBPreset = FB_PRESETS.find((p) => p.id === "swap-zx")!;
+
+function block(pos: Position3D, type: BlockType): Block {
+  return { pos, type };
+}
+
+function makeState(opts: {
+  armedTool: ArmedTool;
+  cubeType?: CubeType | "Y";
+  pipeVariant?: PipeVariant | null;
+  fbPreset?: FBPreset | null;
+  freeBuild?: boolean;
+  blocks?: Block[];
+}): PlaceModeState {
+  const blockMap = new Map<string, Block>();
+  for (const b of opts.blocks ?? []) blockMap.set(posKey(b.pos), b);
+  return {
+    armedTool: opts.armedTool,
+    cubeType: opts.cubeType ?? "XZZ",
+    pipeVariant: opts.pipeVariant ?? null,
+    fbPreset: opts.fbPreset ?? null,
+    freeBuild: opts.freeBuild ?? false,
+    blocks: blockMap,
+    spatialIndex: buildSpatialIndex(blockMap),
+  };
+}
+
+describe("decidePlaceModeHover — armedTool === 'cube'", () => {
+  it("returns cube-replace ghost when cubeType differs from hovered.type", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(intent.pos).toEqual({ x: 0, y: 0, z: 0 });
+    expect(intent.type).toBe("XZZ");
+    expect(intent.invalid).toBe(false);
+    expect(intent.replace).toBe(true);
+  });
+
+  it("clears ghost when cubeType === hovered.type (face-based fallback fails on cube-pipe-slot mismatch)", () => {
+    // adj = (1,0,0) is a pipe slot, not a valid cube position, so face-based clears.
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("clear");
+  });
+
+});
+
+describe("decidePlaceModeHover — armedTool === 'pipe' + fbPreset (FB snap regression)", () => {
+  it("never enters cube-replace; returns FB pipe ghost in adj slot regardless of cubeType", () => {
+    // Before the fix this case rendered a CUBE ghost at the cube position.
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ", // different from hovered.type — would have triggered cube-replace
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(isFreeBuildPipeSpec(intent.type)).toBe(true);
+    expect(intent.pos).toEqual({ x: 1, y: 0, z: 0 });
+    expect(intent.invalid).toBe(false);
+  });
+
+  it("places FB pipe in adj slot for every face direction tested (cube hover)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const cases: { normal: Vector3; expected: Position3D }[] = [
+      { normal: new Vector3(1, 0, 0), expected: { x: 1, y: 0, z: 0 } },
+      { normal: new Vector3(-1, 0, 0), expected: { x: -2, y: 0, z: 0 } },
+      { normal: new Vector3(0, 1, 0), expected: { x: 0, y: 0, z: 1 } },
+      { normal: new Vector3(0, 0, 1), expected: { x: 0, y: -2, z: 0 } },
+    ];
+    for (const { normal, expected } of cases) {
+      const intent = decidePlaceModeHover(state, cube, normal);
+      expect(intent.kind).toBe("ghost");
+      if (intent.kind !== "ghost") continue;
+      expect(intent.pos).toEqual(expected);
+      expect(isFreeBuildPipeSpec(intent.type)).toBe(true);
+    }
+  });
+
+  it("clears when face resolution fails (no faceNormal)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, null);
+    expect(intent.kind).toBe("clear");
+  });
+});
+
+describe("decidePlaceModeHover — armedTool === 'pipe' + pipeVariant (TQEC)", () => {
+  it("returns TQEC pipe ghost in adj slot", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const intent = decidePlaceModeHover(state, cube, new Vector3(1, 0, 0));
+    expect(intent.kind).toBe("ghost");
+    if (intent.kind !== "ghost") return;
+    expect(intent.pos).toEqual({ x: 1, y: 0, z: 0 });
+    // X-open ZX pipe at this slot is "OZX"
+    expect(intent.type).toBe("OZX");
+  });
+
+  it("adj slot matches the FB-equivalent path (parity)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const tqecState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const fbState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    for (const normal of [
+      new Vector3(1, 0, 0),
+      new Vector3(-1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, 0, 1),
+    ]) {
+      const tqec = decidePlaceModeHover(tqecState, cube, normal);
+      const fb = decidePlaceModeHover(fbState, cube, normal);
+      expect(tqec.kind).toBe("ghost");
+      expect(fb.kind).toBe("ghost");
+      if (tqec.kind !== "ghost" || fb.kind !== "ghost") continue;
+      expect(fb.pos).toEqual(tqec.pos);
+    }
+  });
+});
+
+describe("decidePlaceModeClick", () => {
+  it("returns place-at hovered.pos when cube tool replaces a different-type cube", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({ armedTool: "cube", cubeType: "XZZ", blocks: [cube] });
+    const action = decidePlaceModeClick(state, cube, new Vector3(1, 0, 0));
+    expect(action).toEqual({ kind: "place-at", pos: cube.pos });
+  });
+
+  it("FB-armed click on a different-type cube places at adj pipe slot, not at cube pos (REGRESSION)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const action = decidePlaceModeClick(state, cube, new Vector3(1, 0, 0));
+    expect(action).toEqual({ kind: "place-at", pos: { x: 1, y: 0, z: 0 } });
+  });
+
+  it("returns noop when no face normal and no cube-replace path applies", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "XZZ");
+    const state = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    const action = decidePlaceModeClick(state, cube, null);
+    expect(action).toEqual({ kind: "noop" });
+  });
+
+  it("FB-click adj position equals TQEC-click adj position for the same hover (parity)", () => {
+    const cube = block({ x: 0, y: 0, z: 0 }, "ZXZ");
+    const tqecState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      pipeVariant: "ZX",
+      blocks: [cube],
+    });
+    const fbState = makeState({
+      armedTool: "pipe",
+      cubeType: "XZZ",
+      fbPreset: FB_SWAP_ZX,
+      freeBuild: true,
+      blocks: [cube],
+    });
+    for (const normal of [
+      new Vector3(1, 0, 0),
+      new Vector3(-1, 0, 0),
+      new Vector3(0, 1, 0),
+      new Vector3(0, 0, 1),
+    ]) {
+      const tqec = decidePlaceModeClick(tqecState, cube, normal);
+      const fb = decidePlaceModeClick(fbState, cube, normal);
+      expect(tqec.kind).toBe("place-at");
+      expect(fb.kind).toBe("place-at");
+      if (tqec.kind !== "place-at" || fb.kind !== "place-at") continue;
+      expect(fb.pos).toEqual(tqec.pos);
+    }
+  });
+});
+
+// Sanity: the resolution helpers are re-exported from the logic module so
+// other components (OpenPipeGhosts) can import from one place. Cover the
+// re-exports so the surface is stable.
+describe("resolution helpers (sanity)", () => {
+  it("resolveFBSpecFromFace returns a valid pipe slot", () => {
+    const r = resolveFBSpecFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), FB_SWAP_ZX);
+    expect(r).not.toBeNull();
+    expect(r!.adj).toEqual({ x: 1, y: 0, z: 0 });
+    expect(r!.spec.openAxis).toBe(0);
+  });
+
+  it("resolvePipeTypeFromFace agrees with FB on adj slot", () => {
+    const tqec = resolvePipeTypeFromFace({ x: 0, y: 0, z: 0 }, "XZZ", new Vector3(1, 0, 0), "ZX");
+    expect(tqec).toBe("OZX");
+  });
+});

--- a/gui/src/components/BlockInstances.logic.ts
+++ b/gui/src/components/BlockInstances.logic.ts
@@ -1,0 +1,224 @@
+import * as THREE from "three";
+import type {
+  Block,
+  BlockType,
+  CubeType,
+  FBPreset,
+  FreeBuildPipeSpec,
+  PipeVariant,
+  Position3D,
+  SpatialIndex,
+} from "../types";
+import {
+  getAdjacentPos,
+  hasBlockOverlap,
+  hasCubeColorConflict,
+  hasPipeColorConflict,
+  hasYCubePipeAxisConflict,
+  isPipeType,
+  isValidPipePos,
+  isValidPos,
+  pipeAxisFromPos,
+  posKey,
+  resolvePipeType,
+  VARIANT_AXIS_MAP,
+} from "../types";
+import type { ArmedTool } from "../stores/blockStore";
+
+// FB-aware face-resolution helpers. Pure: no React, no zustand.
+
+export function resolvePipeTypeFromFace(
+  srcPos: Position3D,
+  srcType: BlockType,
+  normal: THREE.Vector3,
+  variant: PipeVariant,
+): BlockType | null {
+  for (const candidateType of VARIANT_AXIS_MAP[variant]) {
+    const probe = getAdjacentPos(srcPos, srcType, normal, candidateType);
+    if (!isValidPipePos(probe)) continue;
+    const resolved = resolvePipeType(variant, probe);
+    if (resolved) return resolved;
+  }
+  return null;
+}
+
+export function resolveFBSpecFromFace(
+  srcPos: Position3D,
+  srcType: BlockType,
+  normal: THREE.Vector3,
+  preset: FBPreset,
+): { adj: Position3D; spec: FreeBuildPipeSpec } | null {
+  for (const ax of [0, 1, 2] as const) {
+    const candidate: FreeBuildPipeSpec = { ...preset.spec, openAxis: ax };
+    const adj = getAdjacentPos(srcPos, srcType, normal, candidate);
+    if (!isValidPipePos(adj)) continue;
+    const tqecAxis = pipeAxisFromPos(adj);
+    if (tqecAxis === null) continue;
+    return { adj, spec: { ...preset.spec, openAxis: tqecAxis } };
+  }
+  return null;
+}
+
+// Snapshot the handlers project from the store before calling the decision
+// functions. Keeping the surface explicit means the logic is unit-testable
+// without instantiating a real store, and it documents exactly which fields
+// drive place-mode behaviour.
+export type PlaceModeState = {
+  armedTool: ArmedTool;
+  cubeType: CubeType | "Y";
+  pipeVariant: PipeVariant | null;
+  fbPreset: FBPreset | null;
+  freeBuild: boolean;
+  blocks: Map<string, Block>;
+  spatialIndex: SpatialIndex;
+};
+
+export type HoverIntent =
+  | {
+      kind: "ghost";
+      pos: Position3D;
+      type: BlockType;
+      invalid: boolean;
+      reason?: string;
+      replace: boolean;
+    }
+  | { kind: "clear" };
+
+export type ClickAction =
+  | { kind: "place-at"; pos: Position3D }
+  | { kind: "noop" };
+
+type Verdict =
+  | { kind: "ok"; replace: boolean }
+  | { kind: "invalid"; reason?: string; replace: boolean }
+  | { kind: "hidden" };
+
+function classifyTarget(
+  state: PlaceModeState,
+  pos: Position3D,
+  type: BlockType,
+  existingKey: string | undefined,
+): Verdict {
+  const existing = existingKey ? state.blocks.get(existingKey) : undefined;
+  const replace = !!(existing && existing.type !== type);
+  if (hasBlockOverlap(pos, type, state.blocks, state.spatialIndex, existingKey)) {
+    return { kind: "invalid", replace };
+  }
+  if (existing && existing.type === type) {
+    return { kind: "hidden" };
+  }
+  if (!state.freeBuild) {
+    if (isPipeType(type) && hasPipeColorConflict(type, pos, state.blocks)) {
+      return { kind: "invalid", reason: "Pipe colors don't match the adjacent cube", replace };
+    }
+    if (
+      !isPipeType(type) &&
+      type !== "Y" &&
+      hasCubeColorConflict(type as CubeType, pos, state.blocks)
+    ) {
+      return { kind: "invalid", reason: "Cube colors don't match the adjacent pipe", replace };
+    }
+    if (hasYCubePipeAxisConflict(type, pos, state.blocks)) {
+      return {
+        kind: "invalid",
+        reason: "Y cube cannot be next to an X-open or Y-open pipe",
+        replace,
+      };
+    }
+  }
+  return { kind: "ok", replace };
+}
+
+function resolveFaceDestination(
+  state: PlaceModeState,
+  hovered: Block,
+  normal: THREE.Vector3,
+): { dst: BlockType; adj: Position3D } | null {
+  if (state.fbPreset) {
+    const r = resolveFBSpecFromFace(hovered.pos, hovered.type, normal, state.fbPreset);
+    if (!r) return null;
+    return { dst: r.spec, adj: r.adj };
+  }
+  if (state.pipeVariant) {
+    const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, normal, state.pipeVariant);
+    if (!resolved) return null;
+    const adj = getAdjacentPos(hovered.pos, hovered.type, normal, resolved);
+    return { dst: resolved, adj };
+  }
+  // Cube tool: place adjacent cube of the chosen cubeType.
+  const dst: BlockType = state.cubeType;
+  const adj = getAdjacentPos(hovered.pos, hovered.type, normal, dst);
+  return { dst, adj };
+}
+
+export function decidePlaceModeHover(
+  state: PlaceModeState,
+  hovered: Block,
+  faceNormal: THREE.Vector3 | null,
+): HoverIntent {
+  // Cube-replace runs only when the cube tool is armed. The gate makes
+  // FB-armed and TQEC-pipe-armed paths fall through to face-based placement
+  // regardless of cubeType's value.
+  if (state.armedTool === "cube") {
+    const replaceType = state.cubeType;
+    if (isValidPos(hovered.pos, replaceType) && replaceType !== hovered.type) {
+      const verdict = classifyTarget(state, hovered.pos, replaceType, posKey(hovered.pos));
+      if (verdict.kind === "ok") {
+        return {
+          kind: "ghost",
+          pos: hovered.pos,
+          type: replaceType,
+          invalid: false,
+          replace: verdict.replace,
+        };
+      }
+      if (verdict.kind === "invalid") {
+        return {
+          kind: "ghost",
+          pos: hovered.pos,
+          type: replaceType,
+          invalid: true,
+          reason: verdict.reason,
+          replace: verdict.replace,
+        };
+      }
+      // hidden falls through to face-based placement.
+    }
+  }
+
+  if (!faceNormal) return { kind: "clear" };
+  const resolved = resolveFaceDestination(state, hovered, faceNormal);
+  if (!resolved) return { kind: "clear" };
+  const { dst, adj } = resolved;
+  if (!isValidPos(adj, dst)) return { kind: "clear" };
+  const adjKey = posKey(adj);
+  const existingKey = state.blocks.has(adjKey) ? adjKey : undefined;
+  const verdict = classifyTarget(state, adj, dst, existingKey);
+  if (verdict.kind === "hidden") return { kind: "clear" };
+  return {
+    kind: "ghost",
+    pos: adj,
+    type: dst,
+    invalid: verdict.kind === "invalid",
+    reason: verdict.kind === "invalid" ? verdict.reason : undefined,
+    replace: verdict.replace,
+  };
+}
+
+export function decidePlaceModeClick(
+  state: PlaceModeState,
+  clicked: Block,
+  faceNormal: THREE.Vector3 | null,
+): ClickAction {
+  if (state.armedTool === "cube") {
+    const replaceType = state.cubeType;
+    if (isValidPos(clicked.pos, replaceType) && replaceType !== clicked.type) {
+      return { kind: "place-at", pos: clicked.pos };
+    }
+  }
+
+  if (!faceNormal) return { kind: "noop" };
+  const resolved = resolveFaceDestination(state, clicked, faceNormal);
+  if (!resolved) return { kind: "noop" };
+  return { kind: "place-at", pos: resolved.adj };
+}

--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -8,23 +8,30 @@ import {
   createBlockGeometry,
   createBlockEdges,
   blockThreeSize,
-  hasBlockOverlap,
-  hasCubeColorConflict,
-  hasPipeColorConflict,
-  hasYCubePipeAxisConflict,
-  isValidPipePos,
-  isValidPos,
   isPipeType,
   isFreeBuildPipeSpec,
-  pipeAxisFromPos,
-  resolvePipeType,
-  getAdjacentPos,
-  posKey,
   blockTypeCacheKey,
-  VARIANT_AXIS_MAP,
+  posKey,
 } from "../types";
-import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant, FBPreset, FreeBuildPipeSpec } from "../types";
+import type { Block, BlockType, FaceMask } from "../types";
+import {
+  decidePlaceModeClick,
+  decidePlaceModeHover,
+  type PlaceModeState,
+} from "./BlockInstances.logic";
 import { posInActiveSlice } from "../utils/isoView";
+
+function snapshotPlaceMode(store: ReturnType<typeof useBlockStore.getState>): PlaceModeState {
+  return {
+    armedTool: store.armedTool,
+    cubeType: store.cubeType,
+    pipeVariant: store.pipeVariant,
+    fbPreset: store.fbPreset,
+    freeBuild: store.freeBuild,
+    blocks: store.blocks,
+    spatialIndex: store.spatialIndex,
+  };
+}
 
 const DIMMED_OPACITY = 0.18;
 const DIMMED_EDGE_OPACITY = 0.25;
@@ -45,45 +52,6 @@ const dimmedEdgeLineMaterial = new THREE.LineBasicMaterial({
   opacity: DIMMED_EDGE_OPACITY,
   depthWrite: false,
 });
-
-// eslint-disable-next-line react-refresh/only-export-components
-export function resolvePipeTypeFromFace(
-  srcPos: Position3D,
-  srcType: BlockType,
-  normal: THREE.Vector3,
-  variant: PipeVariant,
-): BlockType | null {
-  for (const candidateType of VARIANT_AXIS_MAP[variant]) {
-    const probe = getAdjacentPos(srcPos, srcType, normal, candidateType);
-    if (!isValidPipePos(probe)) continue;
-    const resolved = resolvePipeType(variant, probe);
-    if (resolved) return resolved;
-  }
-  return null;
-}
-
-// FB analogue of resolvePipeTypeFromFace. Iterates candidate open-axis values
-// to find a face-adjacent slot that lands on a valid pipe position, then sets
-// the spec's openAxis to match the slot's TQEC axis. Mirrors the placement
-// invariant in addBlock — the preset's template openAxis is overridden by
-// pipeAxisFromPos at placement time.
-// eslint-disable-next-line react-refresh/only-export-components
-export function resolveFBSpecFromFace(
-  srcPos: Position3D,
-  srcType: BlockType,
-  normal: THREE.Vector3,
-  preset: FBPreset,
-): { adj: Position3D; spec: FreeBuildPipeSpec } | null {
-  for (const ax of [0, 1, 2] as const) {
-    const candidate: FreeBuildPipeSpec = { ...preset.spec, openAxis: ax };
-    const adj = getAdjacentPos(srcPos, srcType, normal, candidate);
-    if (!isValidPipePos(adj)) continue;
-    const tqecAxis = pipeAxisFromPos(adj);
-    if (tqecAxis === null) continue;
-    return { adj, spec: { ...preset.spec, openAxis: tqecAxis } };
-  }
-  return null;
-}
 
 // eslint-disable-next-line react-refresh/only-export-components
 export function getCachedGeometry(blockType: BlockType, hiddenFaces: FaceMask): THREE.BufferGeometry {
@@ -267,71 +235,13 @@ function TypedInstances({
       // either removes the cube or does nothing (and sets a warning).
       store.setHoveredGridPos(null);
     } else {
-      // Place mode: check if we can replace the hovered block itself
-      const hovered = b[e.instanceId];
-      let replaceType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
-        const resolved = resolvePipeType(store.pipeVariant, hovered.pos);
-        if (resolved) replaceType = resolved;
-      }
-      if (isValidPos(hovered.pos, replaceType) && replaceType !== hovered.type) {
-        const hovKey = posKey(hovered.pos);
-        if (hasBlockOverlap(hovered.pos, replaceType, store.blocks, store.spatialIndex, hovKey)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, undefined, true);
-        } else if (!store.freeBuild && isPipeType(replaceType) && hasPipeColorConflict(replaceType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Pipe colors don't match the adjacent cube", true);
-        } else if (!store.freeBuild && !isPipeType(replaceType) && replaceType !== "Y" && hasCubeColorConflict(replaceType as CubeType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Cube colors don't match the adjacent pipe", true);
-        } else if (!store.freeBuild && hasYCubePipeAxisConflict(replaceType, hovered.pos, store.blocks)) {
-          store.setHoveredGridPos(hovered.pos, replaceType, true, "Y cube cannot be next to an X-open or Y-open pipe", true);
-        } else {
-          store.setHoveredGridPos(hovered.pos, replaceType, false, undefined, true);
-        }
-        return;
-      }
-
-      if (!e.face) return;
-
-      // Determine the destination block type for adjacent placement
-      let dstType: BlockType = store.cubeType;
-      if (store.fbPreset) {
-        const r = resolveFBSpecFromFace(hovered.pos, hovered.type, e.face.normal, store.fbPreset);
-        if (!r) {
-          store.setHoveredGridPos(null);
-          return;
-        }
-        dstType = r.spec;
-      } else if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(hovered.pos, hovered.type, e.face.normal, store.pipeVariant);
-        if (!resolved) {
-          store.setHoveredGridPos(null);
-          return;
-        }
-        dstType = resolved;
-      }
-
-      const adj = getAdjacentPos(hovered.pos, hovered.type, e.face.normal, dstType);
-
-      if (!isValidPos(adj, dstType)) {
+      // Place mode: pure decision logic lives in BlockInstances.logic.ts so
+      // the cube-replace gate and FB/TQEC pipe paths are unit-testable.
+      const intent = decidePlaceModeHover(snapshotPlaceMode(store), b[e.instanceId], e.face?.normal ?? null);
+      if (intent.kind === "clear") {
         store.setHoveredGridPos(null);
-        return;
-      }
-      const adjKey = posKey(adj);
-      const existingKey = store.blocks.has(adjKey) ? adjKey : undefined;
-      const adjReplace = !!(existingKey && store.blocks.get(existingKey)!.type !== dstType);
-      if (hasBlockOverlap(adj, dstType, store.blocks, store.spatialIndex, existingKey)) {
-        store.setHoveredGridPos(adj, dstType, true, undefined, adjReplace);
-      } else if (existingKey && store.blocks.get(existingKey)!.type === dstType) {
-        // Same type — no replacement needed, hide ghost
-        store.setHoveredGridPos(null);
-      } else if (!store.freeBuild && isPipeType(dstType) && hasPipeColorConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Pipe colors don't match the adjacent cube", adjReplace);
-      } else if (!store.freeBuild && !isPipeType(dstType) && dstType !== "Y" && hasCubeColorConflict(dstType as CubeType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Cube colors don't match the adjacent pipe", adjReplace);
-      } else if (!store.freeBuild && hasYCubePipeAxisConflict(dstType, adj, store.blocks)) {
-        store.setHoveredGridPos(adj, dstType, true, "Y cube cannot be next to an X-open or Y-open pipe", adjReplace);
       } else {
-        store.setHoveredGridPos(adj, dstType, false, undefined, adjReplace);
+        store.setHoveredGridPos(intent.pos, intent.type, intent.invalid, intent.reason, intent.replace);
       }
     }
   };
@@ -366,42 +276,14 @@ function TypedInstances({
       store.commitPaste();
       return;
     }
-    {
-      // Port-conversion tool: click on a cube to remove it (leaving a port
-      // if a pipe was attached). Never falls through to pipe-placement.
-      if (armed === "port") {
-        store.convertBlockToPort(b[e.instanceId].pos);
-        return;
-      }
-      // Place mode: try replacing the clicked block if the selected type
-      // is valid at the clicked block's position
-      const clicked = b[e.instanceId];
-      let replaceType: BlockType = store.cubeType;
-      if (store.pipeVariant) {
-        const resolved = resolvePipeType(store.pipeVariant, clicked.pos);
-        if (resolved) replaceType = resolved;
-      }
-      if (isValidPos(clicked.pos, replaceType) && replaceType !== clicked.type) {
-        store.addBlock(clicked.pos);
-        return;
-      }
-
-      if (!e.face) return;
-
-      let dstType: BlockType = store.cubeType;
-      if (store.fbPreset) {
-        const r = resolveFBSpecFromFace(clicked.pos, clicked.type, e.face.normal, store.fbPreset);
-        if (!r) return;
-        dstType = r.spec;
-      } else if (store.pipeVariant) {
-        const resolved = resolvePipeTypeFromFace(clicked.pos, clicked.type, e.face.normal, store.pipeVariant);
-        if (!resolved) return;
-        dstType = resolved;
-      }
-
-      const adj = getAdjacentPos(clicked.pos, clicked.type, e.face.normal, dstType);
-      store.addBlock(adj);
+    // Port-conversion tool: click on a cube to remove it (leaving a port
+    // if a pipe was attached). Never falls through to pipe-placement.
+    if (armed === "port") {
+      store.convertBlockToPort(b[e.instanceId].pos);
+      return;
     }
+    const action = decidePlaceModeClick(snapshotPlaceMode(store), b[e.instanceId], e.face?.normal ?? null);
+    if (action.kind === "place-at") store.addBlock(action.pos);
   };
 
   if (blocks.length === 0) return null;

--- a/gui/src/components/DragShadow.test.tsx
+++ b/gui/src/components/DragShadow.test.tsx
@@ -1,0 +1,162 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block } from "../types";
+import { DragShadow, MAX_SHADOWS } from "./DragShadow";
+
+function meshColor(node: { instance: unknown }): number {
+  return ((node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial).color.getHex();
+}
+
+function mk(pos: { x: number; y: number; z: number }, type: Block["type"] = "XZZ"): Block {
+  return { pos, type };
+}
+
+function setup(opts: {
+  blocks?: Array<[string, Block]>;
+  selected?: string[];
+  dragDelta?: { x: number; y: number; z: number } | null;
+  dragValid?: boolean;
+}) {
+  useBlockStore.setState(
+    {
+      blocks: new Map(opts.blocks ?? []),
+      selectedKeys: new Set(opts.selected ?? []),
+      dragDelta: opts.dragDelta ?? null,
+      dragValid: opts.dragValid ?? true,
+      isDraggingSelection: opts.dragDelta != null,
+    },
+    false,
+  );
+}
+
+beforeEach(() => {
+  // Hard reset all fields DragShadow reads, plus closely-related drag state.
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      selectedKeys: new Set(),
+      dragDelta: null,
+      dragValid: true,
+      isDraggingSelection: false,
+    },
+    false,
+  );
+});
+
+describe("<DragShadow>", () => {
+  it("renders nothing with empty selection", async () => {
+    setup({});
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("renders one shadow per elevated selected block at rest, none for z=0 blocks", async () => {
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["0,0,3", mk({ x: 0, y: 0, z: 3 })],
+        ["3,0,3", mk({ x: 3, y: 0, z: 3 })],
+      ],
+      selected: ["0,0,0", "0,0,3", "3,0,3"],
+      dragDelta: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // Two elevated blocks -> two GroundShadowAbsolute groups.
+    expect(r.scene.findAllByType("Group")).toHaveLength(2);
+  });
+
+  it("renders nothing if all selected blocks are on the ground", async () => {
+    setup({
+      blocks: [["0,0,0", mk({ x: 0, y: 0, z: 0 })]],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(0);
+  });
+
+  it("uses shifted positions when dragDelta is non-zero", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 6, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const group = r.scene.findByType("Group");
+    // Shifted block at (6, 0, 3) -> ground center cx = 6.5, cz = -0.5
+    expect(group.instance.position.x).toBeCloseTo(6.5);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+
+  it("treats {0,0,0} dragDelta as at-rest mode (no shift, neutral validity)", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 0, y: 0, z: 0 },
+      dragValid: false, // would turn red if drag mode kicked in
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // At-rest -> always-valid -> black mesh, not red
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0x000000);
+  });
+
+  it("renders red shadows when dragValid=false during a real drag", async () => {
+    setup({
+      blocks: [["0,0,3", mk({ x: 0, y: 0, z: 3 })]],
+      selected: ["0,0,3"],
+      dragDelta: { x: 3, y: 0, z: 0 },
+      dragValid: false,
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(meshColor(r.scene.findByType("Mesh"))).toBe(0xff5555);
+  });
+
+  it("caps at MAX_SHADOWS for huge selections", async () => {
+    const blocks: Array<[string, Block]> = [];
+    const selected: string[] = [];
+    // Build 250 elevated blocks, all selected
+    for (let i = 0; i < 250; i++) {
+      const key = `${i * 3},0,3`;
+      blocks.push([key, mk({ x: i * 3, y: 0, z: 3 })]);
+      selected.push(key);
+    }
+    setup({ blocks, selected });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    expect(r.scene.findAllByType("Group")).toHaveLength(MAX_SHADOWS);
+  });
+
+  it("applies yBlockZOffset to at-rest Y-cube under a pipe (visually lifted)", async () => {
+    // Y-cube at logical z=0 with a pipe at z=1 above it -> visually lifted by 0.5
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")], // Z-open pipe above
+      ],
+      selected: ["0,0,0"],
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    // With the lift, the Y-cube's effective z is 0.5 -> shadow appears.
+    expect(r.scene.findAllByType("Group")).toHaveLength(1);
+    const line = r.scene.findByType("LineSegments");
+    // Line len = 0.5 - Y_OFFSET ≈ 0.49
+    expect(line.instance.scale.y).toBeCloseTo(0.49, 2);
+  });
+
+  it("does NOT apply yBlockZOffset during drag (mirrors DragGhost behavior)", async () => {
+    // Y-cube being dragged from z=0 to z=3. During drag we use shifted logical
+    // pos (z=3), no lift even if a pipe sits at z=4 in the destination.
+    setup({
+      blocks: [
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")],
+        ["3,0,4", mk({ x: 3, y: 0, z: 4 }, "ZXO")], // pipe at destination top
+      ],
+      selected: ["0,0,0"],
+      dragDelta: { x: 3, y: 0, z: 3 },
+    });
+    const r = await ReactThreeTestRenderer.create(<DragShadow />);
+    const line = r.scene.findByType("LineSegments");
+    // Pure shifted z=3, line len = 3 - Y_OFFSET ≈ 2.99
+    expect(line.instance.scale.y).toBeCloseTo(2.99, 2);
+  });
+});

--- a/gui/src/components/DragShadow.tsx
+++ b/gui/src/components/DragShadow.tsx
@@ -1,0 +1,69 @@
+import { useMemo } from "react";
+import { useBlockStore } from "../stores/blockStore";
+import { yBlockZOffset } from "../types";
+import type { Block, Position3D } from "../types";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+export const MAX_SHADOWS = 200;
+
+export function DragShadow() {
+  const dragDelta = useBlockStore((s) => s.dragDelta);
+  const dragValid = useBlockStore((s) => s.dragValid);
+  const selectedKeys = useBlockStore((s) => s.selectedKeys);
+  const blocks = useBlockStore((s) => s.blocks);
+
+  // Stable list keyed on selectedKeys/blocks (same pattern as DragGhost) so
+  // rAF-driven dragDelta/dragValid only re-render leaves.
+  const shadows = useMemo(() => {
+    const result: Array<{ key: string; block: Block }> = [];
+    for (const key of selectedKeys) {
+      const block = blocks.get(key);
+      if (!block) continue;
+      result.push({ key, block });
+      if (result.length >= MAX_SHADOWS) break;
+    }
+    return result;
+  }, [selectedKeys, blocks]);
+
+  if (shadows.length === 0) return null;
+
+  // {0,0,0} delta = at-rest mode (treated as null). Drag commits a non-zero
+  // delta the moment the pointer crosses the drag threshold.
+  const liveDelta =
+    dragDelta && (dragDelta.x !== 0 || dragDelta.y !== 0 || dragDelta.z !== 0)
+      ? dragDelta
+      : null;
+  const valid = liveDelta ? dragValid : true;
+
+  return (
+    <>
+      {shadows.map(({ key, block }) => {
+        let pos: Position3D;
+        if (liveDelta) {
+          // Drag mode: shifted logical position, no Y-cube lift (matches
+          // DragGhost which renders the dragged ghost at the logical destination).
+          pos = {
+            x: block.pos.x + liveDelta.x,
+            y: block.pos.y + liveDelta.y,
+            z: block.pos.z + liveDelta.z,
+          };
+        } else {
+          // At-rest mode: committed block is rendered by BlockInstances with
+          // yBlockZOffset applied to Y-cubes that have a pipe above. Mirror
+          // that lift here so the shadow reflects what the user actually SEES,
+          // not the bare logical z.
+          const lift = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
+          pos = { ...block.pos, z: block.pos.z + lift };
+        }
+        return (
+          <GroundShadowAbsolute
+            key={key}
+            pos={pos}
+            blockType={block.type}
+            valid={valid}
+          />
+        );
+      })}
+    </>
+  );
+}

--- a/gui/src/components/FlowsPanel.tsx
+++ b/gui/src/components/FlowsPanel.tsx
@@ -221,19 +221,52 @@ export function FlowsPanel({
     if (stale && flowVizMode) setFlowVizMode(false);
   }, [stale, flowVizMode, setFlowVizMode]);
 
+  // Order port labels by user-defined rank (PortMeta.rank). Labels without a
+  // rank fall back to the server's order. This drives the column order in the
+  // generator and membership tables, i.e. the qubit-register position when
+  // the diagram is interpreted as a circuit.
+  const labelRank = useMemo(() => {
+    const m = new Map<string, number>();
+    for (const meta of portMeta.values()) {
+      if (meta.rank !== undefined) m.set(meta.label, meta.rank);
+    }
+    return m;
+  }, [portMeta]);
+  const sortByRank = useCallback(
+    (labels: string[]): string[] => {
+      const indexed = labels.map((l, i) => ({ l, i }));
+      indexed.sort((a, b) => {
+        const ra = labelRank.get(a.l) ?? Number.POSITIVE_INFINITY;
+        const rb = labelRank.get(b.l) ?? Number.POSITIVE_INFINITY;
+        if (ra !== rb) return ra - rb;
+        return a.i - b.i;
+      });
+      return indexed.map(({ l }) => l);
+    },
+    [labelRank],
+  );
+  const orderedInputs = useMemo(
+    () => (result?.ok ? sortByRank(result.inputs) : []),
+    [result, sortByRank],
+  );
+  const orderedOutputs = useMemo(
+    () => (result?.ok ? sortByRank(result.outputs) : []),
+    [result, sortByRank],
+  );
+
   const generatorSpan = useMemo(() => {
     if (!result || !result.ok) return null;
-    const labels = [...result.inputs, ...result.outputs];
+    const labels = [...orderedInputs, ...orderedOutputs];
     const vecs = result.flows.map((flow) => {
       const pauliStr = labels
         .map((l, i) =>
-          i < result.inputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
+          i < orderedInputs.length ? flow.inputs[l] ?? "I" : flow.outputs[l] ?? "I",
         )
         .join("");
       return pauliToSymplectic(pauliStr);
     });
-    return { labels, vecs, inputCount: result.inputs.length };
-  }, [result]);
+    return { labels, vecs, inputCount: orderedInputs.length };
+  }, [result, orderedInputs, orderedOutputs]);
 
   const addQuery = useCallback(() => {
     if (!generatorSpan) return;
@@ -475,7 +508,7 @@ export function FlowsPanel({
               <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                 <thead>
                   <tr>
-                    {result.inputs.map((label) => (
+                    {orderedInputs.map((label) => (
                       <th
                         key={`in-${label}`}
                         style={{
@@ -489,7 +522,7 @@ export function FlowsPanel({
                       </th>
                     ))}
                     <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>→</th>
-                    {result.outputs.map((label) => (
+                    {orderedOutputs.map((label) => (
                       <th
                         key={`out-${label}`}
                         style={{
@@ -521,7 +554,7 @@ export function FlowsPanel({
                           outline: isActive ? "2px solid #4a9eff" : undefined,
                         }}
                       >
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <td
                             key={`in-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -530,7 +563,7 @@ export function FlowsPanel({
                           </td>
                         ))}
                         <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <td
                             key={`out-${label}`}
                             style={{ padding: "3px 6px", textAlign: "center" }}
@@ -610,7 +643,7 @@ export function FlowsPanel({
                   <table style={{ borderCollapse: "collapse", fontSize: 12 }}>
                     <thead>
                       <tr>
-                        {result.inputs.map((label) => (
+                        {orderedInputs.map((label) => (
                           <th
                             key={`qin-${label}`}
                             style={{
@@ -626,7 +659,7 @@ export function FlowsPanel({
                         <th style={{ padding: "0 4px", borderBottom: "1px solid #ddd" }}>
                           →
                         </th>
-                        {result.outputs.map((label) => (
+                        {orderedOutputs.map((label) => (
                           <th
                             key={`qout-${label}`}
                             style={{
@@ -648,7 +681,7 @@ export function FlowsPanel({
                         const inSpan = isQueryInSpan(q);
                         return (
                           <tr key={q.id}>
-                            {result.inputs.map((label) => (
+                            {orderedInputs.map((label) => (
                               <td
                                 key={`qin-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}
@@ -660,7 +693,7 @@ export function FlowsPanel({
                               </td>
                             ))}
                             <td style={{ padding: "0 4px", color: "#888" }}>→</td>
-                            {result.outputs.map((label) => (
+                            {orderedOutputs.map((label) => (
                               <td
                                 key={`qout-${label}`}
                                 style={{ padding: "3px 6px", textAlign: "center" }}

--- a/gui/src/components/FreeBuildPipeVariantsPanel.tsx
+++ b/gui/src/components/FreeBuildPipeVariantsPanel.tsx
@@ -1,0 +1,203 @@
+import { useMemo } from "react";
+import { useBlockStore } from "../stores/blockStore";
+import {
+  FACE_CONFIGS,
+  X_HEX,
+  Y_DEFECT_HEX,
+  Z_HEX,
+  faceAboveBasis,
+  faceBelowBasis,
+  isFreeBuildPipeSpec,
+} from "../types";
+import type { FaceConfig } from "../types";
+import { useFloatingPanel } from "../hooks/useFloatingPanel";
+import { ResizeGrip } from "../hooks/ResizeGrip";
+
+const PANEL_MIN_WIDTH = 320;
+const PANEL_MIN_HEIGHT = 260;
+
+const COLOR_FOR: Record<"X" | "Z", string> = { X: X_HEX, Z: Z_HEX };
+
+const CELL_W = 56;
+const CELL_H = 36;
+// Face order matches FreeBuildPipeSpec.faces: [+ca0, −ca0, +ca1, −ca1].
+const FACE_LABELS = ["+a", "−a", "+b", "−b"] as const;
+
+function VariantSprite({ faces, size = 1 }: { faces: readonly FaceConfig[]; size?: number }) {
+  // 4 walls × (below, above) strips. Layout: vertical stack of 4 rows, each
+  // row is two halves (left = below, right = above). A magenta divider sits
+  // between the halves on swapping faces (XZ/ZX), echoing the Y-defect ring.
+  const rowH = (CELL_H * size) / 4;
+  const halfW = (CELL_W * size) / 2;
+  return (
+    <svg
+      width={CELL_W * size}
+      height={CELL_H * size}
+      viewBox={`0 0 ${CELL_W * size} ${CELL_H * size}`}
+      shapeRendering="crispEdges"
+    >
+      {faces.map((fc, i) => {
+        const y = i * rowH;
+        const below = COLOR_FOR[faceBelowBasis(fc)];
+        const above = COLOR_FOR[faceAboveBasis(fc)];
+        const swap = fc === "XZ" || fc === "ZX";
+        return (
+          <g key={i}>
+            <rect x={0} y={y} width={halfW} height={rowH} fill={below} />
+            <rect x={halfW} y={y} width={halfW} height={rowH} fill={above} />
+            {swap && (
+              <line
+                x1={halfW}
+                y1={y}
+                x2={halfW}
+                y2={y + rowH}
+                stroke={Y_DEFECT_HEX}
+                strokeWidth={2}
+              />
+            )}
+          </g>
+        );
+      })}
+    </svg>
+  );
+}
+
+function facesEqual(
+  a: readonly FaceConfig[],
+  b: readonly FaceConfig[],
+): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** Enumerate every (face0, face1, face2, face3) ∈ FACE_CONFIGS⁴. */
+function enumerateVariants(): Array<[FaceConfig, FaceConfig, FaceConfig, FaceConfig]> {
+  const out: Array<[FaceConfig, FaceConfig, FaceConfig, FaceConfig]> = [];
+  for (const f0 of FACE_CONFIGS) {
+    for (const f1 of FACE_CONFIGS) {
+      for (const f2 of FACE_CONFIGS) {
+        for (const f3 of FACE_CONFIGS) {
+          out.push([f0, f1, f2, f3]);
+        }
+      }
+    }
+  }
+  return out;
+}
+
+export function FreeBuildPipeVariantsPanel() {
+  const fbPos = useBlockStore((s) => s.fbVariantsPos);
+  const blocks = useBlockStore((s) => s.blocks);
+  const setFBVariantsPos = useBlockStore((s) => s.setFBVariantsPos);
+  const setFBPipeFaces = useBlockStore((s) => s.setFBPipeFaces);
+
+  const block = fbPos ? blocks.get(fbPos) : null;
+  const open = !!(block && isFreeBuildPipeSpec(block.type));
+
+  const {
+    containerStyle,
+    dragHandleProps,
+    resizeGripProps,
+  } = useFloatingPanel({
+    id: "fb-variants",
+    defaultGeometry: {
+      x: typeof window !== "undefined" ? window.innerWidth - 360 : 10,
+      y: 70,
+      width: 340,
+      height: 460,
+    },
+    minWidth: PANEL_MIN_WIDTH,
+    minHeight: PANEL_MIN_HEIGHT,
+  });
+
+  const variants = useMemo(() => enumerateVariants(), []);
+
+  if (!open || !block || !isFreeBuildPipeSpec(block.type)) return null;
+  const currentFaces = block.type.faces;
+
+  return (
+    <div
+      style={{
+        ...containerStyle,
+        zIndex: 50,
+        background: "#fff",
+        borderRadius: 10,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.18)",
+        display: "flex",
+        flexDirection: "column",
+        fontFamily: "sans-serif",
+        fontSize: 12,
+        color: "#222",
+        overflow: "hidden",
+      }}
+    >
+      <header
+        {...dragHandleProps}
+        style={{
+          ...dragHandleProps.style,
+          padding: "10px 12px",
+          borderBottom: "1px solid #eee",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+        }}
+      >
+        <span style={{ fontWeight: 600, fontSize: 13 }}>Free Pipe variants</span>
+        <button
+          onClick={() => setFBVariantsPos(null)}
+          aria-label="Close FB variants panel"
+          style={{ background: "none", border: "none", fontSize: 16, cursor: "pointer", color: "#666", padding: "0 4px" }}
+        >
+          ✕
+        </button>
+      </header>
+
+      <div style={{ padding: "8px 12px", borderBottom: "1px solid #eee", display: "flex", alignItems: "center", gap: 12 }}>
+        <span style={{ color: "#666" }}>Current</span>
+        <VariantSprite faces={currentFaces} size={1.2} />
+        <span style={{ color: "#888", fontFamily: "monospace" }}>{currentFaces.join(" ")}</span>
+      </div>
+
+      <div style={{ padding: "8px 12px", color: "#666", fontSize: 11, borderBottom: "1px solid #eee" }}>
+        Rows top→bottom: {FACE_LABELS.join(", ")}. Left half = below defect, right half = above.
+      </div>
+
+      <div
+        style={{
+          padding: 8,
+          flex: 1,
+          overflowY: "auto",
+          display: "grid",
+          gridTemplateColumns: `repeat(auto-fill, minmax(${CELL_W + 12}px, 1fr))`,
+          gap: 6,
+        }}
+      >
+        {variants.map((faces, idx) => {
+          const isCurrent = facesEqual(faces, currentFaces);
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => setFBPipeFaces(block.pos, faces)}
+              title={faces.join(" ")}
+              style={{
+                padding: 4,
+                background: isCurrent ? "#e8f1ff" : "#fafafa",
+                border: `1px solid ${isCurrent ? "#4a9eff" : "#e0e0e0"}`,
+                borderRadius: 4,
+                cursor: "pointer",
+                display: "flex",
+                justifyContent: "center",
+              }}
+            >
+              <VariantSprite faces={faces} />
+            </button>
+          );
+        })}
+      </div>
+
+      <ResizeGrip {...resizeGripProps} />
+    </div>
+  );
+}

--- a/gui/src/components/GhostBlock.test.tsx
+++ b/gui/src/components/GhostBlock.test.tsx
@@ -1,0 +1,173 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { GhostBlock } from "./GhostBlock";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+describe("<GhostBlock>", () => {
+  it("renders nothing when hoveredGridPos is null", async () => {
+    useBlockStore.setState({ hoveredGridPos: null }, false);
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in build mode", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, mode: "build" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is pointer", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "pointer" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing in edit mode when armedTool is paste", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "paste" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders cube ghost only (no shadow) at ground level", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 0 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // The ghost itself is one positioned group + inner scaled group; no second
+    // GroundShadowAbsolute group because z=0 -> shouldRenderShadow false.
+    const groups = r.scene.findAllByType("Group");
+    // 1 outer positioned group + 1 inner scaled group = 2 (no shadow group)
+    expect(groups.length).toBe(2);
+  });
+
+  it("renders cube ghost + GroundShadowAbsolute at z=2", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "cube", cubeType: "XZZ" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    const groups = r.scene.findAllByType("Group");
+    // ghost outer + ghost inner-scaled + GroundShadowAbsolute world-positioned group = 3
+    expect(groups.length).toBe(3);
+    // 2 LineSegments: ghost-block edges (existing) + shadow projection line (new).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("Y-cube placement preview at z=0 with pipe above gets a lifted shadow", async () => {
+    // A Z-open pipe sits at z=1 directly above the hovered Y placement at z=0.
+    // yBlockZOffset returns 0.5 → effective z = 0.5 → shadow renders.
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 0 },
+        armedTool: "cube",
+        cubeType: "Y",
+        blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Without the yBlockZOffset adjustment, no shadow would render (logical z=0).
+    // With it, effective z=0.5 → shadow + line appear. 2 LineSegments total:
+    // ghost-block edges + shadow projection line.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("port placement preview at z=2 renders port ghost + GroundShadow", async () => {
+    useBlockStore.setState(
+      { hoveredGridPos: { x: 0, y: 0, z: 2 }, armedTool: "port" },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Port ghost positioned group + GroundShadowAbsolute group = 2
+    const groups = r.scene.findAllByType("Group");
+    expect(groups.length).toBe(2);
+    // port-ghost edges (existing) + shadow line (new) = 2 LineSegments.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("isInvalid hover at z=2 renders red shadow (invalid color)", async () => {
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        hoveredInvalid: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Both the ghost edges and the shadow line render in red for invalid hover.
+    // GhostBlock uses #ff0000 lineMaterial; GroundShadowAbsolute uses #ff0000.
+    // Assert all LineSegments are red.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
+  });
+
+  it("isDelete (xHeld in edit mode) renders delete preview but NO shadow", async () => {
+    // xHeld + edit mode = isDelete. We render the existing block being targeted
+    // for removal in red, but explicitly do NOT add a ground shadow (it's a
+    // "remove this" cue, not a "place here" cue).
+    useBlockStore.setState(
+      {
+        hoveredGridPos: { x: 0, y: 0, z: 2 },
+        armedTool: "cube",
+        cubeType: "XZZ",
+        xHeld: true,
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<GhostBlock />);
+    // Delete branch renders only a mesh (no edges). No shadow either.
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(0);
+  });
+});

--- a/gui/src/components/GhostBlock.tsx
+++ b/gui/src/components/GhostBlock.tsx
@@ -13,6 +13,7 @@ import { isoTopThreeAxis } from "../utils/isoFoldOut";
 import type { ThreeAxis } from "../utils/isoFoldOut";
 import { getCachedGeometry, getCachedEdges, getCachedFullBox } from "./BlockInstances";
 import { FoldOutCubeFaces } from "./FoldOutCube";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
 
 const noRaycast = () => {};
 
@@ -116,16 +117,19 @@ function GhostBlockInner() {
   if (armedTool === "port" && mode === "edit" && !xHeld) {
     const [x, y, z] = tqecToThree(hoveredGridPos, "XZZ");
     return (
-      <group position={[x, y, z]}>
-        <mesh raycast={noRaycast}>
-          <primitive object={portGhostBox} attach="geometry" />
-          <primitive object={portGhostMaterial} attach="material" />
-        </mesh>
-        <lineSegments raycast={noRaycast}>
-          <primitive object={portGhostEdges} attach="geometry" />
-          <primitive object={validLineMaterial} attach="material" />
-        </lineSegments>
-      </group>
+      <>
+        <group position={[x, y, z]}>
+          <mesh raycast={noRaycast}>
+            <primitive object={portGhostBox} attach="geometry" />
+            <primitive object={portGhostMaterial} attach="material" />
+          </mesh>
+          <lineSegments raycast={noRaycast}>
+            <primitive object={portGhostEdges} attach="geometry" />
+            <primitive object={validLineMaterial} attach="material" />
+          </lineSegments>
+        </group>
+        <GroundShadowAbsolute pos={hoveredGridPos} blockType="XZZ" valid />
+      </>
     );
   }
 
@@ -178,39 +182,54 @@ function GhostBlockInner() {
     (CUBE_TYPES as readonly string[]).includes(activeType);
   const foldTopAxis: ThreeAxis = viewMode.kind === "iso" ? isoTopThreeAxis(viewMode.axis) : 0;
 
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // a Y-cube placement preview lifted by an above pipe still gets a shadow
+  // whose projection line reaches the rendered block bottom. No shadow for
+  // delete previews — that's a "remove this" cue, not a "place here" cue.
+  const shadowPos = { ...hoveredGridPos, z: hoveredGridPos.z + zo };
+
   return (
-    <group position={[x, y, z]}>
-      {isDelete ? (
-        <mesh scale={1.01} raycast={noRaycast}>
-          <primitive object={getCachedFullBox(activeType)} attach="geometry" />
-          <primitive object={deleteMaterial} attach="material" />
-        </mesh>
-      ) : (
-        <group scale={scale}>
-          {!showFoldOutCube && (
-            <>
-              <mesh>
-                <primitive object={ghostGeometry} attach="geometry" />
-                <primitive object={meshMat} attach="material" />
-              </mesh>
-              <lineSegments>
-                <primitive object={ghostEdges} attach="geometry" />
-                <primitive object={lineMat} attach="material" />
+    <>
+      <group position={[x, y, z]}>
+        {isDelete ? (
+          <mesh scale={1.01} raycast={noRaycast}>
+            <primitive object={getCachedFullBox(activeType)} attach="geometry" />
+            <primitive object={deleteMaterial} attach="material" />
+          </mesh>
+        ) : (
+          <group scale={scale}>
+            {!showFoldOutCube && (
+              <>
+                <mesh>
+                  <primitive object={ghostGeometry} attach="geometry" />
+                  <primitive object={meshMat} attach="material" />
+                </mesh>
+                <lineSegments>
+                  <primitive object={ghostEdges} attach="geometry" />
+                  <primitive object={lineMat} attach="material" />
+                </lineSegments>
+              </>
+            )}
+            {fullPipeEdges && (
+              <lineSegments scale={1.04} renderOrder={999}>
+                <primitive object={fullPipeEdges} attach="geometry" />
+                <primitive object={depthPipeOutlineMaterial} attach="material" />
               </lineSegments>
-            </>
-          )}
-          {fullPipeEdges && (
-            <lineSegments scale={1.04} renderOrder={999}>
-              <primitive object={fullPipeEdges} attach="geometry" />
-              <primitive object={depthPipeOutlineMaterial} attach="material" />
-            </lineSegments>
-          )}
-          {showFoldOutCube && (
-            <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
-          )}
-        </group>
+            )}
+            {showFoldOutCube && (
+              <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
+            )}
+          </group>
+        )}
+      </group>
+      {!isDelete && (
+        <GroundShadowAbsolute
+          pos={shadowPos}
+          blockType={activeType}
+          valid={!isInvalid}
+        />
       )}
-    </group>
+    </>
   );
 }
 

--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -18,6 +18,7 @@ import {
 } from "../types";
 import type { CubeType, Position3D, ViewMode } from "../types";
 import { cameraGroundPoint } from "../utils/groundPlane";
+import { shouldPassThroughGridPlane } from "../utils/gridPlanePassthrough";
 import { snapIsoPos, isoGridMeshTransform } from "../utils/isoView";
 
 const PLANE_SIZE = 1000;
@@ -61,6 +62,21 @@ export function GridPlane() {
   });
 
   const handlePointerMove = (e: ThreeEvent<PointerEvent>) => {
+    // Pass-through (pointer/paste only): when a block/port is also under the
+    // cursor, return early without stopProp so the block's onPointerMove sets
+    // hoveredGridPos. Done before any setHoveredGridPos call so we don't write
+    // the plane cell and let the block immediately overwrite it (one-frame
+    // flash on stacked hits).
+    if (mode === "edit") {
+      const s = useBlockStore.getState();
+      if (
+        !s.xHeld &&
+        (s.armedTool === "pointer" || s.armedTool === "paste") &&
+        shouldPassThroughGridPlane(e.intersections, meshRef.current)
+      ) {
+        return;
+      }
+    }
     e.stopPropagation();
     if (mode !== "edit") { setHoveredGridPos(null); return; }
 
@@ -120,17 +136,31 @@ export function GridPlane() {
   };
 
   const handleClick = (e: ThreeEvent<MouseEvent>) => {
-    e.stopPropagation();
-    if (e.delta > 2) return; // ignore drags
-    if (mode !== "edit") return;
+    if (e.delta > 2) { e.stopPropagation(); return; } // ignore drags
+    if (mode !== "edit") { e.stopPropagation(); return; }
 
     const store = useBlockStore.getState();
     // X-held delete on empty grid is a no-op.
-    if (store.xHeld) return;
+    if (store.xHeld) { e.stopPropagation(); return; }
+
     if (store.armedTool === "pointer") {
+      // Pass-through: when the click ray also hits a block or port ghost
+      // further along, let that handler own the event so sub-ground blocks
+      // (TQEC z<0) can be selected from above.
+      //
+      // NOTE: this couples deselect-on-empty-click policy to GridPlane. Any
+      // future clickable scene mesh must either opt out of raycast (the
+      // raycast={noRaycast} convention used by decoratives) or call
+      // e.stopPropagation() in its own onClick. Otherwise deselection would
+      // silently stop working through that mesh.
+      if (shouldPassThroughGridPlane(e.intersections, meshRef.current)) return;
+      e.stopPropagation();
       store.clearSelection();
       return;
     }
+    // Paste / port / placement: the plane is the intended target, so we
+    // always consume the click here.
+    e.stopPropagation();
     // Paste tool: commit the clipboard at the snapped hover cell, then
     // return to pointer (commitPaste sets armedTool="pointer").
     if (store.armedTool === "paste") {

--- a/gui/src/components/GroundShadowAbsolute.test.tsx
+++ b/gui/src/components/GroundShadowAbsolute.test.tsx
@@ -1,0 +1,103 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { describe, expect, it } from "vitest";
+import {
+  INVALID_LINE_COLOR,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+} from "../utils/groundShadow";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+function meshMaterial(node: { instance: unknown }): THREE.MeshBasicMaterial {
+  return (node.instance as THREE.Mesh).material as THREE.MeshBasicMaterial;
+}
+function lineMaterial(node: { instance: unknown }): THREE.LineBasicMaterial {
+  return (node.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+}
+
+describe("<GroundShadowAbsolute>", () => {
+  it("renders nothing when on the ground (z=0)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 0 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing when below ground (defensive)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: -1 }} blockType="XZZ" valid />,
+    );
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders a group + mesh + line for an elevated cube", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 3, y: 6, z: 2 }} blockType="XZZ" valid />,
+    );
+    const groups = r.scene.findAllByType("Group");
+    expect(groups).toHaveLength(1);
+    const group = groups[0];
+    // World-space group at (cx, 0, cz) = (3.5, 0, -6.5)
+    expect(group.instance.position.x).toBeCloseTo(3.5);
+    expect(group.instance.position.y).toBeCloseTo(0);
+    expect(group.instance.position.z).toBeCloseTo(-6.5);
+    // Mesh + line live inside the group
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(1);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(1);
+  });
+
+  it("rotates mesh -PI/2 around X (lays plane flat) and lifts by Y_OFFSET", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="XZZ" valid />,
+    );
+    const mesh = r.scene.findByType("Mesh");
+    expect(mesh.instance.rotation.x).toBeCloseTo(-Math.PI / 2);
+    expect(mesh.instance.position.y).toBeCloseTo(Y_OFFSET);
+  });
+
+  it("scales line to (1, lineLen, 1) so the unit-vertical geom spans block bottom", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 5 }} blockType="XZZ" valid />,
+    );
+    const line = r.scene.findByType("LineSegments");
+    expect(line.instance.scale.x).toBe(1);
+    expect(line.instance.scale.y).toBeCloseTo(5 - Y_OFFSET);
+    expect(line.instance.scale.z).toBe(1);
+  });
+
+  it("uses valid colors and full opacity at z=1 (no fade)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 1 }} blockType="XZZ" valid />,
+    );
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
+    expect(meshMat.color.getHex()).toBe(VALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(VALID_LINE_COLOR);
+    expect(meshMat.opacity).toBeCloseTo(VALID_MESH_OPACITY);
+  });
+
+  it("uses invalid red colors and full (non-faded) opacity when valid=false", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 30 }} blockType="XZZ" valid={false} />,
+    );
+    const meshMat = meshMaterial(r.scene.findByType("Mesh"));
+    const lineMat = lineMaterial(r.scene.findByType("LineSegments"));
+    expect(meshMat.color.getHex()).toBe(INVALID_SHADOW_COLOR);
+    expect(lineMat.color.getHex()).toBe(INVALID_LINE_COLOR);
+    // Invalid skips elevation falloff: full base opacity even at z=30
+    expect(meshMat.opacity).toBe(INVALID_MESH_OPACITY);
+  });
+
+  it("respects pipe footprint dims (X-open pipe centers at offset 1, 0.5)", async () => {
+    const r = await ReactThreeTestRenderer.create(
+      <GroundShadowAbsolute pos={{ x: 0, y: 0, z: 2 }} blockType="OZX" valid />,
+    );
+    const group = r.scene.findByType("Group");
+    expect(group.instance.position.x).toBeCloseTo(1);
+    expect(group.instance.position.z).toBeCloseTo(-0.5);
+  });
+});

--- a/gui/src/components/GroundShadowAbsolute.tsx
+++ b/gui/src/components/GroundShadowAbsolute.tsx
@@ -1,0 +1,94 @@
+import * as THREE from "three";
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+import { shadowVisuals, shouldRenderShadow, Y_OFFSET } from "../utils/groundShadow";
+
+// PERF NOTE: Per-instance materials (inline JSX) chosen for simplicity and
+// per-elevation opacity. Worst case ~800 materials in flight at MAX_SHADOWS=200
+// across 4 call sites — fine at typical scale. If perf becomes a problem at
+// extreme selection sizes, swap for InstancedMesh + per-instance opacity
+// vertex attribute. See TODOS.md (perf-shadows).
+
+const noRaycast = () => {};
+
+const planeCache = new Map<string, THREE.PlaneGeometry>();
+function getPlane(sx: number, sy: number): THREE.PlaneGeometry {
+  const key = `${sx}x${sy}`;
+  let g = planeCache.get(key);
+  if (!g) {
+    g = new THREE.PlaneGeometry(sx, sy);
+    planeCache.set(key, g);
+  }
+  return g;
+}
+
+const lineGeom = new THREE.BufferGeometry().setFromPoints([
+  new THREE.Vector3(0, 0, 0),
+  new THREE.Vector3(0, 1, 0),
+]);
+
+/**
+ * Ground-projected shadow + vertical anchor line for an elevated block.
+ *
+ * WORLD-SPACE COMPONENT — the `Absolute` suffix is a contract.
+ *
+ * This component positions itself in WORLD coordinates derived from `pos`.
+ * Do NOT render it inside a positioned `<group>` wrapper — the positions will
+ * compound and the shadow will end up at the wrong cell on the ground.
+ *
+ * Correct (rendered as a sibling of the positioned ghost):
+ *   return <>
+ *     <group position={[x, y, z]}><mesh>...</mesh></group>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />
+ *   </>;
+ *
+ * Wrong (nested — positions compound, shadow ends up offset by [x, y, z]):
+ *   return <group position={[x, y, z]}>
+ *     <mesh>...</mesh>
+ *     <GroundShadowAbsolute pos={tqecPos} ... />   // <-- bug
+ *   </group>;
+ */
+export function GroundShadowAbsolute({
+  pos,
+  blockType,
+  valid,
+}: {
+  pos: Position3D;
+  blockType: BlockType;
+  valid: boolean;
+}) {
+  if (!shouldRenderShadow(pos)) return null;
+  const [sx, sy] = blockTqecSize(blockType);
+  const v = shadowVisuals(pos, blockType, valid);
+
+  return (
+    <group position={[v.cx, 0, v.cz]}>
+      <mesh
+        position={[0, Y_OFFSET, 0]}
+        rotation={[-Math.PI / 2, 0, 0]}
+        geometry={getPlane(sx, sy)}
+        raycast={noRaycast}
+      >
+        <meshBasicMaterial
+          color={v.meshColor}
+          transparent
+          opacity={v.meshOpacity}
+          depthWrite={false}
+          side={THREE.DoubleSide}
+        />
+      </mesh>
+      <lineSegments
+        position={[0, Y_OFFSET, 0]}
+        scale={[1, v.lineLen, 1]}
+        geometry={lineGeom}
+        raycast={noRaycast}
+      >
+        <lineBasicMaterial
+          color={v.lineColor}
+          transparent
+          opacity={v.lineOpacity}
+          depthWrite={false}
+        />
+      </lineSegments>
+    </group>
+  );
+}

--- a/gui/src/components/OpenPipeGhosts.tsx
+++ b/gui/src/components/OpenPipeGhosts.tsx
@@ -15,7 +15,7 @@ import {
   getAdjacentPos,
   getAllPortPositions,
 } from "../types";
-import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "./BlockInstances";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "./BlockInstances.logic";
 import type { Position3D, BlockType, CubeType } from "../types";
 
 // Sentinel cube type for sizing/face-normal calculations on a port (which has

--- a/gui/src/components/PasteGhost.test.tsx
+++ b/gui/src/components/PasteGhost.test.tsx
@@ -1,0 +1,159 @@
+import ReactThreeTestRenderer from "@react-three/test-renderer";
+import * as THREE from "three";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useBlockStore } from "../stores/blockStore";
+import type { Block, BlockType, Position3D } from "../types";
+import { PasteGhost } from "./PasteGhost";
+
+function mk(pos: Position3D, type: BlockType = "XZZ"): Block {
+  return { pos, type };
+}
+
+beforeEach(() => {
+  useBlockStore.setState(
+    {
+      blocks: new Map(),
+      spatialIndex: new Map(),
+      hiddenFaces: new Map(),
+      history: [],
+      future: [],
+      mode: "edit",
+      cubeType: "XZZ",
+      pipeVariant: null,
+      armedTool: "cube",
+      xHeld: false,
+      portWarning: null,
+      hoveredGridPos: null,
+      hoveredBlockType: null,
+      hoveredInvalid: false,
+      hoveredReplace: false,
+      selectedKeys: new Set(),
+      selectedPortPositions: new Set(),
+      portPositions: new Set(),
+      selectionPivot: null,
+      undeterminedCubes: new Map(),
+      freeBuild: false,
+      clipboard: null,
+    },
+    false,
+  );
+});
+
+function setPaste(opts: {
+  clipboard?: Map<string, Block> | null;
+  hoveredGridPos?: Position3D | null;
+  blocks?: Map<string, Block>;
+}) {
+  useBlockStore.setState(
+    {
+      armedTool: "paste",
+      mode: "edit",
+      clipboard: opts.clipboard ?? null,
+      hoveredGridPos: opts.hoveredGridPos ?? null,
+      blocks: opts.blocks ?? new Map(),
+    },
+    false,
+  );
+}
+
+describe("<PasteGhost>", () => {
+  it("renders nothing when armedTool is not paste", async () => {
+    useBlockStore.setState(
+      {
+        armedTool: "cube",
+        clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+        hoveredGridPos: { x: 3, y: 0, z: 0 },
+      },
+      false,
+    );
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing with empty/null clipboard", async () => {
+    setPaste({ clipboard: null, hoveredGridPos: { x: 0, y: 0, z: 0 } });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders nothing without a hovered grid pos", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 })]]),
+      hoveredGridPos: null,
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    expect(r.scene.children).toHaveLength(0);
+  });
+
+  it("renders one paste-ghost per clipboard entry at z=0 (no shadows)", async () => {
+    setPaste({
+      clipboard: new Map([
+        ["0,0,0", mk({ x: 0, y: 0, z: 0 })],
+        ["3,0,0", mk({ x: 3, y: 0, z: 0 })],
+      ]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 2 ghost meshes; ghost edges (LineSegments) for each = 2 LineSegments.
+    // No shadows because z=0.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("renders shadow + projection line for elevated paste-ghost block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 1 ghost mesh + 1 shadow mesh = 2; ghost edges + shadow line = 2 LineSegments.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(2);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("turns shadow red when paste collides with existing block", async () => {
+    setPaste({
+      clipboard: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,3", mk({ x: 0, y: 0, z: 3 })]]), // collision
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // Both ghost edges and shadow line should be red on collision.
+    const lines = r.scene.findAllByType("LineSegments");
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    for (const line of lines) {
+      const mat = (line.instance as THREE.LineSegments).material as THREE.LineBasicMaterial;
+      expect(mat.color.getHex()).toBe(0xff0000);
+    }
+  });
+
+  it("Y-cube paste at z=0 with pipe above gets a lifted shadow", async () => {
+    // Clipboard contains a Y-cube at z=0; paste destination has a pipe at z=1
+    // directly above. yBlockZOffset returns 0.5 -> shadow renders.
+    setPaste({
+      clipboard: new Map([["0,0,0", mk({ x: 0, y: 0, z: 0 }, "Y")]]),
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+      blocks: new Map([["0,0,1", mk({ x: 0, y: 0, z: 1 }, "ZXO")]]),
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // ghost edges + shadow line = 2 LineSegments (shadow renders thanks to yBlockZOffset).
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(2);
+  });
+
+  it("caps clipboard at 200 entries (MAX_PASTE_SHADOWS)", async () => {
+    // Build a clipboard with 250 elevated blocks
+    const big = new Map<string, Block>();
+    for (let i = 0; i < 250; i++) {
+      big.set(`${i * 3},0,3`, mk({ x: i * 3, y: 0, z: 3 }));
+    }
+    setPaste({
+      clipboard: big,
+      hoveredGridPos: { x: 0, y: 0, z: 0 },
+    });
+    const r = await ReactThreeTestRenderer.create(<PasteGhost />);
+    // 200 paste-ghost meshes + 200 shadow meshes = 400 total.
+    // 200 ghost edges + 200 shadow lines = 400 LineSegments.
+    expect(r.scene.findAllByType("Mesh")).toHaveLength(400);
+    expect(r.scene.findAllByType("LineSegments")).toHaveLength(400);
+  });
+});

--- a/gui/src/components/PasteGhost.tsx
+++ b/gui/src/components/PasteGhost.tsx
@@ -4,6 +4,9 @@ import { useBlockStore } from "../stores/blockStore";
 import { tqecToThree, yBlockZOffset, isValidPos } from "../types";
 import type { Block, Position3D } from "../types";
 import { getCachedGeometry, getCachedEdges } from "./BlockInstances";
+import { GroundShadowAbsolute } from "./GroundShadowAbsolute";
+
+const MAX_PASTE_SHADOWS = 200;
 
 const noRaycast = () => {};
 
@@ -57,7 +60,7 @@ export function PasteGhost() {
 
   const entries = useMemo(() => {
     if (!clipboard) return null;
-    return Array.from(clipboard.values());
+    return Array.from(clipboard.values()).slice(0, MAX_PASTE_SHADOWS);
   }, [clipboard]);
 
   if (mode !== "edit" || armedTool !== "paste" || !hoveredGridPos || !entries) {
@@ -103,17 +106,23 @@ function PasteGhostBlock({
   const [x, y, z] = tqecToThree(worldPos, block.type, zo);
   const meshMat = collides ? invalidMaterial : pasteMaterial;
   const lineMat = collides ? invalidLineMaterial : pasteLineMaterial;
+  // Shadow position uses the visually-rendered z (logical + Y-cube lift), so
+  // shadow + projection line align with what the user sees.
+  const shadowPos = { ...worldPos, z: worldPos.z + zo };
 
   return (
-    <group position={[x, y, z]}>
-      <mesh raycast={noRaycast}>
-        <primitive object={geometry} attach="geometry" />
-        <primitive object={meshMat} attach="material" />
-      </mesh>
-      <lineSegments raycast={noRaycast}>
-        <primitive object={edges} attach="geometry" />
-        <primitive object={lineMat} attach="material" />
-      </lineSegments>
-    </group>
+    <>
+      <group position={[x, y, z]}>
+        <mesh raycast={noRaycast}>
+          <primitive object={geometry} attach="geometry" />
+          <primitive object={meshMat} attach="material" />
+        </mesh>
+        <lineSegments raycast={noRaycast}>
+          <primitive object={edges} attach="geometry" />
+          <primitive object={lineMat} attach="material" />
+        </lineSegments>
+      </group>
+      <GroundShadowAbsolute pos={shadowPos} blockType={block.type} valid={!collides} />
+    </>
   );
 }

--- a/gui/src/components/PortsTable.tsx
+++ b/gui/src/components/PortsTable.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from "react";
 import * as THREE from "three";
 import { useBlockStore } from "../stores/blockStore";
 import { useLocateStore } from "../stores/locateStore";
-import { getAllPortPositions, posKey, tqecToThree, type Position3D } from "../types";
+import { getOrderedPortPositions, posKey, tqecToThree, type Position3D } from "../types";
 import { animateCamera } from "../utils/cameraAnim";
 
 function PortLabelInput({
@@ -72,6 +72,19 @@ function LocateIcon() {
   );
 }
 
+function GripIcon() {
+  return (
+    <svg width="10" height="14" viewBox="0 0 10 14" aria-hidden="true">
+      <circle cx="3" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="3" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="7" r="1.1" fill="currentColor" />
+      <circle cx="3" cy="11" r="1.1" fill="currentColor" />
+      <circle cx="7" cy="11" r="1.1" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function PortsTable({
   controlsRef,
 }: {
@@ -83,9 +96,13 @@ export function PortsTable({
   const portPositions = useBlockStore((s) => s.portPositions);
   const setPortLabel = useBlockStore((s) => s.setPortLabel);
   const setPortIO = useBlockStore((s) => s.setPortIO);
+  const reorderPort = useBlockStore((s) => s.reorderPort);
+
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
 
   const portList = useMemo(() => {
-    const positions = getAllPortPositions(blocks, portPositions);
+    const positions = getOrderedPortPositions(blocks, portPositions, portMeta);
     return positions.map((pos) => {
       const key = posKey(pos);
       const meta = portMeta.get(key);
@@ -119,56 +136,105 @@ export function PortsTable({
           No open ports. Add open pipes or place port markers.
         </div>
       )}
-      {portList.map(({ pos, key, meta }) => (
-        <div
-          key={key}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            gap: 6,
-            marginBottom: 4,
-          }}
-        >
-          <button
-            type="button"
-            onClick={() => handleLocate(pos)}
-            aria-label="Locate port"
-            title="Locate port"
+      {portList.map(({ pos, key, meta }, index) => {
+        const isDragging = dragIndex === index;
+        const showDropAbove =
+          dragIndex !== null && overIndex === index && index < dragIndex;
+        const showDropBelow =
+          dragIndex !== null && overIndex === index && index > dragIndex;
+        return (
+          <div
+            key={key}
+            onDragOver={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              e.dataTransfer.dropEffect = "move";
+              if (overIndex !== index) setOverIndex(index);
+            }}
+            onDrop={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              if (dragIndex !== index) reorderPort(dragIndex, index);
+              setDragIndex(null);
+              setOverIndex(null);
+            }}
             style={{
-              background: "none",
-              border: "none",
-              padding: 2,
-              cursor: "pointer",
-              color: "#666",
-              display: "inline-flex",
+              display: "flex",
               alignItems: "center",
-              justifyContent: "center",
-              flexShrink: 0,
+              gap: 6,
+              marginBottom: 4,
+              padding: "2px 0",
+              opacity: isDragging ? 0.4 : 1,
+              borderTop: showDropAbove ? "2px solid #4a9eff" : "2px solid transparent",
+              borderBottom: showDropBelow ? "2px solid #4a9eff" : "2px solid transparent",
             }}
           >
-            <LocateIcon />
-          </button>
-          <PortLabelInput
-            pos={pos}
-            label={meta?.label ?? ""}
-            onCommit={setPortLabel}
-          />
-          <select
-            value={meta?.io ?? "in"}
-            onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
-            style={{ fontSize: 12, padding: "2px 4px" }}
-          >
-            <option value="in">in</option>
-            <option value="out">out</option>
-          </select>
-          <span
-            title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
-            style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
-          >
-            {pos.x / 3},{pos.y / 3},{pos.z / 3}
-          </span>
-        </div>
-      ))}
+            <span
+              draggable
+              onDragStart={(e) => {
+                setDragIndex(index);
+                e.dataTransfer.effectAllowed = "move";
+                e.dataTransfer.setData("text/plain", String(index));
+              }}
+              onDragEnd={() => {
+                setDragIndex(null);
+                setOverIndex(null);
+              }}
+              aria-label="Drag to reorder"
+              title="Drag to reorder"
+              style={{
+                cursor: "grab",
+                color: "#aaa",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+                padding: "0 2px",
+              }}
+            >
+              <GripIcon />
+            </span>
+            <button
+              type="button"
+              onClick={() => handleLocate(pos)}
+              aria-label="Locate port"
+              title="Locate port"
+              style={{
+                background: "none",
+                border: "none",
+                padding: 2,
+                cursor: "pointer",
+                color: "#666",
+                display: "inline-flex",
+                alignItems: "center",
+                justifyContent: "center",
+                flexShrink: 0,
+              }}
+            >
+              <LocateIcon />
+            </button>
+            <PortLabelInput
+              pos={pos}
+              label={meta?.label ?? ""}
+              onCommit={setPortLabel}
+            />
+            <select
+              value={meta?.io ?? "in"}
+              onChange={(e) => setPortIO(pos, e.target.value as "in" | "out")}
+              style={{ fontSize: 12, padding: "2px 4px" }}
+            >
+              <option value="in">in</option>
+              <option value="out">out</option>
+            </select>
+            <span
+              title={`(${pos.x / 3}, ${pos.y / 3}, ${pos.z / 3})`}
+              style={{ color: "#aaa", fontFamily: "monospace", fontSize: 10 }}
+            >
+              {pos.x / 3},{pos.y / 3},{pos.z / 3}
+            </span>
+          </div>
+        );
+      })}
     </section>
   );
 }

--- a/gui/src/components/SharedSceneBanner.tsx
+++ b/gui/src/components/SharedSceneBanner.tsx
@@ -1,0 +1,70 @@
+import type { SceneSnapshotV1 } from "../utils/sceneSnapshot";
+
+export function SharedSceneBanner({
+  previousSnapshot,
+  onRestore,
+  onDismiss,
+}: {
+  previousSnapshot: SceneSnapshotV1;
+  onRestore: (snapshot: SceneSnapshotV1) => void;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        position: "fixed",
+        top: 12,
+        left: "50%",
+        transform: "translateX(-50%)",
+        zIndex: 1100,
+        background: "#fff8d6",
+        border: "1px solid #d8c46a",
+        borderRadius: 6,
+        boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
+        padding: "8px 12px",
+        fontFamily: "sans-serif",
+        fontSize: 13,
+        color: "#5b4a00",
+        display: "flex",
+        alignItems: "center",
+        gap: 12,
+      }}
+    >
+      <span>Loaded a shared scene. Your previous work is still saved.</span>
+      <button
+        onClick={() => onRestore(previousSnapshot)}
+        style={{
+          fontSize: 12,
+          padding: "4px 10px",
+          border: "1px solid #b89a30",
+          borderRadius: 4,
+          background: "#fff",
+          cursor: "pointer",
+          color: "#5b4a00",
+        }}
+      >
+        Restore previous
+      </button>
+      <button
+        onClick={onDismiss}
+        aria-label="Dismiss"
+        title="Dismiss"
+        style={{
+          fontSize: 14,
+          width: 22,
+          height: 22,
+          border: "none",
+          background: "transparent",
+          cursor: "pointer",
+          color: "#7a6300",
+          padding: 0,
+          lineHeight: 1,
+        }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -6,6 +6,12 @@ import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPo
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
+import {
+  buildShareUrl,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+} from "../utils/sceneShare";
+import { captureSnapshot } from "../utils/sceneSnapshot";
 import { fetchTemplateManifest, loadTemplateBlocks, type TemplateEntry } from "../utils/templates";
 import { evalCoordExpr } from "../utils/parseCoordExpr";
 import { usePreviewImages } from "./PreviewRenderer";
@@ -1108,7 +1114,15 @@ function FileMenu({
   const [templates, setTemplates] = useState<TemplateEntry[] | null>(null);
   const [templatesError, setTemplatesError] = useState<string | null>(null);
   const [loadingFile, setLoadingFile] = useState<string | null>(null);
+  const [shareStatus, setShareStatus] = useState<"idle" | "copied" | "too-long" | "error">("idle");
+  const shareTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const wrapRef = useRef<HTMLDivElement | null>(null);
+  const compressionSupported = isCompressionStreamSupported();
+
+  // ~6 KB total URL — Twitter/X and most chat clients are well above this,
+  // but very long URLs choke older SMS, some embeds, and the URL bar in
+  // older browsers. Past this we surface the .dae export instead.
+  const SHARE_URL_MAX_LEN = 6144;
 
   useEffect(() => {
     if (!open) return;
@@ -1157,6 +1171,52 @@ function FileMenu({
     cursor: disabled ? "default" : "pointer",
     whiteSpace: "nowrap",
   });
+
+  const onShare = async () => {
+    if (!compressionSupported || blocksEmpty) return;
+    if (shareTimeoutRef.current !== null) {
+      clearTimeout(shareTimeoutRef.current);
+      shareTimeoutRef.current = null;
+    }
+    try {
+      const snapshot = captureSnapshot();
+      const encoded = await encodeSnapshotToHashParam(snapshot);
+      const url = buildShareUrl(encoded);
+      if (url.length > SHARE_URL_MAX_LEN) {
+        setShareStatus("too-long");
+      } else {
+        await navigator.clipboard.writeText(url);
+        setShareStatus("copied");
+      }
+    } catch {
+      setShareStatus("error");
+    }
+    shareTimeoutRef.current = setTimeout(() => {
+      setShareStatus("idle");
+      setOpen(false);
+      shareTimeoutRef.current = null;
+    }, 1600);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (shareTimeoutRef.current !== null) clearTimeout(shareTimeoutRef.current);
+    };
+  }, []);
+
+  let shareLabel = "Share link";
+  let shareTitle = "Copy a link that loads this exact scene";
+  if (!compressionSupported) {
+    shareTitle = "Share link is unsupported in this browser (needs CompressionStream)";
+  } else if (shareStatus === "copied") {
+    shareLabel = "Link copied!";
+  } else if (shareStatus === "too-long") {
+    shareLabel = "Too large — use Export";
+    shareTitle = "Scene is too big for a URL; use Export to send a .dae file instead";
+  } else if (shareStatus === "error") {
+    shareLabel = "Could not copy";
+  }
+  const shareDisabled = blocksEmpty || !compressionSupported;
 
   return (
     <div ref={wrapRef} style={{ position: "relative" }}>
@@ -1214,6 +1274,16 @@ function FileMenu({
             style={item(blocksEmpty)}
           >
             Export
+          </button>
+          <button
+            onClick={() => {
+              void onShare();
+            }}
+            disabled={shareDisabled}
+            title={shareTitle}
+            style={item(shareDisabled)}
+          >
+            {shareLabel}
           </button>
           <button
             onClick={() => {

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -636,7 +636,7 @@ export function Toolbar({
               onPointerDown={() => {
                 if (mode !== "edit") return;
                 if (selectedCubeSlotInfo != null) return;
-                setCubeType(ct as BlockType);
+                setCubeType(ct);
                 setPaletteDragging(true);
               }}
               onClick={() => {
@@ -648,7 +648,7 @@ export function Toolbar({
                   cycleSelectedType(1, { kind: "cube", type: ct });
                   return;
                 }
-                setCubeType(ct as BlockType);
+                setCubeType(ct);
               }}
               style={blockBtnStyle(
                 (mode === "edit" && armedTool === "cube" && cubeType === ct) ||

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -759,7 +759,8 @@ export function Toolbar({
       </div>
 
       {/* Free Build group — only visible when freeBuild is enabled.
-         Non-TQEC pipes parameterized by Y-defect positions. */}
+         Single generic Free Pipe; the per-face variant is picked from the
+         side panel that opens after placement. */}
       {freeBuild && (
         <>
           <div style={{ width: 1, background: "#ddd" }} />
@@ -777,11 +778,7 @@ export function Toolbar({
                   onClick={() => {
                     setFBPreset(preset);
                   }}
-                  title={
-                    preset.spec.swapAxes && preset.spec.swapAxes !== "all"
-                      ? `Free-build half color-swap pipe (${preset.label}) — only one wall pair flips at the midpoint`
-                      : `Free-build color-swap pipe (${preset.label}) with a Y defect at the midpoint`
-                  }
+                  title="Free-build pipe — drop to place, then pick a color/swap variant from the side panel"
                   style={blockBtnStyle(
                     mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
                     false,

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { useBlockStore } from "./blockStore";
 import type { Block } from "../types";
-import { buildSpatialIndex } from "../types";
+import { buildSpatialIndex, FB_PRESETS } from "../types";
 
 function reset() {
   useBlockStore.setState({
@@ -13,6 +13,7 @@ function reset() {
     mode: "edit",
     cubeType: "XZZ",
     pipeVariant: null,
+    fbPreset: null,
     armedTool: "cube",
     xHeld: false,
     portWarning: null,
@@ -583,6 +584,31 @@ describe("blockStore", () => {
       useBlockStore.getState().setPlacePort(true);
       useBlockStore.getState().setPlacePort(false);
       expect(useBlockStore.getState().armedTool).toBe("pointer");
+    });
+  });
+
+  // cubeType used to be silently rewritten to a PipeType by setPipeVariant
+  // and left untouched by setFBPreset. That asymmetry caused the FB-pipe
+  // snap-to-cube bug: when cubeType was a real CubeType while an FB preset
+  // was armed, the cube-replace branch in BlockInstances fired against the
+  // hovered cube position. The fix is for cubeType to be owned exclusively
+  // by the cube tool and persist across pipe-mode arming.
+  describe("cubeType ownership", () => {
+    it("setPipeVariant does NOT overwrite cubeType (FB snap regression)", () => {
+      useBlockStore.getState().setCubeType("ZXZ");
+      useBlockStore.getState().setPipeVariant("ZX");
+      expect(useBlockStore.getState().cubeType).toBe("ZXZ");
+      expect(useBlockStore.getState().armedTool).toBe("pipe");
+      expect(useBlockStore.getState().pipeVariant).toBe("ZX");
+    });
+
+    it("setFBPreset does NOT overwrite cubeType", () => {
+      useBlockStore.getState().setCubeType("ZXZ");
+      const swapZx = FB_PRESETS.find((p) => p.id === "swap-zx")!;
+      useBlockStore.getState().setFBPreset(swapZx);
+      expect(useBlockStore.getState().cubeType).toBe("ZXZ");
+      expect(useBlockStore.getState().armedTool).toBe("pipe");
+      expect(useBlockStore.getState().fbPreset?.id).toBe("swap-zx");
     });
   });
 

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1283,6 +1283,62 @@ describe("blockStore", () => {
     });
   });
 
+  describe("reorderPort", () => {
+    function seedFourPorts() {
+      useBlockStore.setState({
+        blocks: new Map(),
+        portPositions: new Set(["0,0,0", "3,0,0", "6,0,0", "9,0,0"]),
+        portMeta: new Map(),
+      });
+      useBlockStore.getState().ensurePortLabels();
+    }
+
+    function ranksByX(): Record<number, number | undefined> {
+      const out: Record<number, number | undefined> = {};
+      for (const [k, m] of useBlockStore.getState().portMeta) {
+        const x = Number(k.split(",")[0]);
+        out[x] = m.rank;
+      }
+      return out;
+    }
+
+    it("ensurePortLabels assigns sequential ranks 0..N-1 in spatial order", () => {
+      seedFourPorts();
+      // Spatial sort is by x ascending → ranks should match the x order.
+      expect(ranksByX()).toEqual({ 0: 0, 3: 1, 6: 2, 9: 3 });
+    });
+
+    it("moves a port forward and rewrites all ranks to 0..N-1", () => {
+      seedFourPorts();
+      // Move the port at index 3 (x=9) to index 0.
+      useBlockStore.getState().reorderPort(3, 0);
+      expect(ranksByX()).toEqual({ 9: 0, 0: 1, 3: 2, 6: 3 });
+    });
+
+    it("moves a port backward and rewrites all ranks", () => {
+      seedFourPorts();
+      // Move the port at index 0 (x=0) to index 2.
+      useBlockStore.getState().reorderPort(0, 2);
+      expect(ranksByX()).toEqual({ 3: 0, 6: 1, 0: 2, 9: 3 });
+    });
+
+    it("is a no-op when from === to", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(2, 2);
+      // Object identity preserved (set returned `state` unchanged).
+      expect(useBlockStore.getState().portMeta).toBe(before);
+    });
+
+    it("is a no-op when indices are out of range", () => {
+      seedFourPorts();
+      const before = useBlockStore.getState().portMeta;
+      useBlockStore.getState().reorderPort(-1, 2);
+      useBlockStore.getState().reorderPort(0, 99);
+      expect(useBlockStore.getState().portMeta).toBe(before);
+    });
+  });
+
   describe("copy / paste", () => {
     it("copySelection snapshots selected blocks normalized to origin", () => {
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -146,9 +146,8 @@ describe("blockStore", () => {
       const fbX = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const fbY = { ...fbX, openAxis: 1 as const };
       const incoming = new Map<string, Block>([
@@ -169,9 +168,8 @@ describe("blockStore", () => {
       const fbX = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const incoming = new Map<string, Block>([
         ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbX }],
@@ -516,9 +514,8 @@ describe("blockStore", () => {
       const fbSpec = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const incoming = new Map<string, Block>([
         ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: fbSpec }],
@@ -533,9 +530,8 @@ describe("blockStore", () => {
       const fbX = {
         kind: "fb-pipe" as const,
         openAxis: 0 as const,
-        baseAtStart: "Z" as const,
-        baseAtEnd: "X" as const,
         defectPositions: [0.5],
+        faces: ["ZX", "ZX", "ZX", "ZX"] as ["ZX", "ZX", "ZX", "ZX"],
       };
       const fbY = { ...fbX, openAxis: 1 as const };
       const incoming = new Map<string, Block>([
@@ -604,11 +600,11 @@ describe("blockStore", () => {
 
     it("setFBPreset does NOT overwrite cubeType", () => {
       useBlockStore.getState().setCubeType("ZXZ");
-      const swapZx = FB_PRESETS.find((p) => p.id === "swap-zx")!;
-      useBlockStore.getState().setFBPreset(swapZx);
+      const freePipe = FB_PRESETS[0];
+      useBlockStore.getState().setFBPreset(freePipe);
       expect(useBlockStore.getState().cubeType).toBe("ZXZ");
       expect(useBlockStore.getState().armedTool).toBe("pipe");
-      expect(useBlockStore.getState().fbPreset?.id).toBe("swap-zx");
+      expect(useBlockStore.getState().fbPreset?.id).toBe(freePipe.id);
     });
   });
 

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -53,11 +53,6 @@ export type ArmedTool = "pointer" | "cube" | "pipe" | "port" | "paste";
 
 const MAX_HISTORY = 100;
 
-/** Canonical X-open PipeType for each variant, used as cubeType fallback. */
-const PIPE_VARIANT_CANONICAL: Record<PipeVariant, BlockType> = {
-  ZX: "OZX", XZ: "OXZ", ZXH: "OZXH", XZH: "OXZH",
-};
-
 // ---------------------------------------------------------------------------
 // Command-based undo — stores the operation, not a full state snapshot.
 // Add/remove commands are O(1) memory; clear saves the full map (rare).
@@ -143,7 +138,7 @@ interface BlockStore {
    * Drag / Drop mode, regardless of the currently armed tool.
    */
   xHeld: boolean;
-  cubeType: BlockType;
+  cubeType: CubeType | "Y";
   pipeVariant: PipeVariant | null;
   /**
    * Currently selected free-build pipe preset. When non-null, placement
@@ -228,7 +223,7 @@ interface BlockStore {
   setMode: (mode: Mode) => void;
   setArmedTool: (tool: ArmedTool) => void;
   setXHeld: (held: boolean) => void;
-  setCubeType: (cubeType: BlockType) => void;
+  setCubeType: (cubeType: CubeType | "Y") => void;
   setPipeVariant: (variant: PipeVariant) => void;
   setFBPreset: (preset: FBPreset | null) => void;
   setPlacePort: (on: boolean) => void;
@@ -792,7 +787,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   }),
   setXHeld: (held) => set({ xHeld: held, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false }),
   setCubeType: (cubeType) => set({ cubeType, armedTool: "cube", pipeVariant: null, fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
-  setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], armedTool: "pipe", fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
+  setPipeVariant: (variant) => set({ pipeVariant: variant, armedTool: "pipe", fbPreset: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
   setFBPreset: (preset) => set({
     fbPreset: preset,
     pipeVariant: null,

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -4,6 +4,7 @@ import type { Flow } from "../utils/flows";
 import type {
   Position3D, Block, BlockType, CubeType, PipeVariant, PipeType, SpatialIndex, FaceMask,
   BuildDirection, UndeterminedCubeInfo, ViewMode, IsoAxis, PortMeta, PortIO, FBPreset,
+  FaceConfig,
   FreeBuildPipeSpec,
 } from "../types";
 import {
@@ -198,6 +199,13 @@ interface BlockStore {
   /** Whether the right-docked ZX-diagram panel is visible. */
   zxPanelOpen: boolean;
 
+  /**
+   * Position (posKey) of the free-build pipe currently being edited via the
+   * variants panel. Auto-set when an FB pipe is placed or selected; clears
+   * when the user closes the panel or selection changes off it.
+   */
+  fbVariantsPos: string | null;
+
   /** Last-computed flows (with surface geometry), published by FlowsPanel. */
   flows: Flow[];
   /** Signature of the diagram when `flows` was last computed; used to detect stale data. */
@@ -308,6 +316,11 @@ interface BlockStore {
   reorderPort: (fromIndex: number, toIndex: number) => void;
   setFlowsPanelOpen: (open: boolean) => void;
   toggleFlowsPanel: () => void;
+
+  /** Open the FB variant picker for the given block, or close it (pos=null). */
+  setFBVariantsPos: (pos: Position3D | null) => void;
+  /** Replace an FB pipe block's `faces` tuple in place. Used by the variant picker. */
+  setFBPipeFaces: (pos: Position3D, faces: [FaceConfig, FaceConfig, FaceConfig, FaceConfig]) => void;
 
   /** Publish computed flows (with surface geometry) for the 3D overlay to read. */
   setFlows: (flows: Flow[], signature: string) => void;
@@ -640,6 +653,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   portMeta: new Map(),
   flowsPanelOpen: false,
   zxPanelOpen: false,
+  fbVariantsPos: null,
   flows: [],
   flowsSignature: null,
   selectedFlowIndex: null,
@@ -1166,6 +1180,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       }
 
       const block: Block = { pos, type: blockType };
+      // Auto-open the FB variant picker for a freshly-placed FB pipe so the
+      // user immediately sees the 256 candidate variants. Placing any other
+      // block type clears the panel — the user is no longer focused on a
+      // specific FB pipe.
+      const fbVariantsPos = isFreeBuildPipeSpec(blockType) ? key : null;
 
       if (existing) {
         // Skip if same type — nothing to replace
@@ -1181,6 +1200,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           history: [...state.history, cmd].slice(-MAX_HISTORY),
           future: [],
           undeterminedCubes: newUndetermined,
+          fbVariantsPos,
         };
       }
 
@@ -1209,6 +1229,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             history: [...state.history, cmd].slice(-MAX_HISTORY),
             future: [],
             portPositions: newPorts,
+            fbVariantsPos,
           };
         }
       }
@@ -1223,6 +1244,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           history: [...state.history, cmd].slice(-MAX_HISTORY),
           future: [],
           portPositions: newPorts,
+          fbVariantsPos,
         };
       }
 
@@ -1231,6 +1253,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         hiddenFaces,
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
+        fbVariantsPos,
       };
     }),
 
@@ -2212,17 +2235,30 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       } else {
         next.add(key);
       }
+      // Surface the FB variants picker iff exactly one FB pipe is now selected.
+      let fbVariantsPos: string | null = null;
+      if (next.size === 1) {
+        const onlyKey = next.values().next().value as string;
+        const onlyBlock = state.blocks.get(onlyKey);
+        if (onlyBlock && isFreeBuildPipeSpec(onlyBlock.type)) fbVariantsPos = onlyKey;
+      }
       return {
         selectedKeys: next,
         selectedPortPositions: additive ? state.selectedPortPositions : new Set<string>(),
         selectionPivot: null,
+        fbVariantsPos,
       };
     }),
 
   clearSelection: () =>
     set((state) => {
       if (state.selectedKeys.size === 0 && state.selectedPortPositions.size === 0) return state;
-      return { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null };
+      return {
+        selectedKeys: new Set<string>(),
+        selectedPortPositions: new Set<string>(),
+        selectionPivot: null,
+        fbVariantsPos: null,
+      };
     }),
 
   togglePortSelection: (pos, additive) =>
@@ -3594,6 +3630,25 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         ? { flowsPanelOpen: false, flowVizMode: false }
         : { flowsPanelOpen: true },
     ),
+
+  setFBVariantsPos: (pos) => set({ fbVariantsPos: pos ? posKey(pos) : null }),
+  setFBPipeFaces: (pos, faces) =>
+    set((state) => {
+      const key = posKey(pos);
+      const block = state.blocks.get(key);
+      if (!block || !isFreeBuildPipeSpec(block.type)) return state;
+      const newType: FreeBuildPipeSpec = { ...block.type, faces };
+      const newBlock: Block = { pos: block.pos, type: newType };
+      const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, block);
+      const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, key, newBlock);
+      const cmd: UndoCommand = { kind: "replace", key, oldBlock: block, newBlock };
+      return {
+        blocks,
+        hiddenFaces,
+        history: [...state.history, cmd].slice(-MAX_HISTORY),
+        future: [],
+      };
+    }),
 
   setFlows: (flows, signature) =>
     set({

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -8,6 +8,7 @@ import type {
 import {
   posKey,
   getAllPortPositions,
+  getOrderedPortPositions,
   defaultPortIO,
   hasBlockOverlap,
   hasCubeColorConflict,
@@ -291,6 +292,12 @@ interface BlockStore {
   ensurePortLabels: () => void;
   setPortLabel: (pos: Position3D, label: string) => void;
   setPortIO: (pos: Position3D, io: PortIO) => void;
+  /**
+   * Reorder ports by moving the port at `fromIndex` (in the current
+   * user-ordered port list) to `toIndex`, then rewriting all ranks
+   * 0..N-1 so the array indices match the stored ranks.
+   */
+  reorderPort: (fromIndex: number, toIndex: number) => void;
   setFlowsPanelOpen: (open: boolean) => void;
   toggleFlowsPanel: () => void;
 
@@ -3439,7 +3446,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       for (const k of stale) next.delete(k);
 
       const used = new Set<string>();
-      for (const meta of next.values()) used.add(meta.label);
+      let maxRank = -1;
+      for (const meta of next.values()) {
+        used.add(meta.label);
+        if (meta.rank !== undefined && meta.rank > maxRank) maxRank = meta.rank;
+      }
       let nextId = 1;
       const allocLabel = (): string => {
         while (used.has(`P${nextId}`)) nextId++;
@@ -3449,9 +3460,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       };
 
       for (const pos of missing) {
+        maxRank += 1;
         next.set(posKey(pos), {
           label: allocLabel(),
           io: defaultPortIO(pos, state.blocks),
+          rank: maxRank,
         });
       }
       return { portMeta: next };
@@ -3493,6 +3506,34 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       if (!existing || existing.io === io) return state;
       const next = new Map(state.portMeta);
       next.set(key, { ...existing, io });
+      return { portMeta: next };
+    }),
+
+  reorderPort: (fromIndex, toIndex) =>
+    set((state) => {
+      const ordered = getOrderedPortPositions(
+        state.blocks,
+        state.portPositions,
+        state.portMeta,
+      );
+      if (
+        fromIndex === toIndex ||
+        fromIndex < 0 ||
+        toIndex < 0 ||
+        fromIndex >= ordered.length ||
+        toIndex >= ordered.length
+      ) {
+        return state;
+      }
+      const keys = ordered.map(posKey);
+      const [moved] = keys.splice(fromIndex, 1);
+      keys.splice(toIndex, 0, moved);
+
+      const next = new Map(state.portMeta);
+      keys.forEach((k, i) => {
+        const m = next.get(k);
+        if (m && m.rank !== i) next.set(k, { ...m, rank: i });
+      });
       return { portMeta: next };
     }),
 

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -23,7 +23,7 @@ import {
   FB_PRESETS,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
-import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances";
+import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
 
 const Z_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
@@ -242,6 +242,19 @@ describe("FB_PRESETS", () => {
     expect(halfZx!.spec.baseAtEnd).toBe("X");
     expect(halfXz!.spec.baseAtStart).toBe("X");
     expect(halfXz!.spec.baseAtEnd).toBe("Z");
+  });
+
+  it("ships the mirror half-swap presets (the 'other' face pair flips)", () => {
+    const halfZxH = FB_PRESETS.find((p) => p.id === "half-zx-h");
+    const halfXzH = FB_PRESETS.find((p) => p.id === "half-xz-h");
+    expect(halfZxH).toBeDefined();
+    expect(halfXzH).toBeDefined();
+    expect(halfZxH!.spec.swapAxes).toBe("second");
+    expect(halfXzH!.spec.swapAxes).toBe("second");
+    expect(halfZxH!.spec.baseAtStart).toBe("Z");
+    expect(halfZxH!.spec.baseAtEnd).toBe("X");
+    expect(halfXzH!.spec.baseAtStart).toBe("X");
+    expect(halfXzH!.spec.baseAtEnd).toBe("Z");
   });
 });
 

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -21,32 +21,36 @@ import {
   X_COLOR,
   Z_COLOR,
   FB_PRESETS,
+  FB_DEFAULT_FACES,
+  migrateLegacyFBSpec,
+  normalizeFBSpec,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
 import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
 
+// Z-open full-swap reference (matches legacy `baseAtStart:Z, baseAtEnd:X` semantics
+// for Z-open pipes: ca0=X-axis takes Z-below + X-above; ca1=Z-axis takes X-below + Z-above).
 const Z_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 2,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["ZX", "ZX", "XZ", "XZ"],
 };
 
 const X_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 0,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["ZX", "ZX", "XZ", "XZ"],
 };
 
+// Legacy Y-open spec mirrored the start/end pair (tail-orientation flip), so the
+// equivalent new spec puts XZ on ca0 (X-axis Three.js) and ZX on ca1 (Y-axis Three.js).
 const Y_OPEN_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 1,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["XZ", "XZ", "ZX", "ZX"],
 };
 
 describe("isFreeBuildBlock / isFreeBuildPipeSpec", () => {
@@ -95,12 +99,14 @@ describe("createBlockGeometry for FB pipes", () => {
     for (let i = 0; i < arr.length; i += 3) out.push({ r: arr[i], g: arr[i + 1], b: arr[i + 2] });
     return out;
   }
+  function colorEq(a: { r: number; g: number; b: number }, c: typeof X_COLOR): boolean {
+    return Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
+  }
 
   it("emits no yellow (H_COLOR) vertices — FB has no Hadamard band", () => {
     const geo = createBlockGeometry(Z_OPEN_SPEC);
     const colors = vertexColors(geo);
     for (const c of colors) {
-      // Yellow Hadamard band would be (H_COLOR.r, H_COLOR.g, H_COLOR.b).
       const isYellow =
         Math.abs(c.r - H_COLOR.r) < 1e-6 &&
         Math.abs(c.g - H_COLOR.g) < 1e-6 &&
@@ -109,80 +115,128 @@ describe("createBlockGeometry for FB pipes", () => {
     }
   });
 
-  it("contains both X_COLOR and Z_COLOR vertices (color swap at midpoint)", () => {
+  it("contains both X_COLOR and Z_COLOR vertices when a wall swaps", () => {
     const geo = createBlockGeometry(Z_OPEN_SPEC);
     const colors = vertexColors(geo);
-    const sameAs = (a: { r: number; g: number; b: number }, c: typeof X_COLOR) =>
-      Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
-    expect(colors.some((c) => sameAs(c, X_COLOR))).toBe(true);
-    expect(colors.some((c) => sameAs(c, Z_COLOR))).toBe(true);
+    expect(colors.some((c) => colorEq(c, X_COLOR))).toBe(true);
+    expect(colors.some((c) => colorEq(c, Z_COLOR))).toBe(true);
+  });
+
+  it("solid-X pipe has only X_COLOR vertices on every wall", () => {
+    const solid: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "X", "X", "X"] };
+    const colors = vertexColors(createBlockGeometry(solid));
+    for (const c of colors) {
+      // All non-zero color verts must be red (X) — open-axis faces are stripped.
+      if (c.r === 0 && c.g === 0 && c.b === 0) continue;
+      expect(colorEq(c, X_COLOR)).toBe(true);
+    }
+  });
+
+  it("each FaceConfig produces the expected (below, above) basis pair", () => {
+    // Each wall has 2 strips × 4 verts = 8 colored verts. Build a single-wall
+    // probe: vary one face at a time, leave the other 3 as solid X.
+    const cases: Array<{ fc: "XZ" | "ZX" | "X" | "Z"; below: typeof X_COLOR; above: typeof X_COLOR }> = [
+      { fc: "X", below: X_COLOR, above: X_COLOR },
+      { fc: "Z", below: Z_COLOR, above: Z_COLOR },
+      { fc: "XZ", below: X_COLOR, above: Z_COLOR },
+      { fc: "ZX", below: Z_COLOR, above: X_COLOR },
+    ];
+    for (const { fc, below, above } of cases) {
+      const spec: FreeBuildPipeSpec = {
+        ...Z_OPEN_SPEC,
+        faces: [fc, "X", "X", "X"],
+      };
+      const colors = vertexColors(createBlockGeometry(spec));
+      // The first wall (face 0 = +ca0) emits 2 strips × 4 verts. With ca0 = X
+      // (Three.js axis 0), the +ca0 wall verts can be identified by x-coord
+      // > 0. Below-strip verts have y < 0; above-strip verts have y > 0
+      // (Three.js openAxis = 1 for Z-open). We pull both strips and check.
+      const positions = createBlockGeometry(spec).getAttribute("position").array as Float32Array;
+      let belowFound = false;
+      let aboveFound = false;
+      for (let i = 0; i < positions.length / 3; i++) {
+        const px = positions[i * 3];
+        const py = positions[i * 3 + 1];
+        if (px <= 0) continue;
+        const c = colors[i];
+        if (py < 0 && colorEq(c, below)) belowFound = true;
+        if (py > 0 && colorEq(c, above)) aboveFound = true;
+      }
+      expect(belowFound).toBe(true);
+      expect(aboveFound).toBe(true);
+    }
   });
 });
 
-describe("createYDefectEdges for FB pipes", () => {
+describe("createYDefectEdges for FB pipes (per-face)", () => {
   function edgeCount(geo: ReturnType<typeof createYDefectEdges>): number {
     const arr = geo.getAttribute("position").array as Float32Array;
     return arr.length / 6;
   }
 
-  it("FB pipe with one defect emits 4 corner edges + 4 ring segments = 8", () => {
+  it("full-swap pipe (all 4 walls swap) emits 4 corner edges + 4 ring segments = 8", () => {
     expect(edgeCount(createYDefectEdges(Z_OPEN_SPEC))).toBe(8);
     expect(edgeCount(createYDefectEdges(X_OPEN_SPEC))).toBe(8);
     expect(edgeCount(createYDefectEdges(Y_OPEN_SPEC))).toBe(8);
   });
 
-  it("FB pipe with no defects emits only the 4 corner edges (no ring)", () => {
-    const noDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [] };
-    expect(edgeCount(createYDefectEdges(noDefects))).toBe(4);
+  it("solid pipe (every face same basis) emits no Y-defect edges", () => {
+    const solid: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "X", "X", "X"] };
+    expect(edgeCount(createYDefectEdges(solid))).toBe(0);
   });
 
-  it("FB pipe with two defects emits 4 corners + 2 rings × 4 = 12", () => {
-    const twoDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [0.33, 0.67] };
-    expect(edgeCount(createYDefectEdges(twoDefects))).toBe(12);
+  it("one swapping face puts a ring on that face plus corner cylinders on its 2 adjacent corners", () => {
+    // Faces: [+ca0=XZ, -ca0=X, +ca1=X, -ca1=X]. Below: +ca0 X = -ca0 X = +ca1 X = -ca1 X (no diff).
+    // Above: +ca0 Z, others X — corners (+ca0,±ca1) light up above. So 2 above-half corners
+    // + 1 ring on the swapping face = 3 edges total.
+    const spec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["XZ", "X", "X", "X"] };
+    expect(edgeCount(createYDefectEdges(spec))).toBe(3);
   });
 
-  it("half-swap FB pipe emits 4 half-length corners + 2 ring segments = 6", () => {
-    // swapAxes "first": below midpoint, ca0/ca1 differ → 4 corners on the
-    // lower half. Above midpoint, both walls share the same basis → no
-    // corners. Ring at the defect only crosses the swapping (ca0) walls,
-    // contributing 2 segments instead of 4.
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
+  it("half-swap pipe (one pair swaps, the other stays solid X) emits 4 half-corners + 2 rings = 6", () => {
+    // Migrating the legacy {baseAtStart:Z, swapAxes:"first"} → faces=["ZX","ZX","X","X"].
+    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["ZX", "ZX", "X", "X"] };
     expect(edgeCount(createYDefectEdges(halfSpec))).toBe(6);
   });
 
-  it("half-swap FB pipe corner segments span only the lower half of the open axis", () => {
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
-    const arr = createYDefectEdges(halfSpec).getAttribute("position").array as Float32Array;
-    // Z_OPEN_SPEC has Three.js openAxis = 1 (Y). Corner edges are the first 4
-    // line segments; ring segments come last. Each segment is two 3-vec verts.
-    // For a half-swap pipe, corner segments must run from the negative-Y end
-    // to the midpoint (Y = 0), not all the way across.
-    for (let i = 0; i < 4; i++) {
-      const y0 = arr[i * 6 + 1];
-      const y1 = arr[i * 6 + 4];
-      const yMin = Math.min(y0, y1);
-      const yMax = Math.max(y0, y1);
-      expect(yMin).toBeLessThan(0);
-      expect(yMax).toBeCloseTo(0, 6);
-    }
+  it("pipe with no defects: corner cylinder appears iff bases differ across the whole length", () => {
+    // Solid faces only — different colors on opposite walls give 4 corners (no rings, no defect).
+    const noDefects: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, defectPositions: [], faces: ["X", "X", "Z", "Z"] };
+    expect(edgeCount(createYDefectEdges(noDefects))).toBe(4);
+  });
+
+  it("opposite-direction swaps on a pair (XZ vs ZX) light up Y-defects on both halves", () => {
+    // ca0 +face XZ (X→Z), ca0 -face ZX (Z→X). At the corner with the orthogonal wall (X solid):
+    //   below: +ca0 = X vs ca1 = X — no diff
+    //   above: +ca0 = Z vs ca1 = X — diff → cylinder above
+    //   below: -ca0 = Z vs ca1 = X — diff → cylinder below
+    //   above: -ca0 = X vs ca1 = X — no diff
+    // Both ca0 walls swap → 2 ring segments. Total: 2 above-corners + 2 below-corners + 2 rings = 6.
+    const spec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["XZ", "ZX", "X", "X"] };
+    expect(edgeCount(createYDefectEdges(spec))).toBe(6);
   });
 });
 
 describe("flipBlockType on FB pipes", () => {
-  it("swaps baseAtStart and baseAtEnd between X and Z, leaving defects unchanged", () => {
+  it("flips X↔Z on every face config (X↔Z, XZ↔ZX), leaving openAxis/defects unchanged", () => {
     const flipped = flipBlockType(Z_OPEN_SPEC) as FreeBuildPipeSpec;
     expect(flipped.kind).toBe("fb-pipe");
-    expect(flipped.baseAtStart).toBe("X");
-    expect(flipped.baseAtEnd).toBe("Z");
-    expect(flipped.defectPositions).toEqual([0.5]);
     expect(flipped.openAxis).toBe(2);
+    expect(flipped.defectPositions).toEqual([0.5]);
+    // Z_OPEN_SPEC.faces = ["ZX","ZX","XZ","XZ"] → ["XZ","XZ","ZX","ZX"]
+    expect(flipped.faces).toEqual(["XZ", "XZ", "ZX", "ZX"]);
   });
 
   it("is an involution on FB pipes (flip twice = original)", () => {
     const once = flipBlockType(Z_OPEN_SPEC) as FreeBuildPipeSpec;
     const twice = flipBlockType(once) as FreeBuildPipeSpec;
-    expect(twice.baseAtStart).toBe(Z_OPEN_SPEC.baseAtStart);
-    expect(twice.baseAtEnd).toBe(Z_OPEN_SPEC.baseAtEnd);
+    expect(twice.faces).toEqual(Z_OPEN_SPEC.faces);
+  });
+
+  it("solid faces flip too: X→Z, Z→X", () => {
+    const solid: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "Z", "X", "Z"] };
+    const flipped = flipBlockType(solid) as FreeBuildPipeSpec;
+    expect(flipped.faces).toEqual(["Z", "X", "Z", "X"]);
   });
 });
 
@@ -193,8 +247,8 @@ describe("blockTypeCacheKey", () => {
   });
 
   it("returns a deterministic content-based key for FB specs", () => {
-    expect(blockTypeCacheKey(Z_OPEN_SPEC)).toBe("fb:2|Z|X|0.5|all");
-    expect(blockTypeCacheKey(X_OPEN_SPEC)).toBe("fb:0|Z|X|0.5|all");
+    expect(blockTypeCacheKey(Z_OPEN_SPEC)).toBe("fb:2|ZXZXXZXZ|0.5");
+    expect(blockTypeCacheKey(X_OPEN_SPEC)).toBe("fb:0|ZXZXXZXZ|0.5");
   });
 
   it("two structurally equal specs produce the same key", () => {
@@ -203,126 +257,99 @@ describe("blockTypeCacheKey", () => {
     expect(blockTypeCacheKey(a)).toBe(blockTypeCacheKey(b));
   });
 
-  it("specs that differ only in swapAxes produce different keys", () => {
-    const full: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
-    const half: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
-    expect(blockTypeCacheKey(full)).not.toBe(blockTypeCacheKey(half));
+  it("specs that differ in any face produce different keys", () => {
+    const a: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
+    const b: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, faces: ["X", "X", "X", "X"] };
+    expect(blockTypeCacheKey(a)).not.toBe(blockTypeCacheKey(b));
   });
 });
 
 describe("FB_PRESETS", () => {
-  it("all presets have a single Y defect at 0.5", () => {
-    for (const p of FB_PRESETS) {
-      expect(p.spec.kind).toBe("fb-pipe");
-      expect(p.spec.defectPositions).toEqual([0.5]);
-    }
-  });
-
-  it("the full presets are color-swap mirrors of each other (Z→X and X→Z)", () => {
-    const zx = FB_PRESETS.find((p) => p.id === "swap-zx");
-    const xz = FB_PRESETS.find((p) => p.id === "swap-xz");
-    expect(zx).toBeDefined();
-    expect(xz).toBeDefined();
-    expect(zx!.spec.baseAtStart).toBe("Z");
-    expect(zx!.spec.baseAtEnd).toBe("X");
-    expect(xz!.spec.baseAtStart).toBe("X");
-    expect(xz!.spec.baseAtEnd).toBe("Z");
-    expect(zx!.spec.swapAxes ?? "all").toBe("all");
-    expect(xz!.spec.swapAxes ?? "all").toBe("all");
-  });
-
-  it("ships half-swap presets that change only 2 opposite faces", () => {
-    const halfZx = FB_PRESETS.find((p) => p.id === "half-zx");
-    const halfXz = FB_PRESETS.find((p) => p.id === "half-xz");
-    expect(halfZx).toBeDefined();
-    expect(halfXz).toBeDefined();
-    expect(halfZx!.spec.swapAxes).toBe("first");
-    expect(halfXz!.spec.swapAxes).toBe("first");
-    expect(halfZx!.spec.baseAtStart).toBe("Z");
-    expect(halfZx!.spec.baseAtEnd).toBe("X");
-    expect(halfXz!.spec.baseAtStart).toBe("X");
-    expect(halfXz!.spec.baseAtEnd).toBe("Z");
-  });
-
-  it("ships the mirror half-swap presets (the 'other' face pair flips)", () => {
-    const halfZxH = FB_PRESETS.find((p) => p.id === "half-zx-h");
-    const halfXzH = FB_PRESETS.find((p) => p.id === "half-xz-h");
-    expect(halfZxH).toBeDefined();
-    expect(halfXzH).toBeDefined();
-    expect(halfZxH!.spec.swapAxes).toBe("second");
-    expect(halfXzH!.spec.swapAxes).toBe("second");
-    expect(halfZxH!.spec.baseAtStart).toBe("Z");
-    expect(halfZxH!.spec.baseAtEnd).toBe("X");
-    expect(halfXzH!.spec.baseAtStart).toBe("X");
-    expect(halfXzH!.spec.baseAtEnd).toBe("Z");
+  it("ships a single Free Pipe preset (variants are picked from the side panel)", () => {
+    expect(FB_PRESETS).toHaveLength(1);
+    const fp = FB_PRESETS[0];
+    expect(fp.id).toBe("free-pipe");
+    expect(fp.spec.kind).toBe("fb-pipe");
+    expect(fp.spec.defectPositions).toEqual([0.5]);
+    expect(fp.spec.faces).toEqual(FB_DEFAULT_FACES);
   });
 });
 
-describe("FB pipe geometry honors swapAxes", () => {
-  function vertexColors(geo: ReturnType<typeof createBlockGeometry>): { r: number; g: number; b: number }[] {
-    const arr = geo.getAttribute("color").array as Float32Array;
-    const out: { r: number; g: number; b: number }[] = [];
-    for (let i = 0; i < arr.length; i += 3) out.push({ r: arr[i], g: arr[i + 1], b: arr[i + 2] });
-    return out;
-  }
-  function colorEq(a: { r: number; g: number; b: number }, c: typeof X_COLOR): boolean {
-    return Math.abs(a.r - c.r) < 1e-6 && Math.abs(a.g - c.g) < 1e-6 && Math.abs(a.b - c.b) < 1e-6;
-  }
-
-  it("full-swap pipe has each base color count balanced (all 4 walls swap)", () => {
-    const colors = vertexColors(createBlockGeometry(Z_OPEN_SPEC));
-    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
-    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
-    // 4 walls × 2 strips × 4 verts = 32 colored verts; each base appears on
-    // 4 strips (2 below + 2 above per axis pair), so counts are equal.
-    expect(xCount).toBe(zCount);
-    expect(xCount + zCount).toBe(32);
+describe("legacy FB spec migration", () => {
+  it("converts {baseAtStart:Z, baseAtEnd:X, swapAxes:'all'} to per-face equivalent", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 2 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["ZX", "ZX", "XZ", "XZ"]);
+    expect(migrated.openAxis).toBe(2);
+    expect(migrated.defectPositions).toEqual([0.5]);
   });
 
-  it("half-swap pipe biases toward the start-side base (3 strips of one color, 1 of the other)", () => {
-    // Z→X half: closed axis 0 wall pair shows Z below + X above.
-    //           closed axis 1 wall pair shows X below AND X above (no swap).
-    // Total Z verts: 1 strip × 2 walls × 4 verts = 8.
-    // Total X verts: 3 strips × 2 walls × 4 verts = 24.
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "first" };
-    const colors = vertexColors(createBlockGeometry(halfSpec));
-    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
-    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
-    expect(xCount).toBe(24);
-    expect(zCount).toBe(8);
+  it("converts swapAxes:'first' (only ca0 pair flips)", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 2 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+      swapAxes: "first" as const,
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["ZX", "ZX", "X", "X"]);
   });
 
-  it("swapAxes 'second' mirrors 'first' on the other closed-axis pair", () => {
-    // Z→X second-axis half: closed axis 0 wall pair stays Z (no swap).
-    //                       closed axis 1 wall pair shows X below + Z above.
-    // Total Z verts: 3 strips × 2 walls × 4 verts = 24.
-    // Total X verts: 1 strip × 2 walls × 4 verts = 8.
-    // Mirror of the "first" case above (swap on the opposite axis pair).
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "second" };
-    const colors = vertexColors(createBlockGeometry(halfSpec));
-    const xCount = colors.filter((c) => colorEq(c, X_COLOR)).length;
-    const zCount = colors.filter((c) => colorEq(c, Z_COLOR)).length;
-    expect(xCount).toBe(8);
-    expect(zCount).toBe(24);
+  it("converts swapAxes:'second' (only ca1 pair flips)", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 2 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+      swapAxes: "second" as const,
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["Z", "Z", "XZ", "XZ"]);
   });
 
-  it("swapAxes 'second' Y-defect ring lies on the second closed-axis wall pair", () => {
-    // Z_OPEN_SPEC has Three.js openAxis=1 (Y), closedAxes=[0,2]=[X,Z].
-    // swapAxes "second" → only the Z-axis wall pair (closed[1]) swaps. The
-    // ring segments at the defect must therefore vary in X (i.e., run along
-    // the X axis, lying on the Z-walls), not in Z. Total: 4 corners (lower
-    // half) + 2 ring segments = 6 edges, mirroring the "first" case.
-    const halfSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC, swapAxes: "second" };
-    const arr = createYDefectEdges(halfSpec).getAttribute("position").array as Float32Array;
-    expect(arr.length / 6).toBe(6);
-    // Last 2 segments are the ring; verify they vary in X (Three.js axis 0)
-    // and stay constant in Z (Three.js axis 2).
-    for (let i = 4; i < 6; i++) {
-      const x0 = arr[i * 6 + 0], x1 = arr[i * 6 + 3];
-      const z0 = arr[i * 6 + 2], z1 = arr[i * 6 + 5];
-      expect(Math.abs(x1 - x0)).toBeGreaterThan(0.5);
-      expect(z0).toBeCloseTo(z1, 6);
-    }
+  it("Y-open mirror: legacy code flipped wallColors, so migration applies the same flip", () => {
+    const legacy = {
+      kind: "fb-pipe" as const,
+      openAxis: 1 as const,
+      baseAtStart: "Z" as const,
+      baseAtEnd: "X" as const,
+      defectPositions: [0.5],
+    };
+    const migrated = migrateLegacyFBSpec(legacy);
+    expect(migrated.faces).toEqual(["XZ", "XZ", "ZX", "ZX"]);
+  });
+
+  it("normalizeFBSpec passes through new-shape specs untouched", () => {
+    const newSpec: FreeBuildPipeSpec = { ...Z_OPEN_SPEC };
+    expect(normalizeFBSpec(newSpec)).toBe(newSpec);
+  });
+
+  it("normalizeFBSpec migrates a legacy spec", () => {
+    const legacy = {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "Z",
+      baseAtEnd: "X",
+      defectPositions: [0.5],
+    };
+    const out = normalizeFBSpec(legacy);
+    expect(out).not.toBeNull();
+    expect(out!.faces).toEqual(["ZX", "ZX", "XZ", "XZ"]);
+  });
+
+  it("normalizeFBSpec rejects non-FB inputs", () => {
+    expect(normalizeFBSpec(null)).toBeNull();
+    expect(normalizeFBSpec({ kind: "other" })).toBeNull();
+    expect(normalizeFBSpec("OZX")).toBeNull();
   });
 });
 
@@ -333,7 +360,7 @@ describe("FB pipe geometry honors swapAxes", () => {
 // resolvePipeTypeFromFace and gives back BOTH the snapped slot and the spec
 // with openAxis matching that slot's TQEC axis.
 describe("resolveFBSpecFromFace (port-adjacent FB pipe snapping)", () => {
-  const PRESET: FBPreset = FB_PRESETS[0]; // swap-zx, openAxis=2 in template
+  const PRESET: FBPreset = FB_PRESETS[0];
   const PORT: Position3D = { x: 0, y: 0, z: 0 };
 
   it("snaps to the +X pipe slot with +X face normal", () => {
@@ -367,18 +394,14 @@ describe("resolveFBSpecFromFace (port-adjacent FB pipe snapping)", () => {
     expect(r!.spec.openAxis).toBe(1);
   });
 
-  it("preserves the preset's color/defect template, only overriding openAxis", () => {
+  it("preserves the preset's faces/defects template, only overriding openAxis", () => {
     const r = resolveFBSpecFromFace(PORT, "XZZ", new Vector3(1, 0, 0), PRESET);
     expect(r).not.toBeNull();
-    expect(r!.spec.baseAtStart).toBe(PRESET.spec.baseAtStart);
-    expect(r!.spec.baseAtEnd).toBe(PRESET.spec.baseAtEnd);
+    expect(r!.spec.faces).toEqual(PRESET.spec.faces);
     expect(r!.spec.defectPositions).toEqual(PRESET.spec.defectPositions);
   });
 
   it("computes the same adj position as resolvePipeTypeFromFace for every face direction", () => {
-    // Snap parity: an FB preset hovering a port should land on the same grid slot
-    // as a regular pipe variant — the only thing that differs is the resulting
-    // block type (FB spec vs concrete PipeType).
     const port: Position3D = { x: 3, y: 6, z: 0 };
     const normals = [
       new Vector3(1, 0, 0),
@@ -420,7 +443,6 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
   });
 
   it("countAttachedPipes counts FB pipes alongside TQEC pipes", () => {
-    // Cube at origin with one TQEC pipe on +X and one FB pipe on +Y.
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
       { pos: { x: 1, y: 0, z: 0 }, type: "OZX" },
@@ -440,12 +462,8 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
   });
 
   it("does not count an FB pipe whose open axis doesn't point at the cube", () => {
-    // A Z-open FB pipe at (1,0,0) is NOT a +X-attached pipe of the cube at origin
-    // (it occupies a Z-axis slot, but its position isn't even a valid pipe slot).
-    // This is a parity check: regular pipes are filtered the same way.
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
-      // Wrong-axis FB pipe at +X slot — open along Y, not X.
       { pos: { x: 1, y: 0, z: 0 }, type: Y_OPEN_SPEC },
     ]);
     expect(countAttachedPipes({ x: 0, y: 0, z: 0 }, blocks)).toBe(0);

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, CUBE_TYPES, PIPE_TYPES } from "./index";
-import type { PipeType, CubeType } from "./index";
+import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, CUBE_TYPES, PIPE_TYPES } from "./index";
+import type { PipeType, CubeType, PortMeta } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
 
@@ -600,5 +600,62 @@ describe("createYDefectEdges", () => {
     // Sanity: hiding everything yields zero edges.
     const all = FACE_POS_X | FACE_NEG_X | FACE_POS_Y | FACE_NEG_Y | FACE_POS_Z | FACE_NEG_Z;
     expect(edgeCount(createYDefectEdges("XZZ", all))).toBe(0);
+  });
+});
+
+describe("getOrderedPortPositions", () => {
+  const explicitPorts = new Set([
+    "0,0,0",
+    "3,0,0",
+    "6,0,0",
+    "9,0,0",
+  ]);
+  const blocks = new Map<
+    string,
+    { pos: { x: number; y: number; z: number }; type: BlockType }
+  >();
+
+  it("falls back to spatial sort when no ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["3,0,0", { label: "P1", io: "in" }],
+      ["0,0,0", { label: "P2", io: "in" }],
+      ["9,0,0", { label: "P3", io: "in" }],
+      ["6,0,0", { label: "P4", io: "in" }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 3, 6, 9]);
+  });
+
+  it("orders ports by rank when ranks are set", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["0,0,0", { label: "P1", io: "in", rank: 3 }],
+      ["3,0,0", { label: "P2", io: "in", rank: 1 }],
+      ["6,0,0", { label: "P3", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P4", io: "in", rank: 2 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([6, 3, 9, 0]);
+  });
+
+  it("places ranked ports before unranked ones; unranked sort spatially", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["9,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["3,0,0", { label: "P2", io: "in" }],
+      ["0,0,0", { label: "P3", io: "in" }],
+      // P4 at (6,0,0) has no PortMeta entry at all — also unranked.
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([9, 0, 3, 6]);
+  });
+
+  it("breaks ties between equal ranks by spatial order", () => {
+    const portMeta = new Map<string, PortMeta>([
+      ["6,0,0", { label: "P1", io: "in", rank: 0 }],
+      ["0,0,0", { label: "P2", io: "in", rank: 0 }],
+      ["9,0,0", { label: "P3", io: "in", rank: 1 }],
+      ["3,0,0", { label: "P4", io: "in", rank: 1 }],
+    ]);
+    const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
+    expect(result.map((p) => p.x)).toEqual([0, 6, 3, 9]);
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -42,29 +42,53 @@ export const PIPE_TYPES = ["OZX", "OXZ", "OZXH", "OXZH", "ZOX", "XOZ", "ZOXH", "
 export type PipeType = (typeof PIPE_TYPES)[number];
 
 /**
- * Free-build pipe spec — a non-TQEC pipe parameterized by Y-defect positions.
- * `defectPositions` are normalized 0..1 along the open axis; physical defects
- * sit strictly inside (0,1). One defect at 0.5 = today's color-swap pipe.
- * Two defects = a future 3-color pipe. Zero defects = a future solid pipe.
+ * Per-face state for a free-build pipe wall.
+ *   "X"  = solid X (red) all the way along the open axis
+ *   "Z"  = solid Z (blue)
+ *   "XZ" = swap X→Z at the defect (red below, blue above)
+ *   "ZX" = swap Z→X at the defect (blue below, red above)
+ */
+export type FaceConfig = "X" | "Z" | "XZ" | "ZX";
+export const FACE_CONFIGS: ReadonlyArray<FaceConfig> = ["X", "Z", "XZ", "ZX"];
+
+/** Basis of a face's strip. Below-strip is left of the defect along open axis. */
+export function faceBelowBasis(fc: FaceConfig): "X" | "Z" {
+  return fc === "X" || fc === "XZ" ? "X" : "Z";
+}
+export function faceAboveBasis(fc: FaceConfig): "X" | "Z" {
+  return fc === "X" || fc === "ZX" ? "X" : "Z";
+}
+
+/**
+ * Free-build pipe spec — a non-TQEC pipe with independently-colored walls.
  *
- * `swapAxes` controls which closed-axis wall pairs participate in the basis
- * swap at each defect position. "all" (default) flips both pairs — all 4 walls
- * change color. "first" / "second" flip only one pair (2 opposite faces); the
- * other pair shows its baseAtStart-derived color as a solid throughout.
- * "first" / "second" index the closedAxes array in Three.js axis order.
+ * Each of the 4 closed-axis walls carries its own `FaceConfig`, so the user
+ * can cycle through every visual variant (256 per open axis) from the
+ * variants panel after placement.
  *
- * FB blocks ride the existing Y-defect overlay for boundary visualization
- * (magenta cylinders at each defect position) and are excluded from `.dae`
- * export and TQEC validation.
+ * `faces` index order is **Three.js closed-axis order**:
+ *   [0] = +ca0, [1] = −ca0, [2] = +ca1, [3] = −ca1
+ * where `closedAxes = [0,1,2].filter(a => a !== TQEC_TO_THREE_AXIS[openAxis])`
+ * in ascending order. The geometry and Y-defect overlay both consume this
+ * tuple directly.
+ *
+ * `defectPositions` are normalized 0..1 along the open axis; v1 always uses
+ * `[0.5]` (single midpoint defect). Faces marked `XZ`/`ZX` flip color at the
+ * defect; `X`/`Z` faces stay solid through it.
+ *
+ * FB blocks are excluded from `.dae` export and TQEC validation.
  */
 export interface FreeBuildPipeSpec {
   kind: "fb-pipe";
   openAxis: 0 | 1 | 2;          // TQEC axis (0=x, 1=y, 2=z)
-  baseAtStart: "X" | "Z";       // closed-axis bases at the open-axis START end
-  baseAtEnd: "X" | "Z";         // ...at the END end
   defectPositions: number[];    // 0..1 along the open axis
-  swapAxes?: "all" | "first" | "second"; // which closed-axis pair(s) swap; default "all"
+  faces: [FaceConfig, FaceConfig, FaceConfig, FaceConfig];
 }
+
+/** Default config for the toolbar's generic Free Pipe — solid X (red) tube. */
+export const FB_DEFAULT_FACES: [FaceConfig, FaceConfig, FaceConfig, FaceConfig] = [
+  "X", "X", "X", "X",
+];
 
 export type BlockType = CubeType | "Y" | PipeType | FreeBuildPipeSpec;
 export type FaceMask = number;
@@ -101,67 +125,20 @@ export interface FBPreset {
 }
 
 /**
- * FB presets: color-swap pipes with one Y defect at the midpoint.
- * Full presets swap all 4 walls; half presets swap only one closed-axis pair
- * (the other pair shows its baseAtStart-derived color as a solid).
+ * FB presets: a single generic Free Pipe entry whose 256 visual variants are
+ * reached by clicking cells in the variants panel that opens after placement.
+ * The default `faces` here just gives the ghost a recognizable shape — the
+ * user picks a real config from the panel.
  */
 export const FB_PRESETS: ReadonlyArray<FBPreset> = [
   {
-    id: "swap-zx",
-    label: "Z→X",
-    spec: { kind: "fb-pipe", openAxis: 2, baseAtStart: "Z", baseAtEnd: "X", defectPositions: [0.5] },
-  },
-  {
-    id: "swap-xz",
-    label: "X→Z",
-    spec: { kind: "fb-pipe", openAxis: 2, baseAtStart: "X", baseAtEnd: "Z", defectPositions: [0.5] },
-  },
-  {
-    id: "half-zx",
-    label: "Z→X½ⱽ",
+    id: "free-pipe",
+    label: "Free Pipe",
     spec: {
       kind: "fb-pipe",
       openAxis: 2,
-      baseAtStart: "Z",
-      baseAtEnd: "X",
       defectPositions: [0.5],
-      swapAxes: "first",
-    },
-  },
-  {
-    id: "half-xz",
-    label: "X→Z½ⱽ",
-    spec: {
-      kind: "fb-pipe",
-      openAxis: 2,
-      baseAtStart: "X",
-      baseAtEnd: "Z",
-      defectPositions: [0.5],
-      swapAxes: "first",
-    },
-  },
-  {
-    id: "half-zx-h",
-    label: "Z→X½ʰ",
-    spec: {
-      kind: "fb-pipe",
-      openAxis: 2,
-      baseAtStart: "Z",
-      baseAtEnd: "X",
-      defectPositions: [0.5],
-      swapAxes: "second",
-    },
-  },
-  {
-    id: "half-xz-h",
-    label: "X→Z½ʰ",
-    spec: {
-      kind: "fb-pipe",
-      openAxis: 2,
-      baseAtStart: "X",
-      baseAtEnd: "Z",
-      defectPositions: [0.5],
-      swapAxes: "second",
+      faces: [...FB_DEFAULT_FACES],
     },
   },
 ];
@@ -273,8 +250,67 @@ export function isAnyPipeBlock(b: Block): boolean {
  */
 export function blockTypeCacheKey(bt: BlockType): string {
   if (typeof bt === "string") return bt;
-  const sw = bt.swapAxes ?? "all";
-  return `fb:${bt.openAxis}|${bt.baseAtStart}|${bt.baseAtEnd}|${bt.defectPositions.join(",")}|${sw}`;
+  return `fb:${bt.openAxis}|${bt.faces.join("")}|${bt.defectPositions.join(",")}`;
+}
+
+/**
+ * Legacy FB spec (pre-faces): defined as `{ openAxis, baseAtStart, baseAtEnd,
+ * swapAxes?, defectPositions }`. Convert to the new per-face shape on read so
+ * old `.dae` files and old URL-hashed scenes keep loading without surprise.
+ */
+type LegacyFBSpec = {
+  kind: "fb-pipe";
+  openAxis: 0 | 1 | 2;
+  baseAtStart: "X" | "Z";
+  baseAtEnd: "X" | "Z";
+  defectPositions: number[];
+  swapAxes?: "all" | "first" | "second";
+};
+
+function isLegacyFBSpec(o: unknown): o is LegacyFBSpec {
+  if (typeof o !== "object" || o === null) return false;
+  const r = o as { kind?: unknown; faces?: unknown; baseAtStart?: unknown };
+  return r.kind === "fb-pipe" && r.faces === undefined && typeof r.baseAtStart === "string";
+}
+
+/**
+ * Migrate a legacy FB spec (baseAtStart/baseAtEnd/swapAxes) to the new
+ * per-face shape. Pure: same in → same out.
+ *
+ * The legacy convention picked wall colors via:
+ *   wallColors[0] = baseAtStart, wallColors[1] = opposite(baseAtStart)
+ * with a Y-open swap that flips the pair (mirroring the geometry's
+ * tail-orientation flip for TQEC openAxis === 1). swapAxes "first"/"second"
+ * select which pair flips at the defect; both faces of a pair shared a config.
+ */
+export function migrateLegacyFBSpec(legacy: LegacyFBSpec): FreeBuildPipeSpec {
+  const startBase = legacy.baseAtStart;
+  const otherStart: "X" | "Z" = startBase === "X" ? "Z" : "X";
+  const isYOpen = legacy.openAxis === 1;
+  const ca0Below: "X" | "Z" = isYOpen ? otherStart : startBase;
+  const ca1Below: "X" | "Z" = isYOpen ? startBase : otherStart;
+  const swap = legacy.swapAxes ?? "all";
+  const swapsCa0 = swap === "all" || swap === "first";
+  const swapsCa1 = swap === "all" || swap === "second";
+  const ca0: FaceConfig = swapsCa0 ? (ca0Below === "X" ? "XZ" : "ZX") : ca0Below;
+  const ca1: FaceConfig = swapsCa1 ? (ca1Below === "X" ? "XZ" : "ZX") : ca1Below;
+  return {
+    kind: "fb-pipe",
+    openAxis: legacy.openAxis,
+    defectPositions: [...legacy.defectPositions],
+    faces: [ca0, ca0, ca1, ca1],
+  };
+}
+
+/** Apply migration if needed; pass-through otherwise. */
+export function normalizeFBSpec(o: unknown): FreeBuildPipeSpec | null {
+  if (typeof o !== "object" || o === null) return null;
+  if (isLegacyFBSpec(o)) return migrateLegacyFBSpec(o);
+  const r = o as Partial<FreeBuildPipeSpec> & { kind?: unknown };
+  if (r.kind === "fb-pipe" && Array.isArray(r.faces) && r.faces.length === 4) {
+    return r as FreeBuildPipeSpec;
+  }
+  return null;
 }
 
 /** Map a TQEC basis character ('X' or 'Z') to its THREE.Color. */
@@ -497,7 +533,13 @@ function createPipeGeometry(
   bandColor: THREE.Color | null = null,
   hiddenFaces: FaceMask = 0,
   hBandHalfHeight?: number,
-  swapAxes: "all" | "first" | "second" = "all",
+  /**
+   * Optional per-face overrides for "split" mode (free-build pipes). When
+   * provided, each of the 4 walls reads its own (below, above) colors from
+   * `faceConfigs` instead of the shared `wallColors` + `swapAxes` rule.
+   * Index order: [+ca0, −ca0, +ca1, −ca1] in Three.js closed-axis order.
+   */
+  faceConfigs?: [FaceConfig, FaceConfig, FaceConfig, FaceConfig],
 ): THREE.BufferGeometry {
   const closedAxes = [0, 1, 2].filter(a => a !== openAxis) as [number, number];
 
@@ -610,16 +652,18 @@ function createPipeGeometry(
 
       // Strips along the open axis. In "band" mode: below / band / above.
       // In "split" mode: below / above only (bh = 0, middle has zero extent).
-      // For FB pipes, swapAxes can suppress the swap on a specific wall pair:
-      // when this wall is on the non-swapping closed axis, the above strip
-      // reuses the below color so the wall is visually solid.
-      const swapsThisWall =
-        swapAxes === "all" ||
-        (swapAxes === "first" && i === 0) ||
-        (swapAxes === "second" && i === 1);
-      const aboveColor = swapsThisWall ? wallColorsAbove[i] : wallColors[i];
+      // For FB pipes, faceConfigs gives each face an independent (below,
+      // above) basis. Index: i=closed-axis pair, sign=+1/-1 → faces tuple
+      // entry `i*2 + (sign>0?0:1)` ([+ca0,-ca0,+ca1,-ca1]).
+      let belowColor = wallColors[i];
+      let aboveColor = wallColorsAbove[i];
+      if (faceConfigs) {
+        const fc = faceConfigs[i * 2 + (sign > 0 ? 0 : 1)];
+        belowColor = basisColor(faceBelowBasis(fc));
+        aboveColor = basisColor(faceAboveBasis(fc));
+      }
       const [b0, b1, b2, b3] = quad(-1, -bh);
-      addQuad(b0, b1, b2, b3, n, wallColors[i]);
+      addQuad(b0, b1, b2, b3, n, belowColor);
       if (splitMode === "band" && bandColor) {
         const [m0, m1, m2, m3] = quad(-bh, bh);
         addQuad(m0, m1, m2, m3, n, bandColor);
@@ -646,33 +690,18 @@ function createPipeGeometry(
  */
 export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
   if (isFreeBuildPipeSpec(blockType)) {
-    // Free-build color-swap pipe: same wall geometry as a Hadamard pipe but
-    // without the yellow band. Wall colors swap at each defect position.
-    // v1: only one defect at 0.5 is rendered correctly; multi-defect support
-    // is future work.
-    const tqecOpenAxis = blockType.openAxis;
-    const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpenAxis];
-    const closedAxes = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
-    // Below-split colors: bases-at-start mapped to the two closed-axis walls.
-    // Walls are ordered by Three.js axis number (closedAxes[0] then [1]).
-    // Per the TQEC convention used by string-typed pipes, the FIRST closed
-    // wall takes baseAtStart and the SECOND takes its opposite.
-    const startBase = blockType.baseAtStart;
-    const otherStart = startBase === "X" ? "Z" : "X";
-    let wallColors: [THREE.Color, THREE.Color] = [basisColor(startBase), basisColor(otherStart)];
-    // Y-open pipes: same orientation pre-swap as Hadamard (tail at -Z in Three.js).
-    if (tqecOpenAxis === 1) {
-      wallColors = [wallColors[1], wallColors[0]];
-    }
-    void closedAxes; // closedAxes computed for symmetry with TQEC branch; unused here.
+    // Free-build pipe: per-face configs drive each wall's below/above colors.
+    // wallColors here is a placeholder (overridden by faceConfigs in the
+    // geometry constructor); pass red/blue so any unknown face still reads.
+    const threeOpenAxis = TQEC_TO_THREE_AXIS[blockType.openAxis];
     return createPipeGeometry(
       threeOpenAxis,
-      wallColors,
+      [X_COLOR, Z_COLOR],
       "split",
       null,
       hiddenFaces,
       hBandHalfHeight,
-      blockType.swapAxes ?? "all",
+      blockType.faces,
     );
   }
 
@@ -1001,110 +1030,96 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
 }
 
 /**
- * FB-specific Y-defect edges. Walks the open axis as a sequence of segments
- * separated by `defectPositions`, tracking the basis on each closed-axis wall
- * pair (which flips at every defect according to `swapAxes`). A corner edge is
- * a Y defect only on segments where the two closed-axis walls hold different
- * bases. Ring segments at a defect cover only the walls whose axis flipped
- * there.
+ * FB-specific Y-defect edges (per-face configs).
+ *
+ * For each of the 4 open-axis corners (ca0±, ca1±), the two adjacent walls'
+ * bases are checked separately on the below-defect strip and the above-defect
+ * strip. A corner cylinder is drawn for whichever strips show an X/Z mismatch.
+ *
+ * Ring segments at the defect are emitted around any wall whose `FaceConfig`
+ * is `XZ` or `ZX` — those are the walls where the basis itself flips at the
+ * defect, which is exactly where the wall acquires a Y-defect ring.
+ *
+ * v1 only honours the first defect position; multi-defect FB pipes are future
+ * work and the current code base never produces them.
  */
 function createFBYDefectEdges(
   blockType: FreeBuildPipeSpec,
   hiddenFaces: FaceMask,
   halfExts: [number, number, number],
 ): THREE.BufferGeometry {
-  const tqecOpen = blockType.openAxis;
-  const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen];
+  const threeOpenAxis = TQEC_TO_THREE_AXIS[blockType.openAxis];
   const closed = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
-  const swapAxes = blockType.swapAxes ?? "all";
-  const swapsCa0 = swapAxes === "all" || swapAxes === "first";
-  const swapsCa1 = swapAxes === "all" || swapAxes === "second";
+  const faces = blockType.faces;
+  // faces tuple is [+ca0, -ca0, +ca1, -ca1] in Three.js closed-axis order.
+  const faceAt = (caIdx: 0 | 1, sign: 1 | -1): FaceConfig =>
+    faces[caIdx * 2 + (sign > 0 ? 0 : 1)];
 
-  const startBase = blockType.baseAtStart;
-  const otherStart: "X" | "Z" = startBase === "X" ? "Z" : "X";
-  // Match the wall-color assignment used by createBlockGeometry: the first
-  // closed Three.js axis takes baseAtStart, the second takes its opposite,
-  // with a Y-open swap (mirrors the geometry's tail-orientation flip).
-  let curCa0: "X" | "Z" = tqecOpen === 1 ? otherStart : startBase;
-  let curCa1: "X" | "Z" = tqecOpen === 1 ? startBase : otherStart;
-
-  // Build segments along the open axis. Defects (sorted) split [-1, +1] into
-  // N+1 segments; `bases` records (ca0, ca1) on each one.
   const sortedDefects = [...blockType.defectPositions].sort((a, b) => a - b);
-  const breakpoints = [0, ...sortedDefects, 1].map(p => -1 + 2 * p);
-  type Seg = { start: number; end: number; ca0: "X" | "Z"; ca1: "X" | "Z" };
-  const segments: Seg[] = [];
-  for (let s = 0; s < breakpoints.length - 1; s++) {
-    segments.push({ start: breakpoints[s], end: breakpoints[s + 1], ca0: curCa0, ca1: curCa1 });
-    if (s < sortedDefects.length) {
-      if (swapsCa0) curCa0 = curCa0 === "X" ? "Z" : "X";
-      if (swapsCa1) curCa1 = curCa1 === "X" ? "Z" : "X";
-    }
-  }
-
-  // Coalesce adjacent Y-defect segments so a fully-swapping pipe still emits
-  // one corner edge per corner instead of one per inter-defect segment.
-  const yDefectRuns: Array<{ start: number; end: number }> = [];
-  let runStart: number | null = null;
-  for (let s = 0; s < segments.length; s++) {
-    const isYDefect = segments[s].ca0 !== segments[s].ca1;
-    if (isYDefect && runStart === null) runStart = segments[s].start;
-    if (!isYDefect && runStart !== null) {
-      yDefectRuns.push({ start: runStart, end: segments[s - 1].end });
-      runStart = null;
-    }
-  }
-  if (runStart !== null) {
-    yDefectRuns.push({ start: runStart, end: segments[segments.length - 1].end });
-  }
+  const hasDefect = sortedDefects.length > 0;
+  const defectOaVal = hasDefect ? -1 + 2 * sortedDefects[0] : 0;
 
   const linePoints: number[] = [];
 
-  // Corner edges along the open axis, one per (ca0-sign, ca1-sign) pair per
-  // Y-defect run. Skipped if either adjacent wall face is hidden.
-  for (const run of yDefectRuns) {
-    for (const [s1, s2] of [[-1, -1], [1, -1], [-1, 1], [1, 1]] as const) {
+  // ---- Corner edges (one per corner, possibly split into below/above runs)
+  // Each corner sits where two adjacent walls meet. We compare bases on each
+  // strip; emit a cylinder along the strips where the bases differ.
+  for (const s1 of [-1, 1] as const) {
+    for (const s2 of [-1, 1] as const) {
       const faceA = FACE_BIT_BY_INDEX[closed[0] * 2 + (s1 > 0 ? 0 : 1)];
       const faceB = FACE_BIT_BY_INDEX[closed[1] * 2 + (s2 > 0 ? 0 : 1)];
       if ((hiddenFaces & faceA) || (hiddenFaces & faceB)) continue;
-      const v0: [number, number, number] = [0, 0, 0];
-      const v1: [number, number, number] = [0, 0, 0];
-      v0[closed[0]] = s1 * halfExts[closed[0]];
-      v0[closed[1]] = s2 * halfExts[closed[1]];
-      v0[threeOpenAxis] = run.start * halfExts[threeOpenAxis];
-      v1[closed[0]] = s1 * halfExts[closed[0]];
-      v1[closed[1]] = s2 * halfExts[closed[1]];
-      v1[threeOpenAxis] = run.end * halfExts[threeOpenAxis];
-      linePoints.push(...v0, ...v1);
+
+      const fcA = faceAt(0, s1);
+      const fcB = faceAt(1, s2);
+      const belowDiff = faceBelowBasis(fcA) !== faceBelowBasis(fcB);
+      const aboveDiff = faceAboveBasis(fcA) !== faceAboveBasis(fcB);
+
+      const cornerPoint = (oa: number): [number, number, number] => {
+        const v: [number, number, number] = [0, 0, 0];
+        v[closed[0]] = s1 * halfExts[closed[0]];
+        v[closed[1]] = s2 * halfExts[closed[1]];
+        v[threeOpenAxis] = oa * halfExts[threeOpenAxis];
+        return v;
+      };
+
+      if (!hasDefect) {
+        if (belowDiff) linePoints.push(...cornerPoint(-1), ...cornerPoint(1));
+        continue;
+      }
+      // Coalesce when both strips share the mismatch, so a fully-mismatched
+      // corner emits a single cylinder spanning [-1, +1] instead of two
+      // butt-joined ones at the defect.
+      if (belowDiff && aboveDiff) {
+        linePoints.push(...cornerPoint(-1), ...cornerPoint(1));
+      } else if (belowDiff) {
+        linePoints.push(...cornerPoint(-1), ...cornerPoint(defectOaVal));
+      } else if (aboveDiff) {
+        linePoints.push(...cornerPoint(defectOaVal), ...cornerPoint(1));
+      }
     }
   }
 
-  // Ring segments at each defect, restricted to the walls whose closed axis
-  // actually swaps there. A ring edge running along ca1 lies on a ca0=± wall
-  // and is a Y defect iff ca0 swaps; symmetrically for the other direction.
-  for (const p of sortedDefects) {
-    const oaVal = -1 + 2 * p;
-    const corner = (s1: -1 | 1, s2: -1 | 1): [number, number, number] => {
-      const v: [number, number, number] = [0, 0, 0];
-      v[threeOpenAxis] = oaVal;
-      v[closed[0]] = s1 * halfExts[closed[0]];
-      v[closed[1]] = s2 * halfExts[closed[1]];
-      return v;
-    };
-    if (swapsCa0) {
-      // 2 segments on ca0=± walls (run along ca1).
-      for (const s1 of [1, -1] as const) {
-        const faceBit = FACE_BIT_BY_INDEX[closed[0] * 2 + (s1 > 0 ? 0 : 1)];
+  // ---- Ring segments around any swapping wall at the defect.
+  if (hasDefect) {
+    const oaVal = defectOaVal;
+    for (let i = 0; i < 2; i++) {
+      const ca = closed[i];
+      const oc = closed[1 - i];
+      for (const sign of [1, -1] as const) {
+        const fc = faceAt(i as 0 | 1, sign);
+        if (fc !== "XZ" && fc !== "ZX") continue;
+        const faceBit = FACE_BIT_BY_INDEX[ca * 2 + (sign > 0 ? 0 : 1)];
         if (hiddenFaces & faceBit) continue;
-        linePoints.push(...corner(s1, -1), ...corner(s1, 1));
-      }
-    }
-    if (swapsCa1) {
-      // 2 segments on ca1=± walls (run along ca0).
-      for (const s2 of [1, -1] as const) {
-        const faceBit = FACE_BIT_BY_INDEX[closed[1] * 2 + (s2 > 0 ? 0 : 1)];
-        if (hiddenFaces & faceBit) continue;
-        linePoints.push(...corner(-1, s2), ...corner(1, s2));
+        const v0: [number, number, number] = [0, 0, 0];
+        const v1: [number, number, number] = [0, 0, 0];
+        v0[threeOpenAxis] = oaVal;
+        v1[threeOpenAxis] = oaVal;
+        v0[ca] = sign * halfExts[ca];
+        v1[ca] = sign * halfExts[ca];
+        v0[oc] = -halfExts[oc];
+        v1[oc] = halfExts[oc];
+        linePoints.push(...v0, ...v1);
       }
     }
   }
@@ -1616,10 +1631,16 @@ export function swapPipeVariant(pipeBase: string): string {
 export function flipBlockType(type: BlockType): BlockType {
   if (type === "Y") return type;
   if (isFreeBuildPipeSpec(type)) {
+    const flipFace = (fc: FaceConfig): FaceConfig =>
+      fc === "X" ? "Z" : fc === "Z" ? "X" : fc === "XZ" ? "ZX" : "XZ";
     return {
       ...type,
-      baseAtStart: type.baseAtStart === "X" ? "Z" : "X",
-      baseAtEnd: type.baseAtEnd === "X" ? "Z" : "X",
+      faces: [
+        flipFace(type.faces[0]),
+        flipFace(type.faces[1]),
+        flipFace(type.faces[2]),
+        flipFace(type.faces[3]),
+      ],
     };
   }
   let out = "";

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -109,6 +109,13 @@ export type PortIO = "in" | "out";
 export interface PortMeta {
   label: string;
   io: PortIO;
+  /**
+   * User-defined display order, used by the Ports table and Stabilizer Flows
+   * panel to determine the qubit-register position of each port. Lower ranks
+   * sort first; ports without a rank fall back to spatial sort and appear
+   * after ranked ports.
+   */
+  rank?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -1403,6 +1410,28 @@ export function getAllPortPositions(
 
   result.sort((a, b) => a.x - b.x || a.y - b.y || a.z - b.z);
   return result;
+}
+
+/**
+ * Like `getAllPortPositions`, but ordered by user-defined `PortMeta.rank`
+ * with spatial sort as fallback for any port without a rank. This is the
+ * order shown in the Ports table and used to position qubits in the
+ * Stabilizer Flows table when interpreted as a circuit.
+ */
+export function getOrderedPortPositions(
+  blocks: Map<string, Block>,
+  explicitPorts: Set<string>,
+  portMeta: Map<string, PortMeta>,
+): Position3D[] {
+  const positions = getAllPortPositions(blocks, explicitPorts);
+  return positions.slice().sort((a, b) => {
+    const ra = portMeta.get(posKey(a))?.rank;
+    const rb = portMeta.get(posKey(b))?.rank;
+    const ka = ra ?? Number.POSITIVE_INFINITY;
+    const kb = rb ?? Number.POSITIVE_INFINITY;
+    if (ka !== kb) return ka - kb;
+    return a.x - b.x || a.y - b.y || a.z - b.z;
+  });
 }
 
 /**

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -118,7 +118,7 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
   },
   {
     id: "half-zx",
-    label: "Z→X½",
+    label: "Z→X½ⱽ",
     spec: {
       kind: "fb-pipe",
       openAxis: 2,
@@ -130,7 +130,7 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
   },
   {
     id: "half-xz",
-    label: "X→Z½",
+    label: "X→Z½ⱽ",
     spec: {
       kind: "fb-pipe",
       openAxis: 2,
@@ -138,6 +138,30 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
       baseAtEnd: "Z",
       defectPositions: [0.5],
       swapAxes: "first",
+    },
+  },
+  {
+    id: "half-zx-h",
+    label: "Z→X½ʰ",
+    spec: {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "Z",
+      baseAtEnd: "X",
+      defectPositions: [0.5],
+      swapAxes: "second",
+    },
+  },
+  {
+    id: "half-xz-h",
+    label: "X→Z½ʰ",
+    spec: {
+      kind: "fb-pipe",
+      openAxis: 2,
+      baseAtStart: "X",
+      baseAtEnd: "Z",
+      defectPositions: [0.5],
+      swapAxes: "second",
     },
   },
 ];
@@ -149,13 +173,13 @@ export const FB_PRESETS: ReadonlyArray<FBPreset> = [
  */
 export type Placeable =
   | { kind: "port" }
-  | { kind: "cube"; cubeType: BlockType }
+  | { kind: "cube"; cubeType: CubeType | "Y" }
   | { kind: "pipe"; variant: PipeVariant };
 
 export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
   { kind: "port" },
-  ...CUBE_TYPES.map((t) => ({ kind: "cube" as const, cubeType: t as BlockType })),
-  { kind: "cube" as const, cubeType: "Y" as BlockType },
+  ...CUBE_TYPES.map((t) => ({ kind: "cube" as const, cubeType: t })),
+  { kind: "cube" as const, cubeType: "Y" as const },
   ...PIPE_VARIANTS.map((v) => ({ kind: "pipe" as const, variant: v })),
 ];
 
@@ -165,7 +189,7 @@ export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
  */
 export function currentPlaceableIndex(
   armedTool: "pointer" | "cube" | "pipe" | "port" | "paste",
-  cubeType: BlockType,
+  cubeType: CubeType | "Y",
   pipeVariant: PipeVariant | null,
 ): number {
   if (armedTool === "pointer" || armedTool === "paste") return -1;

--- a/gui/src/utils/daeExport.test.ts
+++ b/gui/src/utils/daeExport.test.ts
@@ -169,7 +169,7 @@ describe("round-trip: export → import", () => {
     blocks.set("0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" as Block["type"] });
     blocks.set("0,0,1", {
       pos: { x: 0, y: 0, z: 1 },
-      type: { kind: "fb-pipe", openAxis: 2, baseAtStart: "Z", baseAtEnd: "X", defectPositions: [0.5] },
+      type: { kind: "fb-pipe", openAxis: 2, defectPositions: [0.5], faces: ["ZX", "ZX", "ZX", "ZX"] },
     });
     blocks.set("0,0,3", { pos: { x: 0, y: 0, z: 3 }, type: "ZXZ" as Block["type"] });
     const xml = exportBlocksToDae(blocks);

--- a/gui/src/utils/flows.ts
+++ b/gui/src/utils/flows.ts
@@ -36,7 +36,7 @@ export async function computeFlows(
   }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) portIO[meta.label] = meta.io;

--- a/gui/src/utils/gridPlanePassthrough.test.ts
+++ b/gui/src/utils/gridPlanePassthrough.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import * as THREE from "three";
+import { shouldPassThroughGridPlane } from "./gridPlanePassthrough";
+
+const plane = new THREE.Mesh();
+const block = new THREE.Mesh();
+const port = new THREE.Mesh();
+const hit = (o: THREE.Object3D) => ({ object: o });
+
+describe("shouldPassThroughGridPlane", () => {
+  it("returns false when intersections is empty", () => {
+    expect(shouldPassThroughGridPlane([], plane)).toBe(false);
+  });
+
+  it("returns false when only the plane is hit", () => {
+    expect(shouldPassThroughGridPlane([hit(plane)], plane)).toBe(false);
+  });
+
+  it("returns true when a block is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(block)], plane)).toBe(true);
+  });
+
+  it("returns true when a port ghost is hit beyond the plane", () => {
+    expect(shouldPassThroughGridPlane([hit(plane), hit(port)], plane)).toBe(true);
+  });
+
+  it("returns false when planeMesh is null (e.g., pre-mount frame)", () => {
+    expect(shouldPassThroughGridPlane([hit(block)], null)).toBe(false);
+  });
+});

--- a/gui/src/utils/gridPlanePassthrough.ts
+++ b/gui/src/utils/gridPlanePassthrough.ts
@@ -1,0 +1,31 @@
+import type { Intersection, Object3D } from "three";
+
+/**
+ * In select mode, GridPlane should bow out of clicks/hovers when the ray also
+ * hits another interactive mesh further along (a block or port ghost). Without
+ * this, the invisible plane at Three.js y=0 swallows clicks meant for blocks
+ * placed at TQEC z<0 (below the plane) when the camera looks down from above.
+ *
+ * Click chain (perspective, camera tilted down):
+ *
+ *   camera                  After fix:
+ *     │                       plane sees a non-plane hit in e.intersections
+ *     ▼                       → returns without stopProp/clearSelection
+ *   [GridPlane y=0]           → BlockInstances.handleClick runs
+ *     │                       → sub-ground block gets selected
+ *     ▼
+ *   [Block | Port]
+ *
+ * Returns true if any intersection's object is not the plane itself, meaning
+ * the next handler in the chain should own the event.
+ *
+ * Relies on the project convention that decorative meshes use raycast={noRaycast}
+ * so e.intersections only contains actually-clickable meshes.
+ */
+export function shouldPassThroughGridPlane(
+  intersections: ReadonlyArray<Pick<Intersection, "object">>,
+  planeMesh: Object3D | null,
+): boolean {
+  if (!planeMesh) return false;
+  return intersections.some((i) => i.object !== planeMesh);
+}

--- a/gui/src/utils/groundShadow.test.ts
+++ b/gui/src/utils/groundShadow.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import {
+  ELEVATION_FALLOFF_FLOOR,
+  GROUND_EPSILON,
+  INVALID_LINE_COLOR,
+  INVALID_LINE_OPACITY,
+  INVALID_MESH_OPACITY,
+  INVALID_SHADOW_COLOR,
+  VALID_LINE_COLOR,
+  VALID_LINE_OPACITY,
+  VALID_MESH_OPACITY,
+  VALID_SHADOW_COLOR,
+  Y_OFFSET,
+  elevationFactor,
+  shadowVisuals,
+  shouldRenderShadow,
+} from "./groundShadow";
+
+describe("shouldRenderShadow", () => {
+  it.each<[number, boolean, string]>([
+    [0, false, "exactly on ground"],
+    [GROUND_EPSILON, false, "exactly at GROUND_EPSILON"],
+    [0.001, true, "just above epsilon"],
+    [1, true, "z=1 cube above ground"],
+    [30, true, "very tall block"],
+    [-1, false, "below ground (defensive)"],
+    [-0.5, false, "Y-cube below ground (defensive)"],
+  ])("z=%s -> %s (%s)", (z, expected) => {
+    expect(shouldRenderShadow({ x: 0, y: 0, z })).toBe(expected);
+  });
+});
+
+describe("elevationFactor", () => {
+  it("returns 1 at z=0 (no fade below z=1)", () => {
+    expect(elevationFactor(0)).toBe(1);
+  });
+
+  it("returns 1 at z=1 (full opacity baseline)", () => {
+    expect(elevationFactor(1)).toBe(1);
+  });
+
+  it("decreases monotonically between z=1 and z=30", () => {
+    let prev = elevationFactor(1);
+    for (let z = 2; z <= 30; z++) {
+      const cur = elevationFactor(z);
+      expect(cur).toBeLessThanOrEqual(prev);
+      prev = cur;
+    }
+  });
+
+  it("hits the floor at high z and stays there", () => {
+    // Pure formula at z=30 = 1/3.32 = 0.301, just above floor.
+    // Floor engages around z=30.17. Test slightly past that point.
+    expect(elevationFactor(31)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(50)).toBe(ELEVATION_FALLOFF_FLOOR);
+    expect(elevationFactor(100)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("floors at ELEVATION_FALLOFF_FLOOR even at z=10000", () => {
+    expect(elevationFactor(10000)).toBe(ELEVATION_FALLOFF_FLOOR);
+  });
+
+  it("z=8 ~ 0.61 (sanity-check the curve)", () => {
+    expect(elevationFactor(8)).toBeCloseTo(0.6410, 3);
+  });
+
+  it("z=16 ~ 0.45", () => {
+    expect(elevationFactor(16)).toBeCloseTo(0.4545, 3);
+  });
+});
+
+describe("shadowVisuals", () => {
+  describe("footprint sizing", () => {
+    it("centers a 1x1 cube at (pos.x + 0.5, -(pos.y + 0.5))", () => {
+      const v = shadowVisuals({ x: 3, y: 6, z: 2 }, "XZZ", true);
+      expect(v.cx).toBe(3.5);
+      expect(v.cz).toBe(-6.5);
+    });
+
+    it("uses 2x1 footprint for X-open pipe (OZX): cx offset 1, cz offset 0.5", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "OZX", true);
+      // OZX is [2, 1, 1] in TQEC -> ground footprint sx=2, sy=1
+      expect(v.cx).toBe(1);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x2 footprint for Y-open pipe (ZOX): cx offset 0.5, cz offset 1", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZOX", true);
+      // ZOX is [1, 2, 1] in TQEC -> ground footprint sx=1, sy=2
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-1);
+    });
+
+    it("uses 1x1 footprint for Z-open pipe (ZXO)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "ZXO", true);
+      // ZXO is [1, 1, 2] in TQEC -> ground footprint sx=1, sy=1 (z is open axis)
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+
+    it("uses 1x1 footprint for Y half-cube (sz=0.5 ignored for ground)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.cx).toBe(0.5);
+      expect(v.cz).toBe(-0.5);
+    });
+  });
+
+  describe("lineLen", () => {
+    it("uses pos.z (block bottom), not pos.z + sz (block top)", () => {
+      // Y half-cube at z=2: top is at 2.5, but lineLen must use 2.
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "Y", true);
+      expect(v.lineLen).toBeCloseTo(2 - Y_OFFSET, 6);
+    });
+
+    it("computes correctly for a tall block", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.lineLen).toBeCloseTo(8 - Y_OFFSET, 6);
+    });
+  });
+
+  describe("opacity & elevation falloff", () => {
+    it("applies falloff to valid mesh+line opacity", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 8 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * elevationFactor(8), 6);
+      expect(v.lineOpacity).toBeCloseTo(VALID_LINE_OPACITY * elevationFactor(8), 6);
+    });
+
+    it("does NOT apply falloff when valid=false (full strength)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 30 }, "XZZ", false);
+      expect(v.meshOpacity).toBe(INVALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(INVALID_LINE_OPACITY);
+    });
+
+    it("at z=1, valid mesh opacity == VALID_MESH_OPACITY (no fade)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 1 }, "XZZ", true);
+      expect(v.meshOpacity).toBe(VALID_MESH_OPACITY);
+      expect(v.lineOpacity).toBe(VALID_LINE_OPACITY);
+    });
+
+    it("at high z, valid mesh opacity hits floor (30% of base)", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 50 }, "XZZ", true);
+      expect(v.meshOpacity).toBeCloseTo(VALID_MESH_OPACITY * ELEVATION_FALLOFF_FLOOR, 6);
+    });
+  });
+
+  describe("colors", () => {
+    it("uses #000/#000 for valid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", true);
+      expect(v.meshColor).toBe(VALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(VALID_LINE_COLOR);
+    });
+
+    it("uses #ff5555/#ff0000 for invalid", () => {
+      const v = shadowVisuals({ x: 0, y: 0, z: 2 }, "XZZ", false);
+      expect(v.meshColor).toBe(INVALID_SHADOW_COLOR);
+      expect(v.lineColor).toBe(INVALID_LINE_COLOR);
+    });
+  });
+});

--- a/gui/src/utils/groundShadow.ts
+++ b/gui/src/utils/groundShadow.ts
@@ -1,0 +1,77 @@
+import { blockTqecSize, type BlockType, type Position3D } from "../types";
+
+export const GROUND_EPSILON = 1e-4;
+export const Y_OFFSET = 0.01;
+export const ELEVATION_FALLOFF_FLOOR = 0.30;
+
+// Match DragGhost's red palette for invalid:
+//   shadow color #ff5555 (DragGhost mesh, gui/src/components/DragGhost.tsx:23)
+//   line   color #ff0000 (DragGhost edges, gui/src/components/DragGhost.tsx:30)
+export const VALID_MESH_OPACITY = 0.28;
+export const INVALID_MESH_OPACITY = 0.30;
+export const VALID_LINE_OPACITY = 0.22;
+export const INVALID_LINE_OPACITY = 0.28;
+
+export const VALID_SHADOW_COLOR = 0x000000;
+export const INVALID_SHADOW_COLOR = 0xff5555;
+export const VALID_LINE_COLOR = 0x000000;
+export const INVALID_LINE_COLOR = 0xff0000;
+
+/** True when the block is sufficiently above the ground to deserve a shadow. */
+export function shouldRenderShadow(pos: Position3D): boolean {
+  return pos.z > GROUND_EPSILON;
+}
+
+/**
+ * Elevation falloff factor. Asymptotic, floored at ELEVATION_FALLOFF_FLOOR
+ * so the shadow always remains visible even on very tall TQEC graphs.
+ *  z=1  -> 1.00   (full)
+ *  z=8  -> 0.64
+ *  z=16 -> 0.45
+ *  z=30 -> 0.30   (floor)
+ */
+export function elevationFactor(z: number): number {
+  const raw = 1 / (1 + Math.max(0, z - 1) * 0.08);
+  return Math.max(raw, ELEVATION_FALLOFF_FLOOR);
+}
+
+export interface ShadowVisuals {
+  cx: number;
+  cz: number;
+  lineLen: number;
+  meshOpacity: number;
+  lineOpacity: number;
+  meshColor: number;
+  lineColor: number;
+}
+
+/**
+ * Derive everything a GroundShadowAbsolute needs to render from inputs.
+ *
+ * Coordinate convention: TQEC pos.z is the block's bottom in three.js Y
+ * (since tqecToThree maps TQEC Z -> three.js Y and adds sz/2 from the base).
+ * The shadow's ground-plane center is offset by sx/2, sy/2 from pos in the
+ * XZ plane (with TQEC Y negated to match three.js -Z).
+ *
+ * NOTE: caller is responsible for the shouldRenderShadow gate; this fn
+ * computes visuals unconditionally so tests can exercise the math at z=0.
+ */
+export function shadowVisuals(
+  pos: Position3D,
+  blockType: BlockType,
+  valid: boolean,
+): ShadowVisuals {
+  const [sx, sy] = blockTqecSize(blockType);
+  // Valid shadows fade with elevation; invalid stays full strength so the
+  // conflict signal remains legible at any height.
+  const fade = valid ? elevationFactor(pos.z) : 1;
+  return {
+    cx: pos.x + sx / 2,
+    cz: -(pos.y + sy / 2),
+    lineLen: pos.z - Y_OFFSET,
+    meshOpacity: (valid ? VALID_MESH_OPACITY : INVALID_MESH_OPACITY) * fade,
+    lineOpacity: (valid ? VALID_LINE_OPACITY : INVALID_LINE_OPACITY) * fade,
+    meshColor: valid ? VALID_SHADOW_COLOR : INVALID_SHADOW_COLOR,
+    lineColor: valid ? VALID_LINE_COLOR : INVALID_LINE_COLOR,
+  };
+}

--- a/gui/src/utils/sceneShare.test.ts
+++ b/gui/src/utils/sceneShare.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { Block } from "../types";
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import {
+  buildShareUrl,
+  decodeSnapshotFromHash,
+  encodeSnapshotToHashParam,
+  isCompressionStreamSupported,
+  parseSceneHashParam,
+} from "./sceneShare";
+
+function snapshot(
+  blocks: Array<[string, Block]> = [],
+  portMeta: SceneSnapshotV1["portMeta"] = [],
+  portPositions: string[] = [],
+): SceneSnapshotV1 {
+  return { v: 1, blocks, portMeta, portPositions };
+}
+
+describe("parseSceneHashParam", () => {
+  it("extracts the scene parameter from various hash forms", () => {
+    expect(parseSceneHashParam("#scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("?scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#foo=1&scene=abc")).toBe("abc");
+    expect(parseSceneHashParam("#scene=abc&foo=1")).toBe("abc");
+    expect(parseSceneHashParam("https://x.test/app#scene=abc")).toBe("abc");
+  });
+
+  it("returns null when no scene param is present", () => {
+    expect(parseSceneHashParam("")).toBe(null);
+    expect(parseSceneHashParam("#")).toBe(null);
+    expect(parseSceneHashParam("#otherkey=value")).toBe(null);
+    expect(parseSceneHashParam("scenefoo=bar")).toBe(null);
+  });
+});
+
+describe("buildShareUrl", () => {
+  it("appends the encoded payload to the supplied base", () => {
+    expect(buildShareUrl("xyz", "https://app.test/")).toBe(
+      "https://app.test/#scene=xyz",
+    );
+  });
+});
+
+const compressionAvailable = isCompressionStreamSupported();
+const skipIfNoCompression = compressionAvailable ? describe : describe.skip;
+
+skipIfNoCompression("encode/decode round-trip", () => {
+  it("round-trips an empty scene", async () => {
+    const original = snapshot();
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a small scene with port meta and ranks", async () => {
+    const blocks: Array<[string, Block]> = [
+      ["0,0,0", { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" }],
+      ["3,0,0", { pos: { x: 3, y: 0, z: 0 }, type: "OZX" }],
+      ["6,0,0", { pos: { x: 6, y: 0, z: 0 }, type: "ZXZ" }],
+    ];
+    const original = snapshot(
+      blocks,
+      [
+        ["0,0,0", { label: "P1", io: "in", rank: 0 }],
+        ["6,0,0", { label: "P2", io: "out", rank: 1 }],
+      ],
+      ["0,0,0", "6,0,0"],
+    );
+    const encoded = await encodeSnapshotToHashParam(original);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("round-trips a 200-block scene and produces base64url-safe output", async () => {
+    const blocks: Array<[string, Block]> = [];
+    for (let i = 0; i < 200; i++) {
+      const x = (i % 20) * 3;
+      const z = Math.floor(i / 20) * 3;
+      blocks.push([`${x},0,${z}`, { pos: { x, y: 0, z }, type: "XZZ" }]);
+    }
+    const original = snapshot(blocks);
+    const encoded = await encodeSnapshotToHashParam(original);
+    expect(/^[A-Za-z0-9_-]+$/.test(encoded)).toBe(true);
+    const decoded = await decodeSnapshotFromHash(`#scene=${encoded}`);
+    expect(decoded).toEqual(original);
+  });
+
+  it("returns null for a malformed base64 payload", async () => {
+    expect(await decodeSnapshotFromHash("#scene=!!!not-base64")).toBe(null);
+  });
+
+  it("returns null when valid base64 is not deflate-compressed", async () => {
+    expect(await decodeSnapshotFromHash("#scene=aGVsbG8")).toBe(null);
+  });
+
+  it("returns null when the decoded JSON has the wrong shape", async () => {
+    const wrongShape = await encodeSnapshotToHashParam({
+      v: 1,
+      blocks: "not-an-array" as unknown as never,
+      portMeta: [],
+      portPositions: [],
+    } as SceneSnapshotV1);
+    expect(await decodeSnapshotFromHash(`#scene=${wrongShape}`)).toBe(null);
+  });
+
+  it("returns null when there is no scene param", async () => {
+    expect(await decodeSnapshotFromHash("#nothing-here")).toBe(null);
+  });
+});

--- a/gui/src/utils/sceneShare.ts
+++ b/gui/src/utils/sceneShare.ts
@@ -1,0 +1,99 @@
+import type { SceneSnapshotV1 } from "./sceneSnapshot";
+import { isSceneSnapshotV1 } from "./sceneSnapshot";
+
+export const SCENE_HASH_KEY = "scene";
+
+const COMPRESSION_FORMAT = "deflate-raw" as const;
+
+export function isCompressionStreamSupported(): boolean {
+  return (
+    typeof CompressionStream !== "undefined" &&
+    typeof DecompressionStream !== "undefined"
+  );
+}
+
+async function runStream(
+  input: Uint8Array,
+  transform: GenericTransformStream,
+): Promise<Uint8Array> {
+  const writer = transform.writable.getWriter();
+  // Swallow writer-side rejections so they don't become unhandled. The
+  // canonical error surface is the readable side, which the caller awaits.
+  writer.write(input).catch(() => {});
+  writer.close().catch(() => {});
+  const buf = await new Response(transform.readable).arrayBuffer();
+  return new Uint8Array(buf);
+}
+
+async function compress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new CompressionStream(COMPRESSION_FORMAT));
+}
+
+async function decompress(input: Uint8Array): Promise<Uint8Array> {
+  return runStream(input, new DecompressionStream(COMPRESSION_FORMAT));
+}
+
+function bytesToBase64Url(bytes: Uint8Array): string {
+  // Chunk to keep apply() argument count safe across engines.
+  const CHUNK = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary).replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/, "");
+}
+
+function base64UrlToBytes(s: string): Uint8Array {
+  const padded = s.replaceAll("-", "+").replaceAll("_", "/");
+  const pad = padded.length % 4 === 0 ? "" : "=".repeat(4 - (padded.length % 4));
+  const binary = atob(padded + pad);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) bytes[i] = binary.charCodeAt(i);
+  return bytes;
+}
+
+export async function encodeSnapshotToHashParam(
+  snapshot: SceneSnapshotV1,
+): Promise<string> {
+  const json = JSON.stringify(snapshot);
+  const compressed = await compress(new TextEncoder().encode(json));
+  return bytesToBase64Url(compressed);
+}
+
+/**
+ * Accepts any of: "#scene=xyz", "scene=xyz", "?scene=xyz", "&scene=xyz",
+ * or a full URL containing "scene=xyz". Returns the value, or null if
+ * no `scene` parameter is present.
+ */
+export function parseSceneHashParam(hashOrUrl: string): string | null {
+  const re = /(?:^|[#?&])scene=([^&]*)/;
+  const match = re.exec(hashOrUrl);
+  if (!match || !match[1]) return null;
+  return match[1];
+}
+
+export async function decodeSnapshotFromHash(
+  hashOrUrl: string,
+): Promise<SceneSnapshotV1 | null> {
+  const param = parseSceneHashParam(hashOrUrl);
+  if (!param) return null;
+  try {
+    const bytes = base64UrlToBytes(param);
+    const decompressed = await decompress(bytes);
+    const json = new TextDecoder().decode(decompressed);
+    const parsed: unknown = JSON.parse(json);
+    if (!isSceneSnapshotV1(parsed)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function buildShareUrl(hashParam: string, base?: string): string {
+  const b =
+    base ??
+    (typeof window !== "undefined"
+      ? window.location.origin + window.location.pathname + window.location.search
+      : "");
+  return `${b}#${SCENE_HASH_KEY}=${hashParam}`;
+}

--- a/gui/src/utils/sceneSnapshot.ts
+++ b/gui/src/utils/sceneSnapshot.ts
@@ -1,0 +1,69 @@
+import type { Block, PortMeta } from "../types";
+import { useBlockStore } from "../stores/blockStore";
+
+export const SCENE_SCHEMA_VERSION = 1;
+
+export interface SceneSnapshotV1 {
+  v: 1;
+  blocks: Array<[string, Block]>;
+  portMeta: Array<[string, PortMeta]>;
+  portPositions: string[];
+}
+
+export function captureSnapshot(): SceneSnapshotV1 {
+  const s = useBlockStore.getState();
+  return {
+    v: 1,
+    blocks: Array.from(s.blocks.entries()),
+    portMeta: Array.from(s.portMeta.entries()),
+    portPositions: Array.from(s.portPositions),
+  };
+}
+
+export function snapshotIsEmpty(snapshot: SceneSnapshotV1): boolean {
+  return snapshot.blocks.length === 0;
+}
+
+export function isSceneSnapshotV1(value: unknown): value is SceneSnapshotV1 {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Partial<SceneSnapshotV1>;
+  if (v.v !== 1) return false;
+  if (!Array.isArray(v.blocks) || !Array.isArray(v.portMeta) || !Array.isArray(v.portPositions)) {
+    return false;
+  }
+  for (const entry of v.blocks) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const block = entry[1] as Partial<Block> | undefined;
+    if (!block || typeof block !== "object") return false;
+    if (typeof block.type !== "string") return false;
+    if (!block.pos || typeof block.pos !== "object") return false;
+    const { x, y, z } = block.pos;
+    if (typeof x !== "number" || typeof y !== "number" || typeof z !== "number") return false;
+  }
+  for (const entry of v.portMeta) {
+    if (!Array.isArray(entry) || entry.length !== 2) return false;
+    if (typeof entry[0] !== "string") return false;
+    const meta = entry[1] as Partial<PortMeta> | undefined;
+    if (!meta || typeof meta.label !== "string") return false;
+    if (meta.io !== "in" && meta.io !== "out") return false;
+  }
+  for (const p of v.portPositions) {
+    if (typeof p !== "string") return false;
+  }
+  return true;
+}
+
+export type ApplyMode = "load" | "hydrate";
+
+export function applySnapshot(snapshot: SceneSnapshotV1, mode: ApplyMode = "hydrate"): void {
+  const store = useBlockStore.getState();
+  const blocks = new Map<string, Block>(snapshot.blocks);
+  if (mode === "load") store.loadBlocks(blocks);
+  else store.hydrateBlocks(blocks);
+  useBlockStore.setState({
+    portMeta: new Map(snapshot.portMeta),
+    portPositions: new Set(snapshot.portPositions),
+  });
+  useBlockStore.getState().ensurePortLabels();
+}

--- a/gui/src/utils/validate.test.ts
+++ b/gui/src/utils/validate.test.ts
@@ -5,9 +5,8 @@ import type { Block, FreeBuildPipeSpec } from "../types";
 const FB_SPEC: FreeBuildPipeSpec = {
   kind: "fb-pipe",
   openAxis: 2,
-  baseAtStart: "Z",
-  baseAtEnd: "X",
   defectPositions: [0.5],
+  faces: ["XZ", "XZ", "XZ", "XZ"],
 };
 
 describe("validateDiagram", () => {

--- a/gui/src/utils/zx.ts
+++ b/gui/src/utils/zx.ts
@@ -68,7 +68,7 @@ export async function computeZX(
   }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
-    return { pos: [p.x, p.y, p.z], label: meta.label };
+    return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
   });
   const portIO: Record<string, string> = {};
   for (const meta of portMeta.values()) {

--- a/gui/vitest.config.ts
+++ b/gui/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "jsdom",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.{ts,tsx}"],
   },
 });

--- a/server.py
+++ b/server.py
@@ -549,8 +549,13 @@ async def zx(req: ZXRequest) -> ZXResponse:
     if req.simplify:
         pyzx.simplify.full_reduce(pzx.g)
         # normalize() places inputs/outputs at sensible (qubit, row) — required
-        # before extract_circuit and nicer for display.
-        pzx.g.normalize()
+        # before extract_circuit and nicer for display. Skip it when only
+        # outputs are set: pyzx.normalize() invokes auto_detect_io() whenever
+        # num_inputs() == 0, which clobbers our explicit outputs and raises
+        # TypeError on boundary vertices that share a row with their neighbor
+        # (issue #221). Frontend falls back to a circle layout in that case.
+        if pzx.g.num_inputs() > 0 or pzx.g.num_outputs() == 0:
+            pzx.g.normalize()
 
     circuit_info: ZXCircuit | None = None
     circuit_error: str | None = None

--- a/server.py
+++ b/server.py
@@ -56,6 +56,10 @@ class BlockInput(BaseModel):
 class PortLabelInput(BaseModel):
     pos: list[float]
     label: str
+    # User-defined display rank from the Ports table. Lower ranks come first.
+    # When provided, the /api/zx endpoint sorts the extracted circuit's qubit
+    # register by this value so it matches the order shown in the GUI.
+    rank: int | None = None
 
 
 class ValidateRequest(BaseModel):
@@ -450,8 +454,26 @@ async def flows(req: FlowsRequest) -> FlowsResponse:
             error="Diagram has no open ports",
         )
 
-    inputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "in"]
-    outputs = [p for p in ordered_ports if req.port_io.get(p, "in") == "out"]
+    # Sort by user-defined rank from the Ports table (matches /api/zx) so the
+    # qubit-register position when this diagram is interpreted as a circuit
+    # follows the GUI order. Unranked ports fall through to TQEC's
+    # alphabetical order.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _flows_sort_key(label: str) -> tuple[int, str]:
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    inputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "in"),
+        key=_flows_sort_key,
+    )
+    outputs = sorted(
+        (p for p in ordered_ports if req.port_io.get(p, "in") == "out"),
+        key=_flows_sort_key,
+    )
 
     try:
         surfaces = graph.find_correlation_surfaces()
@@ -534,6 +556,21 @@ async def zx(req: ZXRequest) -> ZXResponse:
             port_label_by_vertex[v] = cube.label
             io = req.port_io.get(cube.label, "in")
             (output_vs if io == "out" else input_vs).append(v)
+
+    # Sort input/output vertex lists by user-defined rank from the Ports table
+    # so the extracted circuit's qubit register matches the GUI order.
+    # Unranked ports sort last, then alphabetically by label.
+    label_to_rank: dict[str, int] = {
+        p.label: p.rank for p in req.port_labels if p.label and p.rank is not None
+    }
+
+    def _port_sort_key(v: int) -> tuple[int, str]:
+        label = port_label_by_vertex.get(v, "")
+        rank = label_to_rank.get(label)
+        return (rank if rank is not None else 2**31, label)
+
+    input_vs.sort(key=_port_sort_key)
+    output_vs.sort(key=_port_sort_key)
 
     # Register boundary vertices as pyzx inputs/outputs (required by
     # pyzx.extract_circuit, harmless otherwise).

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -724,6 +724,74 @@ class TestZXEndpoint:
         labels = {v["label"] for v in result["vertices"] if v["label"]}
         assert labels == {"a", "b"}
 
+    def test_extract_qubit_register_follows_port_rank(self):
+        # Two parallel identity chains → 2 inputs, 2 outputs. The qubit-index
+        # of each input is determined by the user-defined rank on PortLabelInput
+        # (matching the Ports table order), not by alphabetical label sort.
+        # Swapping the ranks must swap which port maps to qubit 0.
+        blocks = [
+            # Chain 1 at y=0
+            BlockInput(pos=[0, 0, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 0, 0], type="OXZ"),
+            BlockInput(pos=[1, 0, 0], type="OXZ"),
+            # Chain 2 at y=3
+            BlockInput(pos=[0, 3, 0], type="ZXZ"),
+            BlockInput(pos=[-2, 3, 0], type="OXZ"),
+            BlockInput(pos=[1, 3, 0], type="OXZ"),
+        ]
+        port_io = {"a_in": "in", "a_out": "out", "b_in": "in", "b_out": "out"}
+
+        def qubit_of_input_label(result: dict, label: str) -> int:
+            # After extract, vertex pos is [row, 0, -qubit]; inputs land at the
+            # smallest row in the layout. Find the vertex carrying `label` and
+            # return its qubit index.
+            for v in result["vertices"]:
+                if v["label"] == label and v["pos"] is not None:
+                    return int(round(-v["pos"][2]))
+            raise AssertionError(f"no vertex labelled {label!r}")
+
+        # Case A: rank a_in=0, b_in=1 → a_in is qubit 0, b_in is qubit 1.
+        port_labels_a = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=0),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=1),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_a = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_a,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_a["ok"] is True, result_a
+        assert result_a["circuit_error"] is None, result_a["circuit_error"]
+        assert qubit_of_input_label(result_a, "a_in") == 0
+        assert qubit_of_input_label(result_a, "b_in") == 1
+
+        # Case B: swap input ranks → b_in is now qubit 0, a_in is qubit 1.
+        port_labels_b = [
+            PortLabelInput(pos=[-3, 0, 0], label="a_in", rank=1),
+            PortLabelInput(pos=[3, 0, 0], label="a_out", rank=2),
+            PortLabelInput(pos=[-3, 3, 0], label="b_in", rank=0),
+            PortLabelInput(pos=[3, 3, 0], label="b_out", rank=3),
+        ]
+        result_b = self._run(
+            ZXRequest(
+                blocks=blocks,
+                port_labels=port_labels_b,
+                port_io=port_io,
+                simplify=True,
+                extract=True,
+            )
+        )
+        assert result_b["ok"] is True, result_b
+        assert result_b["circuit_error"] is None, result_b["circuit_error"]
+        assert qubit_of_input_label(result_b, "a_in") == 1
+        assert qubit_of_input_label(result_b, "b_in") == 0
+
     def test_extract_without_outputs_errors(self):
         result = self._run(
             ZXRequest(

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -378,6 +378,54 @@ class TestZXEndpoint:
         assert simplified["simplified"] is True
         assert len(simplified["vertices"]) <= len(raw["vertices"])
 
+    def test_simplify_with_all_output_ports(self):
+        # Regression for #221: full_reduce + normalize raised TypeError when
+        # every port was marked 'out', because pyzx auto_detect_io fires
+        # whenever num_inputs() == 0 and can't classify boundary vertices that
+        # share a row with their neighbor.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "out", "P2": "out"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+        assert result["simplified"] is True
+        # Both output boundaries should survive full_reduce.
+        assert len(result["vertices"]) == 2
+
+    def test_simplify_with_all_input_ports(self):
+        # Sister case to test_simplify_with_all_output_ports: locks in that
+        # all-input diagrams keep working, since pyzx's auto_detect_io guard
+        # only triggers when num_inputs() == 0.
+        result = self._run(
+            ZXRequest(
+                blocks=[
+                    BlockInput(pos=[0, 0, 0], type="ZXZ"),
+                    BlockInput(pos=[-2, 0, 0], type="OXZ"),
+                    BlockInput(pos=[1, 0, 0], type="OXZ"),
+                ],
+                port_labels=[
+                    PortLabelInput(pos=[-3, 0, 0], label="P1"),
+                    PortLabelInput(pos=[3, 0, 0], label="P2"),
+                ],
+                port_io={"P1": "in", "P2": "in"},
+                simplify=True,
+            )
+        )
+        assert result["ok"] is True
+        assert result["error"] is None
+
     def test_invalid_diagram_returns_error(self):
         # Mismatched pipe colors -> tqec validation error surfaces
         result = self._run(


### PR DESCRIPTION
## Summary
- Replace the 6 hand-curated FB toolbar presets with a single generic Free Pipe; each of the 4 walls now carries an independent FaceConfig (X / Z / XZ / ZX), giving 256 visual variants per open axis.
- Add a floating variants panel that auto-opens on FB placement / selection and lists every variant as a 2D unfolded sprite; click a cell to mutate the placed pipe in place.
- Rewrite `createPipeGeometry` and the Y-defect overlay logic for per-face inputs so corner cylinders and rings respect arbitrary swap combinations.
- Branch also bundles prior unmerged commits: free-build snap-to-cube fix, half-H mirror presets, scene sharing via URL hash, dev-branch fly deploy, ground shadow + projection line, and user-defined port ordering.

## Test plan
- [ ] `npx tsc -b` clean and `npm test` (445/445) green
- [ ] In the GUI, enable Free Build → drag the Free Pipe → variant panel opens → click cells to mutate the pipe → Y-defect cylinders update accordingly
- [ ] Select an existing free-build pipe → panel re-opens with its current variant highlighted
- [ ] Verify legacy `.dae` / scene-share blobs with old `baseAtStart` / `swapAxes` specs still load (auto-migrated to `faces`)

🧙 Built with [WOZCODE](https://wozcode.com)