### PR TITLE
feat: skip color-mismatched free-build pipes in ZX analysis

### DIFF
--- a/gui/src/components/GhostBlock.tsx
+++ b/gui/src/components/GhostBlock.tsx
@@ -218,7 +218,7 @@ function GhostBlockInner() {
               </lineSegments>
             )}
             {showFoldOutCube && (
-              <FoldOutCubeFaces blockType={activeType as string} topAxis={foldTopAxis} />
+              <FoldOutCubeFaces blockType={activeType} topAxis={foldTopAxis} />
             )}
           </group>
         )}

--- a/gui/src/components/ZXPanel.tsx
+++ b/gui/src/components/ZXPanel.tsx
@@ -358,6 +358,7 @@ export function ZXPanel({
     result && result.ok
       ? `${result.vertices.length} spider${result.vertices.length === 1 ? "" : "s"}, ${result.edges.length} edge${result.edges.length === 1 ? "" : "s"}`
       : null;
+  const excludedPipes = result?.excludedFreeBuildPipes ?? 0;
 
   return (
     <div
@@ -506,6 +507,20 @@ export function ZXPanel({
             <span style={{ color: "#666", marginLeft: "auto" }}>{stats}</span>
           )}
         </div>
+
+        {excludedPipes > 0 && (
+          <div
+            style={{
+              color: "#666",
+              fontStyle: "italic",
+              marginBottom: 8,
+              fontSize: 11,
+            }}
+            title="Pipes whose face colors don't match their adjacent cubes are not yet supported by TQEC analysis."
+          >
+            {excludedPipes} free-build pipe{excludedPipes === 1 ? "" : "s"} excluded from analysis (color mismatch with adjacent cubes).
+          </div>
+        )}
 
         {loading && !result && (
           <div style={{ color: "#888", padding: "24px 0", textAlign: "center" }}>

--- a/gui/src/utils/zx.test.ts
+++ b/gui/src/utils/zx.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { Block, BlockType, PipeType } from "../types";
+import { filterFreeBuildPipes } from "./zx";
+
+function makeBlocks(entries: Array<{ x: number; y: number; z: number; type: BlockType }>) {
+  const m = new Map<string, Block>();
+  for (const e of entries) {
+    m.set(`${e.x},${e.y},${e.z}`, { pos: { x: e.x, y: e.y, z: e.z }, type: e.type });
+  }
+  return m;
+}
+
+describe("filterFreeBuildPipes", () => {
+  it("keeps a fully color-consistent cube–pipe–cube line intact", () => {
+    // OXZ pipe (axis 1='X', axis 2='Z'); ZXZ cubes both ends agree.
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "ZXZ" as BlockType },
+      { x: 1, y: 0, z: 0, type: "OXZ" as BlockType },
+      { x: 3, y: 0, z: 0, type: "ZXZ" as BlockType },
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(0);
+    expect(kept).toHaveLength(3);
+  });
+
+  it("drops a pipe whose colors disagree with adjacent cubes", () => {
+    // OZX pipe needs axis 1='Z', axis 2='X'; cube XZZ has axis 2='Z' → mismatch.
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "XZZ" as BlockType },
+      { x: 1, y: 0, z: 0, type: "OZX" as PipeType as BlockType },
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(1);
+    expect(kept.map((b) => b.type)).toEqual(["XZZ"]);
+  });
+
+  it("only drops the mismatched pipe, keeps a valid sibling pipe", () => {
+    // Valid cube/pipe along +X and a separate mismatched pipe attached to a
+    // different cube along +Y.
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "ZXZ" as BlockType },
+      { x: 1, y: 0, z: 0, type: "OXZ" as BlockType }, // valid
+      { x: 3, y: 0, z: 0, type: "ZXZ" as BlockType },
+      { x: 9, y: 0, z: 0, type: "XZZ" as BlockType },
+      { x: 9, y: 1, z: 0, type: "ZOX" as PipeType as BlockType }, // mismatch
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(1);
+    expect(kept).toHaveLength(4);
+    expect(kept.find((b) => b.pos.x === 9 && b.pos.y === 1)).toBeUndefined();
+  });
+
+  it("never excludes cubes", () => {
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "XZZ" as BlockType },
+      { x: 3, y: 0, z: 0, type: "ZXZ" as BlockType },
+    ]);
+    const { kept, excluded } = filterFreeBuildPipes(blocks);
+    expect(excluded).toBe(0);
+    expect(kept).toHaveLength(2);
+  });
+});

--- a/gui/src/utils/zx.ts
+++ b/gui/src/utils/zx.ts
@@ -1,5 +1,5 @@
+import { hasPipeColorConflict, isFreeBuildBlock, isPipeType } from "../types";
 import type { Block, Position3D, PortMeta } from "../types";
-import { isFreeBuildBlock } from "../types";
 
 export type ZXVertexKind = "Z" | "X" | "H" | "BOUNDARY";
 
