### PR TITLE
feat: highlight valid free-pipe variants for XZZ-XZZ X-axis sandwich

### DIFF
--- a/gui/src/components/FreeBuildPipeVariantsPanel.tsx
+++ b/gui/src/components/FreeBuildPipeVariantsPanel.tsx
@@ -8,6 +8,7 @@ import {
   faceAboveBasis,
   faceBelowBasis,
   isFreeBuildPipeSpec,
+  validFBPipeVariantsXZZXAxis,
 } from "../types";
 import type { FaceConfig } from "../types";
 import { useFloatingPanel } from "../hooks/useFloatingPanel";
@@ -113,8 +114,54 @@ export function FreeBuildPipeVariantsPanel() {
 
   const variants = useMemo(() => enumerateVariants(), []);
 
+  const partitioned = useMemo(() => {
+    if (!block) return null;
+    const valid = validFBPipeVariantsXZZXAxis(block, blocks);
+    if (!valid) return null;
+    const validKeys = new Set(valid.map((v) => v.join("|")));
+    const validList: typeof variants = [];
+    const invalidList: typeof variants = [];
+    for (const v of variants) {
+      if (validKeys.has(v.join("|"))) validList.push(v);
+      else invalidList.push(v);
+    }
+    return { validList, invalidList };
+  }, [block, blocks, variants]);
+
   if (!open || !block || !isFreeBuildPipeSpec(block.type)) return null;
   const currentFaces = block.type.faces;
+
+  const renderCell = (faces: [FaceConfig, FaceConfig, FaceConfig, FaceConfig]) => {
+    const isCurrent = facesEqual(faces, currentFaces);
+    const key = faces.join("|");
+    return (
+      <button
+        key={key}
+        type="button"
+        onClick={() => setFBPipeFaces(block.pos, faces)}
+        title={faces.join(" ")}
+        style={{
+          padding: 4,
+          background: isCurrent ? "#e8f1ff" : "#fafafa",
+          border: `1px solid ${isCurrent ? "#4a9eff" : "#e0e0e0"}`,
+          borderRadius: 4,
+          cursor: "pointer",
+          display: "flex",
+          justifyContent: "center",
+        }}
+      >
+        <VariantSprite faces={faces} />
+      </button>
+    );
+  };
+
+  const sectionHeaderStyle = {
+    gridColumn: "1 / -1",
+    color: "#666",
+    fontSize: 11,
+    fontWeight: 600,
+    padding: "4px 2px 2px",
+  } as const;
 
   return (
     <div
@@ -173,28 +220,25 @@ export function FreeBuildPipeVariantsPanel() {
           gap: 6,
         }}
       >
-        {variants.map((faces, idx) => {
-          const isCurrent = facesEqual(faces, currentFaces);
-          return (
-            <button
-              key={idx}
-              type="button"
-              onClick={() => setFBPipeFaces(block.pos, faces)}
-              title={faces.join(" ")}
+        {partitioned ? (
+          <>
+            <div style={sectionHeaderStyle}>Valid for XZZ–XZZ in X</div>
+            {partitioned.validList.map(renderCell)}
+            <div
               style={{
-                padding: 4,
-                background: isCurrent ? "#e8f1ff" : "#fafafa",
-                border: `1px solid ${isCurrent ? "#4a9eff" : "#e0e0e0"}`,
-                borderRadius: 4,
-                cursor: "pointer",
-                display: "flex",
-                justifyContent: "center",
+                ...sectionHeaderStyle,
+                borderTop: "1px solid #eee",
+                marginTop: 6,
+                paddingTop: 8,
               }}
             >
-              <VariantSprite faces={faces} />
-            </button>
-          );
-        })}
+              Other variants (not valid for XZZ–XZZ in X)
+            </div>
+            {partitioned.invalidList.map(renderCell)}
+          </>
+        ) : (
+          variants.map(renderCell)
+        )}
       </div>
 
       <ResizeGrip {...resizeGripProps} />

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -24,6 +24,7 @@ import {
   FB_DEFAULT_FACES,
   migrateLegacyFBSpec,
   normalizeFBSpec,
+  validFBPipeVariantsXZZXAxis,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
 import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
@@ -467,5 +468,88 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
       { pos: { x: 1, y: 0, z: 0 }, type: Y_OPEN_SPEC },
     ]);
     expect(countAttachedPipes({ x: 0, y: 0, z: 0 }, blocks)).toBe(0);
