### PR TITLE
feat: add Y-twist pipes (free-build only) — H band replaced by magenta Y-defect ring

### DIFF
--- a/gui/src/components/PreviewRenderer.tsx
+++ b/gui/src/components/PreviewRenderer.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import * as THREE from "three";
 import {
   CUBE_TYPES,
+  PIPE_VARIANTS,
   VARIANT_AXIS_MAP,
   createBlockGeometry,
   createBlockEdges,
@@ -9,7 +10,7 @@ import {
   blockThreeSize,
   Y_DEFECT_HEX,
 } from "../types";
-import type { BlockType, PipeVariant, ViewMode } from "../types";
+import type { BlockType, ViewMode } from "../types";
 import { useBlockStore } from "../stores/blockStore";
 import {
   FOLD_ANGLE,
@@ -34,7 +35,7 @@ const PREVIEW_TYPES: { key: string; blockType: BlockType | null; isoZBlockType?:
   { key: "Port", blockType: null },
   ...CUBE_TYPES.map((ct) => ({ key: ct, blockType: ct as BlockType })),
   { key: "Y", blockType: "Y" as BlockType },
-  ...(["ZX", "XZ", "ZXH", "XZH"] as PipeVariant[]).map((v) => ({
+  ...PIPE_VARIANTS.map((v) => ({
     key: v,
     blockType: VARIANT_AXIS_MAP[v][2] as BlockType,
     isoZBlockType: VARIANT_AXIS_MAP[v][1] as BlockType,

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useBlockStore, type BuildStep } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { useKeybindStore, type Mode as KeybindMode, type NavStyle } from "../stores/keybindStore";
-import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
+import { CUBE_TYPES, FREE_BUILD_PIPE_VARIANTS, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
@@ -701,7 +701,7 @@ export function Toolbar({
       <div style={{ display: "flex", flexDirection: "column", gap: "4px" }}>
         <span style={groupLabelStyle}>Pipes</span>
         <div style={{ display: "flex", gap: "4px", flex: 1, alignItems: "stretch" }}>
-          {PIPE_VARIANTS.map((v) => (
+          {PIPE_VARIANTS.filter((v) => freeBuild || !FREE_BUILD_PIPE_VARIANTS.has(v)).map((v) => (
             <button
               key={v}
               onPointerDown={() => {
@@ -721,6 +721,11 @@ export function Toolbar({
                 }
                 setPipeVariant(v);
               }}
+              title={
+                FREE_BUILD_PIPE_VARIANTS.has(v)
+                  ? "Y-twist pipe (free-build only): faces flip colour at the band midline; magenta Y-defect ring shows when 'Highlight Y defects' is on."
+                  : undefined
+              }
               style={blockBtnStyle(
                 (mode === "edit" && armedTool === "pipe" && pipeVariant === v) ||
                 (mode === "build" && buildActivePipeVariant === v) ||

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1208,6 +1208,73 @@ describe("blockStore", () => {
       expect(st.armedTool).toBe("cube");
       expect(st.cubeType).toBe("XZZ");
     });
+
+    it("includes the Y-twist pipe variants in the cycle when free-build is on", () => {
+      useBlockStore.setState({ freeBuild: true, armedTool: "pipe", pipeVariant: "XZH" });
+      // After XZH (last non-Y pipe), the next two cycles should land on ZXY then XZY.
+      useBlockStore.getState().cycleArmedType(1);
+      expect(useBlockStore.getState().pipeVariant).toBe("ZXY");
+      useBlockStore.getState().cycleArmedType(1);
+      expect(useBlockStore.getState().pipeVariant).toBe("XZY");
+    });
+
+    it("disarms a Y-twist variant when free-build is toggled off", () => {
+      useBlockStore.setState({ freeBuild: true, armedTool: "pipe", pipeVariant: "ZXY" });
+      useBlockStore.getState().toggleFreeBuild();
+      const st = useBlockStore.getState();
+      expect(st.freeBuild).toBe(false);
+      expect(st.armedTool).toBe("pointer");
+      expect(st.pipeVariant).toBe(null);
+    });
+  });
+
+  describe("Y-twist pipe placement", () => {
+    it("rejects placing a Y-twist pipe outside free-build", () => {
+      useBlockStore.setState({ freeBuild: false, armedTool: "pipe", pipeVariant: "ZXY" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.has("1,0,0")).toBe(false);
+    });
+
+    it("accepts a Y-twist pipe placement when free-build is on", () => {
+      useBlockStore.setState({ freeBuild: true, armedTool: "pipe", pipeVariant: "ZXY" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      const block = useBlockStore.getState().blocks.get("1,0,0");
+      expect(block?.type).toBe("OZXY");
+    });
+
+    it("cyclePipe (build-mode R-key) skips Y-twist variants outside free-build", () => {
+      // Cursor at an empty port, pipe to its right, second endpoint also empty.
+      // Both ends ambiguous → cyclePipe always runs; no neighbour cubes →
+      // every candidate passes validation. Without the freeBuild filter, the
+      // R-key cycle would land on a Y-twist variant.
+      useBlockStore.setState({
+        mode: "build",
+        buildCursor: { x: 0, y: 0, z: 0 },
+        freeBuild: false,
+        blocks: new Map([
+          ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: "OZX" }],
+        ]),
+      });
+      for (let i = 0; i < 8; i++) {
+        useBlockStore.getState().cyclePipe();
+        const t = useBlockStore.getState().blocks.get("1,0,0")!.type;
+        expect(t.endsWith("Y")).toBe(false);
+      }
+    });
+
+    it("cyclePipe with explicit Y-twist target is rejected outside free-build", () => {
+      useBlockStore.setState({
+        mode: "build",
+        buildCursor: { x: 0, y: 0, z: 0 },
+        freeBuild: false,
+        blocks: new Map([
+          ["1,0,0", { pos: { x: 1, y: 0, z: 0 }, type: "OZX" }],
+        ]),
+      });
+      useBlockStore.getState().cyclePipe("ZXY");
+      // Type unchanged because ZXY isn't in the cycle when freeBuild is off.
+      expect(useBlockStore.getState().blocks.get("1,0,0")!.type).toBe("OZX");
+    });
   });
 
   describe("buildMove from an empty origin", () => {

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -16,6 +16,8 @@ import {
   hasYCubePipeAxisConflict,
   isPipeType,
   isSlabType,
+  isYTwistPipe,
+  FREE_BUILD_PIPE_VARIANTS,
   isValidBlockPos,
   isValidPos,
   resolvePipeType,
@@ -52,7 +54,7 @@ const MAX_HISTORY = 100;
 
 /** Canonical X-open PipeType for each variant, used as cubeType fallback. */
 const PIPE_VARIANT_CANONICAL: Record<PipeVariant, BlockType> = {
-  ZX: "OZX", XZ: "OXZ", ZXH: "OZXH", XZH: "OXZH",
+  ZX: "OZX", XZ: "OXZ", ZXH: "OZXH", XZH: "OXZH", ZXY: "OZXY", XZY: "OXZY",
 };
 
 // ---------------------------------------------------------------------------
@@ -659,6 +661,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     if (!next && s.armedTool === "slab") {
       return { freeBuild: next, armedTool: "pointer" as ArmedTool };
     }
+    // Disarm Y-twist pipe variants when leaving free-build (toolbar buttons hide).
+    if (!next && s.armedTool === "pipe" && s.pipeVariant != null && FREE_BUILD_PIPE_VARIANTS.has(s.pipeVariant)) {
+      return { freeBuild: next, armedTool: "pointer" as ArmedTool, pipeVariant: null };
+    }
     return { freeBuild: next };
   }),
 
@@ -798,11 +804,19 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     let next = cur === -1
       ? (dir === 1 ? 0 : N - 1)
       : (((cur + dir) % N) + N) % N;
-    // Skip slab when not in free-build mode — it's the only kind that's
-    // gated, so a single re-step in the same direction always lands on a
-    // legal placeable.
-    if (!s.freeBuild && PLACEABLE_ORDER[next].kind === "slab") {
-      next = (((next + dir) % N) + N) % N;
+    // Skip free-build-only placeables (slab, Y-twist pipe variants) when not in
+    // free-build mode. A bounded re-step loop lands on a legal placeable.
+    const isGated = (idx: number) => {
+      const p = PLACEABLE_ORDER[idx];
+      if (p.kind === "slab") return true;
+      if (p.kind === "pipe" && FREE_BUILD_PIPE_VARIANTS.has(p.variant)) return true;
+      return false;
+    };
+    if (!s.freeBuild) {
+      let guard = N;
+      while (isGated(next) && guard-- > 0) {
+        next = (((next + dir) % N) + N) % N;
+      }
     }
     const target = PLACEABLE_ORDER[next];
     if (target.kind === "port") s.setPlacePort(true);
@@ -827,8 +841,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const pipeCoords: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];
           const currentVariant = PIPE_TYPE_TO_VARIANT[oldType];
 
+          // Y-twist variants are free-build only — exclude them from the cycle
+          // when the gate is off so R-key / arrow-key cycling can't land there.
+          const cycleVariants = s.freeBuild
+            ? PIPE_VARIANTS
+            : PIPE_VARIANTS.filter(v => !FREE_BUILD_PIPE_VARIANTS.has(v));
           const validVariants: PipeVariant[] = [];
-          for (const v of PIPE_VARIANTS) {
+          for (const v of cycleVariants) {
             const candidate = VARIANT_AXIS_MAP[v][openAxis];
             const tmp = new Map(s.blocks);
             tmp.set(pipeKey, { pos: pipeBlock.pos, type: candidate });
@@ -851,7 +870,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           }
 
           const cycle: PipeVariant[] = [];
-          for (const v of PIPE_VARIANTS) {
+          for (const v of cycleVariants) {
             if (v === currentVariant || validVariants.includes(v)) cycle.push(v);
           }
           if (cycle.length <= 1) return s;
@@ -1141,8 +1160,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         return state;
       }
       if (hasBlockOverlap(pos, blockType, state.blocks, state.spatialIndex, existing ? key : undefined)) return state;
-      // Slabs are free-build only; reject if the gate is off.
+      // Slabs and Y-twist pipes are free-build only; reject if the gate is off.
       if (isSlabType(blockType) && !store.freeBuild) return state;
+      if (isYTwistPipe(blockType) && !store.freeBuild) return state;
       if (!store.freeBuild) {
         if (isPipeType(blockType) && hasPipeColorConflict(blockType, pos, state.blocks)) return state;
         if (!isPipeType(blockType) && blockType !== "Y" && !isSlabType(blockType) && hasCubeColorConflict(blockType as CubeType, pos, state.blocks)) return state;
@@ -3340,8 +3360,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     const openAxis = oldBase.indexOf("O") as 0 | 1 | 2;
     const pipeCoords: [number, number, number] = [pipeBlock.pos.x, pipeBlock.pos.y, pipeBlock.pos.z];
 
-    // Compute all candidate pipe types for this axis (one per toolbar variant)
-    const allCandidates = PIPE_VARIANTS.map(v => VARIANT_AXIS_MAP[v][openAxis]);
+    // Compute all candidate pipe types for this axis (one per toolbar variant).
+    // Y-twist variants are free-build only — exclude them from the cycle when
+    // the gate is off so the R-key can't land there.
+    const cycleVariants = state.freeBuild
+      ? PIPE_VARIANTS
+      : PIPE_VARIANTS.filter(v => !FREE_BUILD_PIPE_VARIANTS.has(v));
+    const allCandidates = cycleVariants.map(v => VARIANT_AXIS_MAP[v][openAxis]);
 
     // Filter to valid candidates: both neighbor cubes must have valid options
     // In free build mode, all candidates are valid

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, CUBE_TYPES, PIPE_TYPES } from "./index";
+import { blockTqecSize, createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, CUBE_TYPES, PIPE_TYPES } from "./index";
 import type { PipeType, CubeType, PortMeta } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
@@ -491,6 +491,78 @@ describe("createBlockGeometry", () => {
 
     expect((full.getIndex()?.count ?? 0) - (hidden.getIndex()?.count ?? 0)).toBe(6);
   });
+
+  it("Y-twist pipe geometry omits the yellow Hadamard band", () => {
+    // Hadamard walls are split into 3 strips (below band, yellow band, above).
+    // Y-twist walls are split into 2 strips (below midline, above midline) with
+    // the colours flipped, but no yellow band — so no vertex carries H_COLOR.
+    const geo = createBlockGeometry("OZXY");
+    const colors = geo.getAttribute("color").array as Float32Array;
+    // H_COLOR = #ffff65 → r ≈ 1, g ≈ 1, b ≈ 0.396. Look for any vertex with
+    // both red and green channels saturated (the unique signature of yellow).
+    let yellowVerts = 0;
+    for (let i = 0; i < colors.length; i += 3) {
+      if (colors[i] > 0.95 && colors[i + 1] > 0.95) yellowVerts++;
+    }
+    expect(yellowVerts).toBe(0);
+  });
+
+  it("Y-twist pipe walls flip colour at the midline", () => {
+    // OZXY is X-open. Group quads by (face normal, side of open-axis midline)
+    // and confirm each face's "below midline" and "above midline" buckets
+    // carry different colours.
+    const geo = createBlockGeometry("OZXY");
+    const positions = geo.getAttribute("position").array as Float32Array;
+    const normals = geo.getAttribute("normal").array as Float32Array;
+    const colors = geo.getAttribute("color").array as Float32Array;
+    // Open axis in Three.js for OZXY (TQEC X-open) is X (index 0).
+    const buckets = new Map<string, Set<string>>();
+    for (let q = 0; q < positions.length / 12; q++) {
+      const baseV = q * 12;
+      const baseN = q * 12;
+      // Use the centroid of the 4 verts to decide the side of the band.
+      let sumOpen = 0;
+      for (let v = 0; v < 4; v++) sumOpen += positions[baseV + v * 3 + 0];
+      const side = sumOpen / 4 >= 0 ? "above" : "below";
+      // Normal direction names which face this quad belongs to.
+      const nx = Math.round(normals[baseN]);
+      const ny = Math.round(normals[baseN + 1]);
+      const nz = Math.round(normals[baseN + 2]);
+      const face =
+        nx !== 0 ? (nx > 0 ? "+X" : "-X") :
+        ny !== 0 ? (ny > 0 ? "+Y" : "-Y") :
+        nz > 0 ? "+Z" : "-Z";
+      const c = `${colors[baseV].toFixed(2)},${colors[baseV + 1].toFixed(2)},${colors[baseV + 2].toFixed(2)}`;
+      const key = `${face}|${side}`;
+      if (!buckets.has(key)) buckets.set(key, new Set());
+      buckets.get(key)!.add(c);
+    }
+    // Each closed-axis face has both halves; each half has a single colour
+    // and the two halves must differ (colour flip across the band).
+    for (const face of ["+Y", "-Y", "+Z", "-Z"] as const) {
+      const above = buckets.get(`${face}|above`);
+      const below = buckets.get(`${face}|below`);
+      expect(above, `face ${face} above`).toBeDefined();
+      expect(below, `face ${face} below`).toBeDefined();
+      const aboveC = [...above!][0];
+      const belowC = [...below!][0];
+      expect(aboveC).not.toBe(belowC);
+    }
+  });
+});
+
+describe("Y-twist pipe types (free-build only)", () => {
+  it("registers all 6 Y-twist pipe types", () => {
+    for (const t of ["OZXY", "OXZY", "ZOXY", "XOZY", "ZXOY", "XZOY"] as const) {
+      expect(PIPE_TYPES.includes(t)).toBe(true);
+    }
+  });
+
+  it("Y-twist pipes have the same TQEC dimensions as their plain counterparts", () => {
+    expect(blockTqecSize("OZXY")).toEqual(blockTqecSize("OZX"));
+    expect(blockTqecSize("XOZY")).toEqual(blockTqecSize("XOZ"));
+    expect(blockTqecSize("ZXOY")).toEqual(blockTqecSize("ZXO"));
+  });
 });
 
 describe("flipBlockType", () => {
@@ -600,6 +672,27 @@ describe("createYDefectEdges", () => {
     // Sanity: hiding everything yields zero edges.
     const all = FACE_POS_X | FACE_NEG_X | FACE_POS_Y | FACE_NEG_Y | FACE_POS_Z | FACE_NEG_Z;
     expect(edgeCount(createYDefectEdges("XZZ", all))).toBe(0);
+  });
+
+  it("Y-twist pipes emit 4 long edges + 4 ring segments at the band midline", () => {
+    // 4 along the open axis (same as a non-Hadamard pipe of mixed bases) plus
+    // 4 short segments forming a square ring at the band midline (one on each
+    // closed-axis face, marking the colour-flip seam).
+    expect(edgeCount(createYDefectEdges("OZXY"))).toBe(8);
+    expect(edgeCount(createYDefectEdges("XOZY"))).toBe(8);
+    expect(edgeCount(createYDefectEdges("ZXOY"))).toBe(8);
+  });
+
+  it("Y-twist ring segments lie at the open-axis midline", () => {
+    const geo = createYDefectEdges("OZXY"); // X-open in Three.js
+    const arr = geo.getAttribute("position").array as Float32Array;
+    // 4 edges run along Three.js X (the open axis) — non-zero X span on both endpoints.
+    // 4 edges are ring segments at X = 0 — both endpoints at Three.js X ≈ 0.
+    let ringCount = 0;
+    for (let i = 0; i < arr.length; i += 6) {
+      if (Math.abs(arr[i]) < 1e-6 && Math.abs(arr[i + 3]) < 1e-6) ringCount++;
+    }
+    expect(ringCount).toBe(4);
   });
 });
 

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -38,8 +38,19 @@ export function depthToSlice(depth: number): number {
 export const CUBE_TYPES = ["XZZ", "ZXZ", "ZXX", "XXZ", "ZZX", "XZX"] as const;
 export type CubeType = (typeof CUBE_TYPES)[number];
 
-export const PIPE_TYPES = ["OZX", "OXZ", "OZXH", "OXZH", "ZOX", "XOZ", "ZOXH", "XOZH", "ZXO", "XZO", "ZXOH", "XZOH"] as const;
+export const PIPE_TYPES = [
+  "OZX", "OXZ", "OZXH", "OXZH", "OZXY", "OXZY",
+  "ZOX", "XOZ", "ZOXH", "XOZH", "ZOXY", "XOZY",
+  "ZXO", "XZO", "ZXOH", "XZOH", "ZXOY", "XZOY",
+] as const;
 export type PipeType = (typeof PIPE_TYPES)[number];
+
+/** Y-twist pipes are free-build-only: same colour-flip as Hadamard, but the
+ * yellow band is replaced by a magenta Y-defect ring (visible only when the
+ * "Highlight Y defects" toggle is on). They have no TQEC semantics in v1. */
+export function isYTwistPipe(bt: BlockType): bt is PipeType {
+  return typeof bt === "string" && bt.length === 4 && bt.endsWith("Y") && (PIPE_TYPES as readonly string[]).includes(bt);
+}
 
 /** Slab: a free-build-only element sitting in the gap between 4 horizontal pipes
  * forming a square on the XY plane. Renders as two solid horizontal squares at
@@ -66,9 +77,13 @@ export const FACE_BIT_BY_INDEX: ReadonlyArray<number> = [
   FACE_NEG_Z,
 ];
 
-/** Pipe variant: the two non-O face characters (+ optional H). Open axis determined by position. */
-export type PipeVariant = "ZX" | "XZ" | "ZXH" | "XZH";
-export const PIPE_VARIANTS: PipeVariant[] = ["ZX", "XZ", "ZXH", "XZH"];
+/** Pipe variant: the two non-O face characters (+ optional H or Y suffix).
+ * Open axis is determined by position. The Y suffix is free-build-only (Y-twist
+ * pipes whose yellow Hadamard band is replaced by a magenta Y-defect ring). */
+export type PipeVariant = "ZX" | "XZ" | "ZXH" | "XZH" | "ZXY" | "XZY";
+export const PIPE_VARIANTS: PipeVariant[] = ["ZX", "XZ", "ZXH", "XZH", "ZXY", "XZY"];
+/** Variants that are only available when free-build mode is on. */
+export const FREE_BUILD_PIPE_VARIANTS: ReadonlySet<PipeVariant> = new Set(["ZXY", "XZY"]);
 
 /**
  * Toolbar-order list of placeable items (Port + 6 cubes + Y + 4 pipes).
@@ -231,6 +246,9 @@ export const VARIANT_AXIS_MAP: Record<PipeVariant, [PipeType, PipeType, PipeType
   XZ:  ["OXZ",  "XOZ",  "XZO"],
   ZXH: ["OZXH", "XOZH", "ZXOH"],
   XZH: ["OXZH", "ZOXH", "XZOH"],
+  // Y-twist family mirrors the H family for axis ordering. Free-build only.
+  ZXY: ["OZXY", "XOZY", "ZXOY"],
+  XZY: ["OXZY", "ZOXY", "XZOY"],
 };
 
 /** Reverse lookup: concrete PipeType → toolbar PipeVariant. */
@@ -298,9 +316,9 @@ export function snapGroundPosSlab(rawX: number, rawY: number): Position3D {
 export function blockTqecSize(blockType: BlockType): [number, number, number] {
   switch (blockType) {
     case "Y": return [1, 1, 0.5];
-    case "ZXO": case "XZO": case "ZXOH": case "XZOH": return [1, 1, 2];
-    case "ZOX": case "XOZ": case "ZOXH": case "XOZH": return [1, 2, 1];
-    case "OZX": case "OXZ": case "OZXH": case "OXZH": return [2, 1, 1];
+    case "ZXO": case "XZO": case "ZXOH": case "XZOH": case "ZXOY": case "XZOY": return [1, 1, 2];
+    case "ZOX": case "XOZ": case "ZOXH": case "XOZH": case "ZOXY": case "XOZY": return [1, 2, 1];
+    case "OZX": case "OXZ": case "OZXH": case "OXZH": case "OZXY": case "OXZY": return [2, 1, 1];
     // Slab fills the 2×2 inner gap between 4 pipes that form a square,
     // anchored at its lower-left corner (x ≡ 1, y ≡ 1, z ≡ 0 mod 3).
     case SLAB_TYPE: return [2, 2, 1];
@@ -377,24 +395,30 @@ const THREE_TO_TQEC_AXIS = [0, 2, 1] as const;
  * For non-Hadamard pipes: a BoxGeometry with the open-axis face pair removed and
  * closed-axis walls inset by WALL_EPS.
  *
- * For Hadamard pipes: each wall is subdivided into 3 strips (below band, yellow
- * Hadamard band, above band) with the two wall colors swapping above the band.
+ * For colour-flip pipes (Hadamard or Y-twist): each wall is subdivided into
+ * strips and the two wall colours swap across the band midline. Hadamard adds
+ * a yellow middle strip; Y-twist omits it (the colour-flip seam is the only
+ * marker, with the magenta Y-defect ring drawn separately by the overlay).
  *
  * @param openAxis   Three.js axis index (0=X, 1=Y, 2=Z) that is open (length 2)
  * @param wallColors Colors for the two closed-axis wall pairs, ordered by Three.js axis number
- * @param hadamard   If true, subdivide walls with a yellow Hadamard band; colors swap above it
+ * @param bandStyle  "none" → single-strip walls (no colour flip);
+ *                   "hadamard" → 3 strips with yellow middle band;
+ *                   "ydefect" → 2 strips meeting at the band midline (no yellow)
  * @param hiddenFaces Bitmask of faces to omit from geometry
  */
+export type BandStyle = "none" | "hadamard" | "ydefect";
+
 function createPipeGeometry(
   openAxis: number,
   wallColors: [THREE.Color, THREE.Color],
-  hadamard: boolean,
+  bandStyle: BandStyle,
   hiddenFaces: FaceMask = 0,
   hBandHalfHeight?: number,
 ): THREE.BufferGeometry {
   const closedAxes = [0, 1, 2].filter(a => a !== openAxis) as [number, number];
 
-  if (!hadamard) {
+  if (bandStyle === "none") {
     const e = WALL_EPS;
     const dims: [number, number, number] = [1, 1, 1];
     dims[openAxis] = 2;
@@ -439,11 +463,12 @@ function createPipeGeometry(
     return geo;
   }
 
-  // --- Hadamard pipe: 4 walls × 3 strips each ---
+  // --- Colour-flip pipe (Hadamard / Y-twist): 4 walls × 2-or-3 strips each ---
 
   const halfExt: [number, number, number] = [0.5, 0.5, 0.5];
   for (const ca of closedAxes) halfExt[ca] -= WALL_EPS;
   const bh = hBandHalfHeight ?? H_BAND_HALF_HEIGHT;
+  const isHadamard = bandStyle === "hadamard";
   // Above the band, the two closed-axis colors swap per TQEC convention
   const wallColorsAbove: [THREE.Color, THREE.Color] = [wallColors[1], wallColors[0]];
 
@@ -499,13 +524,21 @@ function createPipeGeometry(
         return [make(t0, -ocDir), make(t1, -ocDir), make(t1, ocDir), make(t0, ocDir)];
       };
 
-      // Three strips along the open axis: below band, yellow band, above band
-      const [b0, b1, b2, b3] = quad(-1, -bh);
-      addQuad(b0, b1, b2, b3, n, wallColors[i]);
-      const [m0, m1, m2, m3] = quad(-bh, bh);
-      addQuad(m0, m1, m2, m3, n, H_COLOR);
-      const [a0, a1, a2, a3] = quad(bh, 1);
-      addQuad(a0, a1, a2, a3, n, wallColorsAbove[i]);
+      // Hadamard: three strips along the open axis (below band, yellow band, above).
+      // Y-twist: two strips meeting at the open-axis midline (no yellow strip).
+      if (isHadamard) {
+        const [b0, b1, b2, b3] = quad(-1, -bh);
+        addQuad(b0, b1, b2, b3, n, wallColors[i]);
+        const [m0, m1, m2, m3] = quad(-bh, bh);
+        addQuad(m0, m1, m2, m3, n, H_COLOR);
+        const [a0, a1, a2, a3] = quad(bh, 1);
+        addQuad(a0, a1, a2, a3, n, wallColorsAbove[i]);
+      } else {
+        const [b0, b1, b2, b3] = quad(-1, 0);
+        addQuad(b0, b1, b2, b3, n, wallColors[i]);
+        const [a0, a1, a2, a3] = quad(0, 1);
+        addQuad(a0, a1, a2, a3, n, wallColorsAbove[i]);
+      }
     }
   }
 
@@ -556,19 +589,22 @@ function createSlabGeometry(): THREE.BufferGeometry {
 export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
   if (isSlabType(blockType)) return createSlabGeometry();
   if (isPipeType(blockType)) {
-    const base = blockType.replace("H", "");
-    const hadamard = blockType.length > 3;
+    const bandStyle: BandStyle =
+      blockType.endsWith("H") ? "hadamard" :
+      blockType.endsWith("Y") ? "ydefect" : "none";
+    const base = blockType.length > 3 ? blockType.slice(0, 3) : blockType;
     const tqecOpenAxis = base.indexOf("O") as 0 | 1 | 2;
     const threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpenAxis];
     const closedAxes = [0, 1, 2].filter(a => a !== threeOpenAxis) as [number, number];
     let wallColors = closedAxes.map(ta => basisColor(base[THREE_TO_TQEC_AXIS[ta]])) as [THREE.Color, THREE.Color];
-    // For Y-open Hadamard pipes, the geometry "below band" end (negative Three.js Z)
-    // corresponds to the tail (higher TQEC Y). Pre-swap so below-band shows tail
-    // (flipped) colors and above-band shows head (original) colors.
-    if (hadamard && tqecOpenAxis === 1) {
+    // For Y-open colour-flip pipes (Hadamard or Y-twist), the geometry "below
+    // band" end (negative Three.js Z) corresponds to the tail (higher TQEC Y).
+    // Pre-swap so below-band shows tail (flipped) colors and above-band shows
+    // head (original) colors.
+    if (bandStyle !== "none" && tqecOpenAxis === 1) {
       wallColors = [wallColors[1], wallColors[0]];
     }
-    return createPipeGeometry(threeOpenAxis, wallColors, hadamard, hiddenFaces, hBandHalfHeight);
+    return createPipeGeometry(threeOpenAxis, wallColors, bandStyle, hiddenFaces, hBandHalfHeight);
   }
 
   if (blockType === "Y") {
@@ -731,8 +767,9 @@ export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0
  * Cubes: 8 of 12 edges qualify for any TQEC cube type (the 4 edges parallel to
  * the matched-basis axis are the same-basis pair and are skipped).
  * Pipes: the 4 edges along the open axis (where the two wall-pairs of opposite
- * basis meet). End caps and band rings are not emitted in v1; the H-pipe band
- * ring is a known follow-up.
+ * basis meet). Y-twist pipes additionally emit a 4-segment ring at the band
+ * midline — the magenta ring that visually replaces the yellow Hadamard band.
+ * The H-pipe band ring (above and below the yellow band) is a known follow-up.
  * Y blocks: empty (single-basis block, no X/Z transitions).
  *
  * An edge is skipped if both adjacent faces are hidden.
@@ -793,7 +830,7 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
   };
 
   if (pipe) {
-    const base = blockType.replace("H", "");
+    const base = blockType.length > 3 ? blockType.slice(0, 3) : blockType;
     const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
     const threeOpen = TQEC_TO_THREE_AXIS[tqecOpen];
     const closed = [0, 1, 2].filter(a => a !== threeOpen) as [number, number];
@@ -827,6 +864,32 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
     // Acceptable trade-off; tagged as known limitation.)
     if ((hiddenFaces & faceA) || (hiddenFaces & faceB)) continue;
     linePoints.push(...corners[i], ...corners[j]);
+  }
+
+  // Y-twist pipes: add a 4-segment magenta ring at the open-axis midline. Each
+  // segment lies on one closed-axis face, runs along the OTHER closed axis, and
+  // marks the seam where the face's colour flips (X ↔ Z). Skip a segment if its
+  // host face is hidden by an adjacent block (consistent with cube edges).
+  if (pipe && isYTwistPipe(blockType)) {
+    const base = blockType.slice(0, 3);
+    const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
+    const threeOpen = TQEC_TO_THREE_AXIS[tqecOpen];
+    const closedThree = [0, 1, 2].filter(a => a !== threeOpen) as [number, number];
+    const halfExt = [hx, hy, hz];
+    for (let k = 0; k < 2; k++) {
+      const ca = closedThree[k];      // axis of the face hosting this seam
+      const oc = closedThree[1 - k];  // axis the seam runs along
+      for (const sign of [1, -1] as const) {
+        const faceBit = FACE_BIT_BY_INDEX[ca * 2 + (sign > 0 ? 0 : 1)];
+        if (hiddenFaces & faceBit) continue;
+        const a: [number, number, number] = [0, 0, 0];
+        const b: [number, number, number] = [0, 0, 0];
+        a[threeOpen] = 0; b[threeOpen] = 0;
+        a[ca] = sign * halfExt[ca]; b[ca] = sign * halfExt[ca];
+        a[oc] = -halfExt[oc]; b[oc] = halfExt[oc];
+        linePoints.push(...a, ...b);
+      }
+    }
   }
 
   const geo = new THREE.BufferGeometry();

--- a/gui/src/utils/blockRotation.test.ts
+++ b/gui/src/utils/blockRotation.test.ts
@@ -35,6 +35,12 @@ describe("rotateBlockKind — 90° Z rotation", () => {
     expect(rotateBlockKind("XOZH", ROT_Z_CCW)).toBe("OXZH");
   });
 
+  it("preserves the Y-twist suffix", () => {
+    expect(rotateBlockKind("OZXY", ROT_Z_CCW)).toBe("ZOXY");
+    expect(rotateBlockKind("XOZY", ROT_Z_CCW)).toBe("OXZY");
+    expect(rotateBlockKind("ZXOY", ROT_Z_CCW)).toBe("XZOY");
+  });
+
   it("leaves Y blocks unchanged (Z rotation is legal)", () => {
     expect(rotateBlockKind("Y", ROT_Z_CCW)).toBe("Y");
     expect(rotateBlockKind("Y", ROT_Z_CW)).toBe("Y");
@@ -116,6 +122,13 @@ describe("rotateBlockAroundZ", () => {
     const pipe: Block = { pos: { x: 1, y: 0, z: 0 }, type: "OZXH" };
     const rotated = rotateBlockAroundZ(pipe, origin, "cw");
     expect(rotated.type).toBe("XOZH");
+  });
+
+  it("flips Y-twist direction when a pipe rotates into a negative axis", () => {
+    // Same direction-canonicalisation as Hadamard, but for Y-twist pipes.
+    const pipe: Block = { pos: { x: 1, y: 0, z: 0 }, type: "OZXY" };
+    const rotated = rotateBlockAroundZ(pipe, origin, "cw");
+    expect(rotated.type).toBe("XOZY");
   });
 
   it("rotates around a non-origin pivot correctly", () => {

--- a/gui/src/utils/blockRotation.ts
+++ b/gui/src/utils/blockRotation.ts
@@ -2,13 +2,18 @@ import type { Block, Position3D } from "../types";
 import { isPipeType, isSlabType, SLAB_TYPE } from "../types";
 
 // ---------------------------------------------------------------------------
-// Hadamard direction equivalences (same as tqec's adjust_hadamards_direction)
+// Hadamard direction equivalences (same as tqec's adjust_hadamards_direction).
+// Y-twist pipes share the same colour-flip convention, so the same equivalences
+// apply with the H suffix swapped for Y.
 // ---------------------------------------------------------------------------
 
 export const HDM_EQUIVALENCES: Record<string, string> = {
   ZXOH: "XZOH",
   XOZH: "ZOXH",
   OXZH: "OZXH",
+  ZXOY: "XZOY",
+  XOZY: "ZOXY",
+  OXZY: "OZXY",
 };
 
 export const HDM_INVERSE: Record<string, string> = Object.fromEntries(
@@ -78,9 +83,14 @@ export function rotateBlockKind(kindStr: string, rot: number[][]): string {
     return kindStr;
   }
 
-  // Hadamard: append 'H' if original had it
+  // Suffix preservation: H (Hadamard) or Y (free-build Y-twist). Both attach to
+  // pipes only; cube types never end in H or Y, and the bare "Y" block was
+  // already returned above. The geometry/colour-flip convention is the same
+  // for both, so rotation handles them identically.
   if (kindStr.endsWith("H")) {
     rotatedName += "H";
+  } else if (kindStr.endsWith("Y") && kindStr.length > 1) {
+    rotatedName += "Y";
   }
 
   return rotatedName.toUpperCase();
@@ -183,10 +193,10 @@ export function rotateBlockAroundZ(
 
   let newType = rotateBlockKind(block.type, rot);
 
-  // Hadamard pipes: after rotation, if the pipe now points in the negative
-  // direction along its axis, swap to the canonical equivalent so rendering
-  // stays consistent. Mirrors daeImport.ts behavior.
-  if (isPipe && newType.endsWith("H")) {
+  // Colour-flip pipes (Hadamard or Y-twist): after rotation, if the pipe now
+  // points in the negative direction along its axis, swap to the canonical
+  // equivalent so rendering stays consistent. Mirrors daeImport.ts behavior.
+  if (isPipe && (newType.endsWith("H") || newType.endsWith("Y"))) {
     const axesDirs = getAxesDirections(rot);
     const dirIdx = pipeDirectionIndex(newType);
     const dirLabel = ["X", "Y", "Z"][dirIdx];

--- a/gui/src/utils/daeExport.test.ts
+++ b/gui/src/utils/daeExport.test.ts
@@ -148,6 +148,23 @@ describe("round-trip: export → import", () => {
     expect(imported.get("1,0,0")!.type).toBe("OZXH");
   });
 
+  it("strips Y-twist pipes on export (free-build only, no TQEC semantics)", () => {
+    const original = makeBlocks(
+      ["0,0,0", { x: 0, y: 0, z: 0 }, "XZZ"],
+      ["1,0,0", { x: 1, y: 0, z: 0 }, "OZXY"],
+      ["3,0,0", { x: 3, y: 0, z: 0 }, "ZXZ"],
+    );
+    const xml = exportBlocksToDae(original);
+    // The Y-twist pipe should not appear in the output XML at all.
+    expect(xml).not.toContain("ozxy");
+    expect(xml).not.toContain("OZXY");
+    const imported = parseDaeToBlocks(xml);
+    expect(imported.size).toBe(2);
+    expect(imported.get("0,0,0")!.type).toBe("XZZ");
+    expect(imported.get("3,0,0")!.type).toBe("ZXZ");
+    expect(imported.has("1,0,0")).toBe(false);
+  });
+
   it("preserves all 6 cube types", () => {
     const types = ["XZZ", "ZXZ", "ZXX", "XXZ", "ZZX", "XZX"] as const;
     const entries: [string, { x: number; y: number; z: number }, string][] = types.map((t, i) => [

--- a/gui/src/utils/daeExport.ts
+++ b/gui/src/utils/daeExport.ts
@@ -1,5 +1,5 @@
 import type { Block } from "../types";
-import { isPipeType, isSlabType } from "../types";
+import { isPipeType, isSlabType, isYTwistPipe } from "../types";
 
 // ---------------------------------------------------------------------------
 // Constants matching tqec's Collada output
@@ -69,20 +69,26 @@ function stubGeometryXml(id: string): string {
  * (both use the same mod-3 grid where scale factor = 1 + pipe_length = 3).
  */
 export function exportBlocksToDae(blocks: Map<string, Block>): string {
-  // Slabs are a free-build-only authoring affordance with no .dae round-trip
-  // in v1 — drop them on export and log once so the user knows.
+  // Slabs and Y-twist pipes are free-build-only authoring affordances with no
+  // .dae round-trip in v1 — drop them on export and log once so the user knows.
   let droppedSlabs = 0;
+  let droppedYTwist = 0;
   for (const block of blocks.values()) {
     if (isSlabType(block.type)) droppedSlabs++;
+    else if (isYTwistPipe(block.type)) droppedYTwist++;
   }
   if (droppedSlabs > 0) {
     console.info(`[daeExport] dropped ${droppedSlabs} slab(s) — slabs are not represented in .dae`);
   }
+  if (droppedYTwist > 0) {
+    console.warn(`[daeExport] dropped ${droppedYTwist} Y-twist pipe(s) — Y-twist pipes have no TQEC semantics in v1`);
+  }
 
-  // Collect unique block kinds (excluding slabs)
+  // Collect unique block kinds (excluding slabs and Y-twist pipes)
   const usedKinds = new Set<string>();
   for (const block of blocks.values()) {
     if (isSlabType(block.type)) continue;
+    if (isYTwistPipe(block.type)) continue;
     usedKinds.add(block.type);
   }
 
@@ -150,6 +156,7 @@ export function exportBlocksToDae(blocks: Map<string, Block>): string {
 
   for (const block of blocks.values()) {
     if (isSlabType(block.type)) continue;
+    if (isYTwistPipe(block.type)) continue;
     const kindLower = block.type.toLowerCase();
     const nodeId = `lib_${kindLower}`;
 

--- a/gui/src/utils/daeImport.ts
+++ b/gui/src/utils/daeImport.ts
@@ -160,6 +160,15 @@ export function parseDaeToBlocks(xmlString: string): Map<string, Block> {
     // Skip correlation surface nodes and ports
     if (kindName.endsWith("_CORRELATION") || kindName === "PORT") continue;
 
+    // Y-twist pipes are a free-build-only piper-draw concept with no TQEC
+    // semantics. If a hand-authored .dae somehow contains one, strip the Y
+    // suffix and import as the matching plain pipe, with a console note so
+    // the conversion is auditable.
+    if (kindName.length === 4 && kindName.endsWith("Y") && kindName.includes("O")) {
+      console.log(`[dae import] stripping Y-twist suffix on ${kindName} → ${kindName.slice(0, 3)} (Y-twist pipes have no TQEC semantics)`);
+      kindName = kindName.slice(0, 3);
+    }
+
     // Validate it's a known block type before rotation
     // (after rotation it should become a valid type)
 


### PR DESCRIPTION
## Summary
- Adds 6 free-build-only Y-twist pipe types (`OZXY`, `OXZY`, `ZOXY`, `XOZY`, `ZXOY`, `XZOY`) and toolbar variants `ZXY`/`XZY`, gated like the Slab tool. Y-twist pipes flip face colours at the band midline (same as Hadamard) but render the band as a 4-segment magenta Y-defect ring shown only when **Highlight Y defects** is on.
- Generalises `createPipeGeometry` to a `BandStyle` discriminator (`"none" | "hadamard" | "ydefect"`) and extends `createYDefectEdges` so Y-twist pipes emit ring segments at the open-axis midline. Rotation preserves the `Y` suffix and direction-canonicalisation handles Y-twist via the same `HDM_EQUIVALENCES` table.
- Free-build gate covers placement (`addBlock`), arrow-key cycle (`cycleArmedType`), R-key build cycle (`cyclePipe`), edit-mode arrow cycle (`cycleSelectedType`), and toggle-off disarm. `.dae` import strips the `Y` suffix with a console note; export drops Y-twist pipes with a console warning (no TQEC semantics in v1).

## Test plan
- [ ] `cd gui && npm test` — 395 tests pass (15 new covering type registration, geometry, defect ring, rotation, dae round-trip, free-build gating, and cycle-key gating).
- [ ] `cd gui && ./node_modules/.bin/tsc -b` — clean.
- [ ] In the GUI: toggle free-build, place `ZXY` and `XZY` pipes for X/Y/Z-open axes, verify colour-flip seam at midline with no yellow band, toggle "Highlight Y defects" and confirm the magenta ring appears at the band midline.
- [ ] Verify `ZXY`/`XZY` toolbar buttons hide when free-build is off and that R-key / arrow-key cycling never lands on Y-twist outside free-build.
- [ ] `.dae` round-trip with a Y-twist pipe → confirm it's stripped on save with a console warning.

🧙 Built with [WOZCODE](https://wozcode.com)