### PR TITLE
feat: ZX panel tolerates free-build pipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ gui/dist/
 
 # Security reports
 .gstack/
+
+# Claude Code harness state
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Drop color-mismatched ("free-build") pipes from the `/api/zx` payload client-side so TQEC validation no longer fails on the whole diagram.
- Surface a small italic notice in the ZX panel with the excluded count when any pipes were filtered.
- Add `filterFreeBuildPipes` helper + 4 unit tests in `gui/src/utils/zx.test.ts`.

This is the first chip toward making free-build pipes participate in analyze features — Verify and Flows are intentionally still strict.

## Test plan
- [x] `npx vitest run` (384/384 pass)
- [x] `npx tsc --noEmit -p tsconfig.app.json` (clean)
- [ ] Manual: enable "Ignore color rules", place a cube–pipe–cube line plus one mismatched pipe, open Analyze → ZX. Expect the graph to render for the valid subset with the excluded-pipes notice.

🧙 Built with [WOZCODE](https://wozcode.com)