+  });
+});
+
+describe("validFBPipeVariantsXZZXAxis", () => {
+  function makeBlocks(entries: Block[]): Map<string, Block> {
+    const map = new Map<string, Block>();
+    for (const b of entries) map.set(posKey(b.pos), b);
+    return map;
+  }
+
+  const PIPE_POS: Position3D = { x: 1, y: 0, z: 0 };
+  const NEG_POS: Position3D = { x: 0, y: 0, z: 0 };
+  const POS_POS: Position3D = { x: 3, y: 0, z: 0 };
+  const FB_X_PIPE: Block = { pos: PIPE_POS, type: X_OPEN_SPEC };
+
+  it("returns the all-Z tuple for the canonical XZZ–FB–XZZ X-axis sandwich", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: POS_POS, type: "XZZ" },
+    ]);
+    const result = validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks);
+    expect(result).toEqual([["Z", "Z", "Z", "Z"]]);
+  });
+
+  it("returns null when the FB pipe is Y-open", () => {
+    const fbY: Block = { pos: { x: 0, y: 1, z: 0 }, type: Y_OPEN_SPEC };
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
+      fbY,
+      { pos: { x: 0, y: 3, z: 0 }, type: "XZZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(fbY, blocks)).toBeNull();
+  });
+
+  it("returns null when the FB pipe is Z-open", () => {
+    const fbZ: Block = { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC };
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
+      fbZ,
+      { pos: { x: 0, y: 0, z: 3 }, type: "XZZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(fbZ, blocks)).toBeNull();
+  });
+
+  it("returns null when the −X neighbour is missing", () => {
+    const blocks = makeBlocks([
+      FB_X_PIPE,
+      { pos: POS_POS, type: "XZZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when the +X neighbour is missing", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when an X-axis neighbour is a non-XZZ cube", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: POS_POS, type: "ZXZ" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when an X-axis neighbour is a Y block", () => {
+    const blocks = makeBlocks([
+      { pos: NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: POS_POS, type: "Y" },
+    ]);
+    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when the input block is not an FB pipe", () => {
+    const cube: Block = { pos: NEG_POS, type: "XZZ" };
+    const blocks = makeBlocks([cube]);
+    expect(validFBPipeVariantsXZZXAxis(cube, blocks)).toBeNull();
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -1469,6 +1469,31 @@ export function hasPipeColorConflict(
 }
 
 /**
+ * v1 hardcoded build rule: returns the (single) valid FB face tuple when the
+ * FB pipe sits between two XZZ cubes along X (offsets −1 and +2). Returns
+ * null in every other configuration (different openAxis, missing neighbour,
+ * non-cube neighbour, non-XZZ cube). Future passes will generalise.
+ *
+ * The single valid variant is `["Z","Z","Z","Z"]` because XZZ has Z on both
+ * its Y and Z axes, so every wall of an X-open pipe must be solid Z on both
+ * sides of the defect.
+ */
+export function validFBPipeVariantsXZZXAxis(
+  block: Block,
+  blocks: BlocksLookup,
+): ReadonlyArray<readonly [FaceConfig, FaceConfig, FaceConfig, FaceConfig]> | null {
+  const t = block.type;
+  if (!isFreeBuildPipeSpec(t) || t.openAxis !== 0) return null;
+  const negPos: Position3D = { x: block.pos.x - 1, y: block.pos.y, z: block.pos.z };
+  const posPos: Position3D = { x: block.pos.x + 2, y: block.pos.y, z: block.pos.z };
+  const neg = blocks.get(posKey(negPos));
+  const pos = blocks.get(posKey(posPos));
+  if (!neg || !pos) return null;
+  if (neg.type !== "XZZ" || pos.type !== "XZZ") return null;
+  return [["Z", "Z", "Z", "Z"]];
+}
+
+/**
  * Check whether a cube placement conflicts with adjacent pipe colors.
  * For each of the 3 TQEC axes, checks both possible neighboring pipe positions.
  * For Hadamard pipes, determines which end faces the cube and uses the right colors.


### PR DESCRIPTION
## Summary
- v1 of the "build rules for free-build pipes" idea: when the open variants panel is for an X-open FB pipe sandwiched between two `XZZ` cubes (offsets −1 and +2 along X), the 256-variant grid is split with full-width section captions, with the single valid variant — the all-Z tube `["Z","Z","Z","Z"]` — sorted to the top.
- New `validFBPipeVariantsXZZXAxis` helper in `types/index.ts` is hardcoded to this one configuration and returns `null` for every other case (different `openAxis`, missing neighbour, non-cube neighbour, non-XZZ cube), so the panel renders unchanged outside the supported setup.
- 8 new unit tests in `freebuild.test.ts` cover the canonical setup plus every bail-out path.

## Test plan
- [x] `npm test` (453 tests pass, 8 new)
- [x] `tsc -b --noEmit` clean
- [x] `npm run lint` (no new warnings)
- [ ] Drop two `XZZ` cubes 3 apart in X, place a Free Pipe between them; confirm the panel shows a "Valid for XZZ–XZZ in X" header with one all-blue cell, then a divider with the other 255
- [ ] Replace one `XZZ` with a different cube type and confirm the headers/divider disappear

🧙 Built with [WOZCODE](https://wozcode.com)