### PR TITLE
feat: generalize valid free-pipe rule to any cube pair on any axis

### DIFF
--- a/gui/src/components/FreeBuildPipeVariantsPanel.tsx
+++ b/gui/src/components/FreeBuildPipeVariantsPanel.tsx
@@ -8,7 +8,7 @@ import {
   faceAboveBasis,
   faceBelowBasis,
   isFreeBuildPipeSpec,
-  validFBPipeVariantsXZZXAxis,
+  validFBPipeVariantsForCubePair,
 } from "../types";
 import type { FaceConfig } from "../types";
 import { useFloatingPanel } from "../hooks/useFloatingPanel";
@@ -116,16 +116,18 @@ export function FreeBuildPipeVariantsPanel() {
 
   const partitioned = useMemo(() => {
     if (!block) return null;
-    const valid = validFBPipeVariantsXZZXAxis(block, blocks);
-    if (!valid) return null;
-    const validKeys = new Set(valid.map((v) => v.join("|")));
+    const result = validFBPipeVariantsForCubePair(block, blocks);
+    if (!result) return null;
+    const axisName = ["X", "Y", "Z"][result.openAxis];
+    const label = `${result.negType}–${result.posType} in ${axisName}`;
+    const validKeys = new Set(result.faces.map((v) => v.join("|")));
     const validList: typeof variants = [];
     const invalidList: typeof variants = [];
     for (const v of variants) {
       if (validKeys.has(v.join("|"))) validList.push(v);
       else invalidList.push(v);
     }
-    return { validList, invalidList };
+    return { validList, invalidList, label };
   }, [block, blocks, variants]);
 
   if (!open || !block || !isFreeBuildPipeSpec(block.type)) return null;
@@ -222,7 +224,7 @@ export function FreeBuildPipeVariantsPanel() {
       >
         {partitioned ? (
           <>
-            <div style={sectionHeaderStyle}>Valid for XZZ–XZZ in X</div>
+            <div style={sectionHeaderStyle}>Valid for {partitioned.label}</div>
             {partitioned.validList.map(renderCell)}
             <div
               style={{
@@ -232,7 +234,7 @@ export function FreeBuildPipeVariantsPanel() {
                 paddingTop: 8,
               }}
             >
-              Other variants (not valid for XZZ–XZZ in X)
+              Other variants (not valid for {partitioned.label})
             </div>
             {partitioned.invalidList.map(renderCell)}
           </>

--- a/gui/src/types/freebuild.test.ts
+++ b/gui/src/types/freebuild.test.ts
@@ -24,7 +24,7 @@ import {
   FB_DEFAULT_FACES,
   migrateLegacyFBSpec,
   normalizeFBSpec,
-  validFBPipeVariantsXZZXAxis,
+  validFBPipeVariantsForCubePair,
 } from "./index";
 import type { Block, BlockType, FBPreset, FreeBuildPipeSpec, Position3D } from "./index";
 import { resolveFBSpecFromFace, resolvePipeTypeFromFace } from "../components/BlockInstances.logic";
@@ -471,85 +471,174 @@ describe("attached-pipe accounting recognizes FB pipes", () => {
   });
 });
 
-describe("validFBPipeVariantsXZZXAxis", () => {
+describe("validFBPipeVariantsForCubePair", () => {
   function makeBlocks(entries: Block[]): Map<string, Block> {
     const map = new Map<string, Block>();
     for (const b of entries) map.set(posKey(b.pos), b);
     return map;
   }
 
-  const PIPE_POS: Position3D = { x: 1, y: 0, z: 0 };
-  const NEG_POS: Position3D = { x: 0, y: 0, z: 0 };
-  const POS_POS: Position3D = { x: 3, y: 0, z: 0 };
-  const FB_X_PIPE: Block = { pos: PIPE_POS, type: X_OPEN_SPEC };
+  // X-axis cases ----------------------------------------------------------
+  const X_PIPE_POS: Position3D = { x: 1, y: 0, z: 0 };
+  const X_NEG_POS: Position3D = { x: 0, y: 0, z: 0 };
+  const X_POS_POS: Position3D = { x: 3, y: 0, z: 0 };
+  const FB_X_PIPE: Block = { pos: X_PIPE_POS, type: X_OPEN_SPEC };
 
-  it("returns the all-Z tuple for the canonical XZZ–FB–XZZ X-axis sandwich", () => {
+  it("XZZ–XZZ along X yields all-Z (both closed axes Z=Z)", () => {
     const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
+      { pos: X_NEG_POS, type: "XZZ" },
       FB_X_PIPE,
-      { pos: POS_POS, type: "XZZ" },
+      { pos: X_POS_POS, type: "XZZ" },
     ]);
-    const result = validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks);
-    expect(result).toEqual([["Z", "Z", "Z", "Z"]]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r).not.toBeNull();
+    expect(r!.faces).toEqual([["Z", "Z", "Z", "Z"]]);
+    expect(r!.negType).toBe("XZZ");
+    expect(r!.posType).toBe("XZZ");
+    expect(r!.openAxis).toBe(0);
   });
 
-  it("returns null when the FB pipe is Y-open", () => {
+  it("ZXX–XZZ along X yields all-XZ (X-below → Z-above on both closed axes)", () => {
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "ZXX" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "XZZ" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["XZ", "XZ", "XZ", "XZ"]]);
+    expect(r!.negType).toBe("ZXX");
+    expect(r!.posType).toBe("XZZ");
+  });
+
+  it("XZZ–ZXX along X (reversed) yields all-ZX", () => {
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "ZXX" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "ZX", "ZX"]]);
+  });
+
+  it("XZZ–ZXZ along X yields different face configs on the two closed axes", () => {
+    // XZZ closed (Y,Z) = (Z,Z); ZXZ closed (Y,Z) = (X,Z).
+    // Y-axis: Z→X = "ZX". Z-axis: Z→Z = "Z".
+    // ca0 (Three.js X→TQEC X is open; ca0=Three Y=TQEC Z): faces[0,1] = "Z".
+    // ca1 (Three.js Z→TQEC Y): faces[2,3] = "ZX".
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "ZXZ" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["Z", "Z", "ZX", "ZX"]]);
+  });
+
+  it("ZXZ–ZXX along X yields a mix of solid X and ZX swap", () => {
+    // ZXZ closed (Y,Z) = (X,Z); ZXX closed (Y,Z) = (X,X).
+    // Y-axis: X→X = "X". Z-axis: Z→X = "ZX".
+    // ca0 (TQEC Z): faces[0,1] = "ZX". ca1 (TQEC Y): faces[2,3] = "X".
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "ZXZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: "ZXX" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(FB_X_PIPE, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "X", "X"]]);
+  });
+
+  // Y-axis ---------------------------------------------------------------
+  it("XZZ–XZZ along Y yields all-X (closed axes X=X both ends)", () => {
+    // openAxis=1 (Y). Closed TQEC axes: X (0) and Z (2). Both ends XZZ.
+    // X-axis basis: X. Z-axis basis: Z. Both same below=above. So solid X on
+    // one ca and solid Z on the other.
+    // ca0 (Three.js X = TQEC X): "X". ca1 (Three.js Y = TQEC Z): "Z".
     const fbY: Block = { pos: { x: 0, y: 1, z: 0 }, type: Y_OPEN_SPEC };
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
       fbY,
       { pos: { x: 0, y: 3, z: 0 }, type: "XZZ" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(fbY, blocks)).toBeNull();
+    const r = validFBPipeVariantsForCubePair(fbY, blocks);
+    expect(r!.faces).toEqual([["X", "X", "Z", "Z"]]);
+    expect(r!.openAxis).toBe(1);
   });
 
-  it("returns null when the FB pipe is Z-open", () => {
+  it("ZXZ–XZZ along Y yields a swap on the X-axis closed wall and solid Z on the Z-axis wall", () => {
+    // ZXZ closed (X,Z) = (Z,Z); XZZ closed (X,Z) = (X,Z).
+    // X-axis: Z→X = "ZX". Z-axis: Z→Z = "Z".
+    // ca0 = TQEC X: "ZX". ca1 = TQEC Z: "Z".
+    const fbY: Block = { pos: { x: 0, y: 1, z: 0 }, type: Y_OPEN_SPEC };
+    const blocks = makeBlocks([
+      { pos: { x: 0, y: 0, z: 0 }, type: "ZXZ" },
+      fbY,
+      { pos: { x: 0, y: 3, z: 0 }, type: "XZZ" },
+    ]);
+    const r = validFBPipeVariantsForCubePair(fbY, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "Z", "Z"]]);
+  });
+
+  // Z-axis ---------------------------------------------------------------
+  it("XZZ–XZZ along Z yields one solid X wall and one solid Z wall", () => {
+    // openAxis=2 (Z). Closed TQEC axes: X (0) and Y (1).
+    // XZZ X=X, XZZ Y=Z. Both ends same. ca0=TQEC X→"X", ca1=TQEC Y→"Z".
     const fbZ: Block = { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC };
     const blocks = makeBlocks([
       { pos: { x: 0, y: 0, z: 0 }, type: "XZZ" },
       fbZ,
       { pos: { x: 0, y: 0, z: 3 }, type: "XZZ" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(fbZ, blocks)).toBeNull();
+    const r = validFBPipeVariantsForCubePair(fbZ, blocks);
+    expect(r!.faces).toEqual([["X", "X", "Z", "Z"]]);
+    expect(r!.openAxis).toBe(2);
   });
 
-  it("returns null when the −X neighbour is missing", () => {
+  it("ZXX–XXZ along Z yields a swap on each closed-axis wall", () => {
+    // ZXX (X=Z, Y=X); XXZ (X=X, Y=X). X-axis: Z→X = "ZX". Y-axis: X→X = "X".
+    const fbZ: Block = { pos: { x: 0, y: 0, z: 1 }, type: Z_OPEN_SPEC };
     const blocks = makeBlocks([
-      FB_X_PIPE,
-      { pos: POS_POS, type: "XZZ" },
+      { pos: { x: 0, y: 0, z: 0 }, type: "ZXX" },
+      fbZ,
+      { pos: { x: 0, y: 0, z: 3 }, type: "XXZ" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+    const r = validFBPipeVariantsForCubePair(fbZ, blocks);
+    expect(r!.faces).toEqual([["ZX", "ZX", "X", "X"]]);
   });
 
-  it("returns null when the +X neighbour is missing", () => {
-    const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
-      FB_X_PIPE,
-    ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  // Null-returning cases -------------------------------------------------
+  it("returns null when the −openAxis neighbour is missing", () => {
+    const blocks = makeBlocks([FB_X_PIPE, { pos: X_POS_POS, type: "XZZ" }]);
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
   });
 
-  it("returns null when an X-axis neighbour is a non-XZZ cube", () => {
-    const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
-      FB_X_PIPE,
-      { pos: POS_POS, type: "ZXZ" },
-    ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+  it("returns null when the +openAxis neighbour is missing", () => {
+    const blocks = makeBlocks([{ pos: X_NEG_POS, type: "XZZ" }, FB_X_PIPE]);
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
   });
 
-  it("returns null when an X-axis neighbour is a Y block", () => {
+  it("returns null when a neighbour is a Y block", () => {
     const blocks = makeBlocks([
-      { pos: NEG_POS, type: "XZZ" },
+      { pos: X_NEG_POS, type: "XZZ" },
       FB_X_PIPE,
-      { pos: POS_POS, type: "Y" },
+      { pos: X_POS_POS, type: "Y" },
     ]);
-    expect(validFBPipeVariantsXZZXAxis(FB_X_PIPE, blocks)).toBeNull();
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
+  });
+
+  it("returns null when a neighbour is an FB pipe (only plain cubes count)", () => {
+    // Hypothetical FB pipe at X_POS_POS — block positions can't legally hold a
+    // pipe, but the rule should reject any non-cube neighbour regardless.
+    const blocks = makeBlocks([
+      { pos: X_NEG_POS, type: "XZZ" },
+      FB_X_PIPE,
+      { pos: X_POS_POS, type: X_OPEN_SPEC },
+    ]);
+    expect(validFBPipeVariantsForCubePair(FB_X_PIPE, blocks)).toBeNull();
   });
 
   it("returns null when the input block is not an FB pipe", () => {
-    const cube: Block = { pos: NEG_POS, type: "XZZ" };
+    const cube: Block = { pos: X_NEG_POS, type: "XZZ" };
     const blocks = makeBlocks([cube]);
-    expect(validFBPipeVariantsXZZXAxis(cube, blocks)).toBeNull();
+    expect(validFBPipeVariantsForCubePair(cube, blocks)).toBeNull();
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -1469,28 +1469,66 @@ export function hasPipeColorConflict(
 }
 
 /**
- * v1 hardcoded build rule: returns the (single) valid FB face tuple when the
- * FB pipe sits between two XZZ cubes along X (offsets −1 and +2). Returns
- * null in every other configuration (different openAxis, missing neighbour,
- * non-cube neighbour, non-XZZ cube). Future passes will generalise.
+ * Hardcoded build rule: for any FB pipe flanked by two plain TQEC cubes along
+ * its open axis, returns the single valid FB face tuple per the touching-faces
+ * rule. Each closed-axis wall's "below" basis must equal the −openAxis cube's
+ * basis on that closed axis, and its "above" basis must equal the +openAxis
+ * cube's basis. There is always exactly one solution for any cube pair.
  *
- * The single valid variant is `["Z","Z","Z","Z"]` because XZZ has Z on both
- * its Y and Z axes, so every wall of an X-open pipe must be solid Z on both
- * sides of the defect.
+ * Returns null when:
+ *   - the input block isn't an FB pipe,
+ *   - either neighbour at offset −1 / +2 along openAxis is missing, or
+ *   - either neighbour isn't a plain CUBE_TYPES cube (Y, TQEC pipes, FB pipes
+ *     all excluded).
+ *
+ * The result also carries the matched cube types and openAxis so the caller
+ * can label the section header (e.g., "ZXX–XZZ in X") without re-reading the
+ * neighbours.
  */
-export function validFBPipeVariantsXZZXAxis(
+export function validFBPipeVariantsForCubePair(
   block: Block,
   blocks: BlocksLookup,
-): ReadonlyArray<readonly [FaceConfig, FaceConfig, FaceConfig, FaceConfig]> | null {
+): {
+  faces: ReadonlyArray<readonly [FaceConfig, FaceConfig, FaceConfig, FaceConfig]>;
+  negType: CubeType;
+  posType: CubeType;
+  openAxis: 0 | 1 | 2;
+} | null {
   const t = block.type;
-  if (!isFreeBuildPipeSpec(t) || t.openAxis !== 0) return null;
-  const negPos: Position3D = { x: block.pos.x - 1, y: block.pos.y, z: block.pos.z };
-  const posPos: Position3D = { x: block.pos.x + 2, y: block.pos.y, z: block.pos.z };
-  const neg = blocks.get(posKey(negPos));
-  const pos = blocks.get(posKey(posPos));
+  if (!isFreeBuildPipeSpec(t)) return null;
+  const openAxis = t.openAxis;
+  const negCoords: [number, number, number] = [block.pos.x, block.pos.y, block.pos.z];
+  const posCoords: [number, number, number] = [block.pos.x, block.pos.y, block.pos.z];
+  negCoords[openAxis] -= 1;
+  posCoords[openAxis] += 2;
+  const neg = blocks.get(posKey({ x: negCoords[0], y: negCoords[1], z: negCoords[2] }));
+  const pos = blocks.get(posKey({ x: posCoords[0], y: posCoords[1], z: posCoords[2] }));
   if (!neg || !pos) return null;
-  if (neg.type !== "XZZ" || pos.type !== "XZZ") return null;
-  return [["Z", "Z", "Z", "Z"]];
+  const isCube = (bt: BlockType): bt is CubeType =>
+    typeof bt === "string" && (CUBE_TYPES as readonly string[]).includes(bt);
+  if (!isCube(neg.type) || !isCube(pos.type)) return null;
+  const negType: CubeType = neg.type;
+  const posType: CubeType = pos.type;
+  // Map ca0 / ca1 (Three.js closed-axis indices, ascending) back to TQEC axis
+  // indices so we can read cube basis chars at the right positions in the type string.
+  const threeOpen = TQEC_TO_THREE_AXIS[openAxis];
+  const threeClosed = ([0, 1, 2] as const).filter((a) => a !== threeOpen);
+  const tqecCa0 = THREE_TO_TQEC_AXIS[threeClosed[0]];
+  const tqecCa1 = THREE_TO_TQEC_AXIS[threeClosed[1]];
+  const fcFor = (tqecAxis: number): FaceConfig => {
+    const below = negType[tqecAxis] as "X" | "Z";
+    const above = posType[tqecAxis] as "X" | "Z";
+    if (below === above) return below;
+    return below === "X" ? "XZ" : "ZX";
+  };
+  const fc0 = fcFor(tqecCa0);
+  const fc1 = fcFor(tqecCa1);
+  return {
+    faces: [[fc0, fc0, fc1, fc1]],
+    negType,
+    posType,
+    openAxis,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- Replaces the XZZ-XZZ-only `validFBPipeVariantsXZZXAxis` with a general `validFBPipeVariantsForCubePair` that derives the single valid FB face tuple from the touching-faces rule for any cube pair flanking the pipe along its open axis (X, Y, or Z).
- Wires `FreeBuildPipeVariantsPanel` to the new helper and labels the section dynamically (e.g. "Valid for ZXX–XZZ in X" / "XZZ–XZZ in Z").
- Replaces the two specific test blocks with one general suite covering X/Y/Z axes, asymmetric cube pairs (e.g. XZZ–ZXZ along X → `[Z, Z, ZX, ZX]`), reversed orderings, and the null cases (missing neighbours, Y blocks, FB-pipe neighbours, non-FB inputs).

## Test plan
- [x] `npm test` (459/459 pass)
- [x] `node_modules/typescript/bin/tsc -b` clean
- [ ] Manual: place any two TQEC cubes along X/Y/Z, drop a free-build pipe between them, confirm the variants panel highlights the single valid face tuple under a label naming the cube pair and axis.

🧙 Built with [WOZCODE](https://wozcode.com)