### PR TITLE
feat: make free-build pipes available in non-free-build mode

### DIFF
--- a/gui/src/components/BlockInstances.logic.ts
+++ b/gui/src/components/BlockInstances.logic.ts
@@ -15,6 +15,7 @@ import {
   hasCubeColorConflict,
   hasPipeColorConflict,
   hasYCubePipeAxisConflict,
+  isFreeBuildPipeSpec,
   isPipeType,
   isValidPipePos,
   isValidPos,
@@ -113,6 +114,7 @@ function classifyTarget(
     }
     if (
       !isPipeType(type) &&
+      !isFreeBuildPipeSpec(type) &&
       type !== "Y" &&
       hasCubeColorConflict(type as CubeType, pos, state.blocks)
     ) {

--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -10,6 +10,7 @@ import {
   hasCubeColorConflict,
   hasPipeColorConflict,
   hasYCubePipeAxisConflict,
+  isFreeBuildPipeSpec,
   isValidPos,
   isPipeType,
   pipeAxisFromPos,
@@ -131,7 +132,7 @@ export function GridPlane() {
       setHoveredGridPos(null);
     } else if (!store.freeBuild && isPipeType(blockType) && hasPipeColorConflict(blockType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Pipe colors don't match the adjacent cube", isReplace);
-    } else if (!store.freeBuild && !isPipeType(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
+    } else if (!store.freeBuild && !isPipeType(blockType) && !isFreeBuildPipeSpec(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Cube colors don't match the adjacent pipe", isReplace);
     } else if (!store.freeBuild && hasYCubePipeAxisConflict(blockType, pos, store.blocks)) {
       setHoveredGridPos(pos, blockType, true, "Y cube cannot be next to an X-open or Y-open pipe", isReplace);

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -747,40 +747,35 @@ export function Toolbar({
         </div>
       </div>
 
-      {/* Free Build group — only visible when freeBuild is enabled.
-         Single generic Free Pipe; the per-face variant is picked from the
-         side panel that opens after placement. */}
-      {freeBuild && (
-        <>
-          <div style={{ width: 1, background: "#ddd" }} />
-          <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
-            <span style={groupLabelStyle}>Free Build</span>
-            <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
-              {FB_PRESETS.map((preset) => (
-                <button
-                  key={preset.id}
-                  onPointerDown={() => {
-                    if (mode !== "edit") return;
-                    setFBPreset(preset);
-                    setPaletteDragging(true);
-                  }}
-                  onClick={() => {
-                    setFBPreset(preset);
-                  }}
-                  title="Free-build pipe — drop to place, then pick a color/swap variant from the side panel"
-                  style={blockBtnStyle(
-                    mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
-                    false,
-                  )}
-                >
-                  {preset.label}
-                  <div style={previewWrapStyle}>{previewImg(preset.id)}</div>
-                </button>
-              ))}
-            </div>
-          </div>
-        </>
-      )}
+      {/* Free Build group — single generic Free Pipe; the per-face variant
+         is picked from the side panel that opens after placement. */}
+      <div style={{ width: 1, background: "#ddd" }} />
+      <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
+        <span style={groupLabelStyle}>Free Build</span>
+        <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
+          {FB_PRESETS.map((preset) => (
+            <button
+              key={preset.id}
+              onPointerDown={() => {
+                if (mode !== "edit") return;
+                setFBPreset(preset);
+                setPaletteDragging(true);
+              }}
+              onClick={() => {
+                setFBPreset(preset);
+              }}
+              title="Free-build pipe — drop to place, then pick a color/swap variant from the side panel"
+              style={blockBtnStyle(
+                mode === "edit" && armedTool === "pipe" && fbPreset?.id === preset.id,
+                false,
+              )}
+            >
+              {preset.label}
+              <div style={previewWrapStyle}>{previewImg(preset.id)}</div>
+            </button>
+          ))}
+        </div>
+      </div>
 
       {/* Position display */}
       <div style={{ width: 1, background: "#ddd" }} />
@@ -1674,7 +1669,7 @@ function SettingsMenu({
             <span>
               Ignore color rules
               <div style={{ fontSize: 10, color: "#888", whiteSpace: "nowrap" }}>
-                (“Free Build” — skips color-matching checks)
+                (relaxes cube/pipe color-matching checks)
               </div>
             </span>
           </label>

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -42,7 +42,7 @@ import {
   PIPE_VARIANTS,
   VARIANT_AXIS_MAP,
   PIPE_TYPE_TO_VARIANT,
-  validFBPipeVariantsXZZXAxis,
+  validFBPipeVariantsForCubePair,
   toggleHadamard,
   swapPipeVariant,
   traversedPipeKey,
@@ -852,11 +852,11 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (target !== undefined) return;
         set((s) => {
           const fb = pipeBlock.type as FreeBuildPipeSpec;
-          const valid = validFBPipeVariantsXZZXAxis(pipeBlock, s.blocks);
+          const valid = validFBPipeVariantsForCubePair(pipeBlock, s.blocks);
           const curKey = fb.faces.join("|");
           let cycle: Array<[FaceConfig, FaceConfig, FaceConfig, FaceConfig]>;
           if (valid) {
-            cycle = valid.map((v) => [...v] as [FaceConfig, FaceConfig, FaceConfig, FaceConfig]);
+            cycle = valid.faces.map((v) => [...v] as [FaceConfig, FaceConfig, FaceConfig, FaceConfig]);
             if (!cycle.some((v) => v.join("|") === curKey)) cycle.unshift([...fb.faces]);
           } else {
             cycle = [];
@@ -1209,8 +1209,6 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         return state;
       }
       if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex, existing ? key : undefined)) return state;
-      // Free-build pieces must only be placed when Free Build is on.
-      if (isFreeBuildPipeSpec(blockType) && !store.freeBuild) return state;
       if (!store.freeBuild) {
         if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
         if (!isPipeType(blockType) && !isFreeBuildPipeSpec(blockType) && blockType !== "Y" && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
@@ -2421,7 +2419,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
             if (hasPipeColorConflict(type, pos, proposed)) {
               return { hoveredInvalidReason: flipBlocked };
             }
-          } else if (type !== "Y") {
+          } else if (!isFreeBuildPipeSpec(type) && type !== "Y") {
             if (hasCubeColorConflict(type as CubeType, pos, proposed)) {
               return { hoveredInvalidReason: flipBlocked };
             }
@@ -2688,7 +2686,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const t = e.newBlock.type;
           const fails =
             (isPipeType(t) && hasPipeColorConflict(t, e.newBlock.pos, blocks)) ||
-            (!isPipeType(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, e.newBlock.pos, blocks)) ||
+            (!isPipeType(t) && !isFreeBuildPipeSpec(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, e.newBlock.pos, blocks)) ||
             hasYCubePipeAxisConflict(t, e.newBlock.pos, blocks);
           if (fails) {
             for (const r of entries) {

--- a/gui/src/utils/dragValidate.ts
+++ b/gui/src/utils/dragValidate.ts
@@ -4,6 +4,7 @@ import {
   hasCubeColorConflict,
   hasPipeColorConflict,
   hasYCubePipeAxisConflict,
+  isFreeBuildPipeSpec,
   isPipeType,
   isValidPos,
   posKey,
@@ -86,7 +87,7 @@ export function isMoveValid(state: MoveValidateState, delta: Position3D): boolea
     for (const nb of newBlocks) {
       const t = nb.type;
       if (isPipeType(t) && hasPipeColorConflict(t, nb.pos, lookup)) return false;
-      if (!isPipeType(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, nb.pos, lookup)) return false;
+      if (!isPipeType(t) && !isFreeBuildPipeSpec(t) && t !== "Y" && hasCubeColorConflict(t as CubeType, nb.pos, lookup)) return false;
       if (hasYCubePipeAxisConflict(t, nb.pos, lookup)) return false;
     }
   }


### PR DESCRIPTION
## Summary
- Drop the `freeBuild` gate around the Free Build toolbar group and the matching rejection in `addBlock` so FB pipes are placeable regardless of the *Ignore color rules* toggle. Add the existing `!isFreeBuildPipeSpec` exclusion (already in `addBlock`'s cube-color check) to the four sibling validation paths (`BlockInstances.logic.ts`, `GridPlane.tsx`, `flipSelection`, `moveSelection` undo, `dragValidate.ts`) so FB specs are no longer cast to `CubeType`.
- Update the toggle subtitle from `("Free Build" — skips color-matching checks)` to `(relaxes cube/pipe color-matching checks)` since FB-pipe access no longer depends on it.
- Fix a pre-existing branch bug from #248: `blockStore` imported the old `validFBPipeVariantsXZZXAxis` (renamed to `validFBPipeVariantsForCubePair` with a new `{ faces, … }` return shape), which was preventing the app from mounting; switch the import and the FB arrow-key cycling call site to read `valid.faces`.

## Test plan
- [x] `npm test` — 459/459 pass
- [x] `tsc -b` — clean
- [ ] Load `http://localhost:<vite>/` in a real browser (headless WebGL fails so I couldn't verify visually) and confirm: Free Pipe button is visible without toggling Ignore color rules; FB-pipe placement works with the toggle off; regular pipe color-conflict rejection still triggers with the toggle off; toggle subtitle reads *(relaxes cube/pipe color-matching checks)*.

🧙 Built with [WOZCODE](https://wozcode.com)