@@ -50,11 +50,37 @@ export interface ZXResult {
   circuit: ZXCircuit | null;
   circuit_error: string | null;
   error: string | null;
+  /** Pipes whose colors don't agree with adjacent cubes — silently dropped
+   *  from the /api/zx payload so TQEC validation can still succeed on the
+   *  rest of the diagram. Zero when none were dropped. */
+  excludedFreeBuildPipes: number;
 }
 
 function posFromKey(key: string): Position3D {
   const [x, y, z] = key.split(",").map(Number);
   return { x, y, z };
+}
+
+/**
+ * Drop pipes that disagree with adjacent cube colors. These are "free build"
+ * pipes — the rest of the diagram is still TQEC-valid, so we ship the subset
+ * to /api/zx and report how many we excluded so the panel can surface a
+ * notice.
+ */
+export function filterFreeBuildPipes(blocks: Map<string, Block>): {
+  kept: Block[];
+  excluded: number;
+} {
+  const kept: Block[] = [];
+  let excluded = 0;
+  for (const b of blocks.values()) {
+    if (isPipeType(b.type) && hasPipeColorConflict(b.type, b.pos, blocks)) {
+      excluded++;
+      continue;
+    }
+    kept.push(b);
+  }
+  return { kept, excluded };
 }
 
 export async function computeZX(
@@ -63,14 +89,19 @@ export async function computeZX(
   simplify: boolean,
   extract: boolean = false,
 ): Promise<ZXResult> {
-  // Defense-in-depth: drop free-build (non-TQEC) blocks before sending to
-  // the backend. ZX requires a TQEC scene; FB pieces don't have a ZX semantic.
-  const blocksPayload = Array.from(blocks.values())
-    .filter((b) => !isFreeBuildBlock(b))
-    .map((b) => ({
-      pos: [b.pos.x, b.pos.y, b.pos.z],
-      type: b.type as string,
-    }));
+  // Two filters compose. First drop free-build (non-TQEC) blocks — they have
+  // no ZX semantic and the backend can't model them. Then run the color-
+  // conflict filter on the TQEC remainder to catch mismatched TQEC pipes
+  // (e.g. placed under "Ignore color rules"); the count surfaces in the panel.
+  const tqecOnly = new Map<string, Block>();
+  for (const [k, b] of blocks) {
+    if (!isFreeBuildBlock(b)) tqecOnly.set(k, b);
+  }
+  const { kept, excluded } = filterFreeBuildPipes(tqecOnly);
+  const blocksPayload = kept.map((b) => ({
+    pos: [b.pos.x, b.pos.y, b.pos.z],
+    type: b.type as string,
+  }));
   const portLabels = Array.from(portMeta.entries()).map(([key, meta]) => {
     const p = posFromKey(key);
     return { pos: [p.x, p.y, p.z], label: meta.label, rank: meta.rank ?? null };
@@ -102,9 +133,11 @@ export async function computeZX(
         circuit: null,
         circuit_error: null,
         error: `Server error: ${res.status}`,
+        excludedFreeBuildPipes: excluded,
       };
     }
-    return (await res.json()) as ZXResult;
+    const json = (await res.json()) as Omit<ZXResult, "excludedFreeBuildPipes">;
+    return { ...json, excludedFreeBuildPipes: excluded };
   } catch {
     return {
       ok: false,
@@ -115,6 +148,7 @@ export async function computeZX(
       circuit: null,
       circuit_error: null,
       error: "ZX server unavailable. Start with: npm run dev:backend",
+      excludedFreeBuildPipes: excluded,
     };
   }
 }


### PR DESCRIPTION
## Summary

- Slice 1 of free-build pipe support for ZX analysis: pipes whose colors don't match adjacent cubes are filtered out of the `/api/zx` payload, and the ZX panel surfaces a small italic notice with the count so TQEC validation still runs on the rest of the diagram.
- New unit tests in `gui/src/utils/zx.test.ts` cover the filter (4 cases — valid line, single mismatch, mixed valid + invalid, cubes-only).
- Because `peter-janderks/free-build-pipes` is significantly behind current `dev`, this PR also brings the target branch up to date with everything that's landed on `dev` since: drag-shadow + ground-shadow + projection-line previews, scene sharing via URL hash, user-defined port ordering, the dev-environment auto-deploy workflow, an expanded toolbar/ports table, and several test/infra additions.

## Test plan

- [x] `npm test` — 384/384 vitest tests pass
- [x] `npx tsc --noEmit -p tsconfig.app.json` — clean
- [ ] Manual: enable "Ignore color rules", place a cube–pipe–cube line with one color-mismatched pipe, open ZX panel — confirm the panel renders the ZX graph for the valid subset and shows the italic "N free-build pipe(s) excluded from analysis" notice.

🧙 Built with [WOZCODE](https://wozcode.com)