### PR TITLE
Free-build select tool: offer all block types when replacing

### DIFF
--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -230,6 +230,9 @@ export function Toolbar({
     } else {
       return null;
     }
+    if (s.freeBuild) {
+      return `${currentType};1;${[...CUBE_TYPES, "Y"].join(",")}`;
+    }
     const coords: [number, number, number] = [pos.x, pos.y, pos.z];
     let pipeCount = 0;
     for (let axis = 0; axis < 3; axis++) {
@@ -271,6 +274,9 @@ export function Toolbar({
     const pipeBlock = s.blocks.get(k);
     if (!pipeBlock || !isPipeType(pipeBlock.type)) return null;
     const currentVariant = PIPE_TYPE_TO_VARIANT[pipeBlock.type as PipeType];
+    if (s.freeBuild) {
+      return `${currentVariant};${PIPE_VARIANTS.join(",")}`;
+    }
     const base = (pipeBlock.type as string).replace("H", "");
     const openAxis = base.indexOf("O") as 0 | 1 | 2;
     const pipeCoords: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1210,6 +1210,83 @@ describe("blockStore", () => {
     });
   });
 
+  describe("cycleSelectedType — freeBuild bypasses validation", () => {
+    it("free-build pipe cycle accepts a variant that color rules would reject", () => {
+      // XZZ–XZ–XZZ on the z-axis is a valid pair. A Hadamard variant (XZH → XZOH)
+      // flips the +z end's closed-axis basis, so it conflicts with two XZZ cubes.
+      useBlockStore.setState({ cubeType: "XZZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 3 });
+      useBlockStore.setState({ pipeVariant: "XZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 1 });
+      expect(useBlockStore.getState().blocks.get("0,0,1")?.type).toBe("XZO");
+
+      useBlockStore.setState({
+        armedTool: "pointer",
+        selectedKeys: new Set(["0,0,1"]),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "pipe", variant: "XZH" });
+      expect(useBlockStore.getState().blocks.get("0,0,1")?.type).toBe("XZO");
+
+      useBlockStore.setState({ freeBuild: true });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "pipe", variant: "XZH" });
+      expect(useBlockStore.getState().blocks.get("0,0,1")?.type).toBe("XZOH");
+    });
+
+    it("free-build cube cycle accepts a CUBE_TYPE that color rules would reject", () => {
+      // OXZ pipe at (1,0,0) constrains the cube at (0,0,0) to Y=X, Z=Z (only
+      // ZXZ and XXZ pass). XZX has Y=Z and is rejected without freeBuild.
+      useBlockStore.setState({ cubeType: "ZXZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "XZ" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXZ");
+
+      useBlockStore.setState({
+        armedTool: "pointer",
+        selectedKeys: new Set(["0,0,0"]),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZX" });
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXZ");
+
+      useBlockStore.setState({ freeBuild: true });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZX" });
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZX");
+    });
+
+    it("free-build cube cycle includes the port option even with two attached pipes", () => {
+      // ZXZ–XZ–ZXZ–XZ–ZXZ along x. The middle cube at (3,0,0) has two attached
+      // X-pipes, so portAllowed = (pipeCount < 2) = false without freeBuild.
+      useBlockStore.setState({ cubeType: "ZXZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 6, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "XZ" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 4, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.size).toBe(5);
+
+      useBlockStore.setState({
+        armedTool: "pointer",
+        selectedKeys: new Set(["3,0,0"]),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "port" });
+      expect(useBlockStore.getState().blocks.has("3,0,0")).toBe(true);
+      expect(useBlockStore.getState().portPositions.has("3,0,0")).toBe(false);
+
+      useBlockStore.setState({ freeBuild: true });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "port" });
+      const s = useBlockStore.getState();
+      expect(s.blocks.has("3,0,0")).toBe(false);
+      expect(s.portPositions.has("3,0,0")).toBe(true);
+      expect(s.selectedKeys.has("3,0,0")).toBe(false);
+      expect(s.selectedPortPositions.has("3,0,0")).toBe(true);
+    });
+  });
+
   describe("buildMove from an empty origin", () => {
     it("leaves the origin slot empty (no cube placed at the start position)", () => {
       useBlockStore.setState({

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -816,26 +816,30 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const currentVariant = PIPE_TYPE_TO_VARIANT[oldType];
 
           const validVariants: PipeVariant[] = [];
-          for (const v of PIPE_VARIANTS) {
-            const candidate = VARIANT_AXIS_MAP[v][openAxis];
-            const tmp = new Map(s.blocks);
-            tmp.set(pipeKey, { pos: pipeBlock.pos, type: candidate });
-            let ok = true;
-            for (const offset of [-1, 2]) {
-              const nc: [number, number, number] = [pipeCoords[0], pipeCoords[1], pipeCoords[2]];
-              nc[openAxis] += offset;
-              const nKey = posKey({ x: nc[0], y: nc[1], z: nc[2] });
-              const neighbor = tmp.get(nKey);
-              if (!neighbor || isPipeType(neighbor.type) || neighbor.type === "Y") continue;
-              const opts = determineCubeOptions(neighbor.pos, tmp);
-              const currentType = neighbor.type as CubeType;
-              if (opts.determined) {
-                if (opts.type !== currentType) { ok = false; break; }
-              } else if (!opts.options.includes(currentType)) {
-                ok = false; break;
+          if (s.freeBuild) {
+            for (const v of PIPE_VARIANTS) validVariants.push(v);
+          } else {
+            for (const v of PIPE_VARIANTS) {
+              const candidate = VARIANT_AXIS_MAP[v][openAxis];
+              const tmp = new Map(s.blocks);
+              tmp.set(pipeKey, { pos: pipeBlock.pos, type: candidate });
+              let ok = true;
+              for (const offset of [-1, 2]) {
+                const nc: [number, number, number] = [pipeCoords[0], pipeCoords[1], pipeCoords[2]];
+                nc[openAxis] += offset;
+                const nKey = posKey({ x: nc[0], y: nc[1], z: nc[2] });
+                const neighbor = tmp.get(nKey);
+                if (!neighbor || isPipeType(neighbor.type) || neighbor.type === "Y") continue;
+                const opts = determineCubeOptions(neighbor.pos, tmp);
+                const currentType = neighbor.type as CubeType;
+                if (opts.determined) {
+                  if (opts.type !== currentType) { ok = false; break; }
+                } else if (!opts.options.includes(currentType)) {
+                  ok = false; break;
+                }
               }
+              if (ok) validVariants.push(v);
             }
-            if (ok) validVariants.push(v);
           }
 
           const cycle: PipeVariant[] = [];
@@ -918,11 +922,18 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           }
         }
       }
-      const result = determineCubeOptions(pos, s.blocks);
-      const cubeOpts = new Set<CubeType | "Y">(result.determined ? [result.type] : result.options);
-      // Y is a leaf: only valid with at most one attached (Z-open) pipe.
-      if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", pos, s.blocks)) cubeOpts.add("Y");
-      const portAllowed = pipeCount < 2;
+      let cubeOpts: Set<CubeType | "Y">;
+      let portAllowed: boolean;
+      if (s.freeBuild) {
+        cubeOpts = new Set<CubeType | "Y">([...CUBE_TYPES, "Y"]);
+        portAllowed = true;
+      } else {
+        const result = determineCubeOptions(pos, s.blocks);
+        cubeOpts = new Set<CubeType | "Y">(result.determined ? [result.type] : result.options);
+        // Y is a leaf: only valid with at most one attached (Z-open) pipe.
+        if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", pos, s.blocks)) cubeOpts.add("Y");
+        portAllowed = pipeCount < 2;
+      }
 
       type Opt = { kind: "port" } | { kind: "cube"; type: CubeType | "Y" };
       const cycle: Opt[] = [];


### PR DESCRIPTION
## Summary
- In free-build mode (Settings → "Ignore color rules"), the pointer-tool replacement palette now exposes every cube type, Y, and pipe variant for a selected block, mirroring how build-mode placement already behaves.
- Implementation short-circuits the validity selectors in `Toolbar.tsx` and the cube/pipe branches of `cycleSelectedType` in `blockStore.ts` when `freeBuild` is true.
- Adds three `cycleSelectedType` unit tests covering pipe-variant override, cube-type override, and port conversion at a 2-attached-pipe position.

## Test plan
- [x] `npm test` — 408/408 pass (3 new in `blockStore.test.ts`)
- [x] `npm run build` — typecheck + Vite build clean
- [ ] Manual: enable "Ignore color rules", select a cube/pipe, confirm all toolbar buttons are clickable and replacement applies

🧙 Built with [WOZCODE](https://wozcode.com)