### PR TITLE
feat: free-build Paint tool — per-face color overrides on cubes, pipes, and slabs

### DIFF
--- a/gui/src/components/BlockInstances.tsx
+++ b/gui/src/components/BlockInstances.tsx
@@ -19,6 +19,9 @@ import {
   getAdjacentPos,
   posKey,
   VARIANT_AXIS_MAP,
+  faceIndexFromNormal,
+  TQEC_TO_THREE_AXIS,
+  H_BAND_HALF_HEIGHT,
 } from "../types";
 import type { BlockType, CubeType, Block, FaceMask, Position3D, PipeVariant } from "../types";
 import { posInActiveSlice } from "../utils/isoView";
@@ -70,6 +73,22 @@ export function getCachedGeometry(blockType: BlockType, hiddenFaces: FaceMask): 
   return geo;
 }
 
+/**
+ * Sorted-key serialisation of a block's face-color overrides — used as part
+ * of the rendering group key so two blocks of the same type/hiddenFaces but
+ * different paint state don't share an InstancedMesh.
+ */
+// eslint-disable-next-line react-refresh/only-export-components
+export function faceColorsKey(faceColors: Record<string, string> | undefined): string {
+  if (!faceColors) return "";
+  const keys = Object.keys(faceColors);
+  if (keys.length === 0) return "";
+  keys.sort();
+  let s = "";
+  for (const k of keys) s += `${k}=${faceColors[k]};`;
+  return s;
+}
+
 // eslint-disable-next-line react-refresh/only-export-components
 export function getCachedEdges(blockType: BlockType, hiddenFaces: FaceMask): THREE.BufferGeometry {
   const key = `${blockType}:${hiddenFaces}`;
@@ -97,12 +116,15 @@ function TypedInstances({
   hiddenFaces,
   allBlocks,
   dimmed,
+  faceColors,
 }: {
   cubeType: BlockType;
   blocks: Block[];
   hiddenFaces: FaceMask;
   allBlocks: Map<string, Block>;
   dimmed: boolean;
+  /** Face-color overrides shared across every block in this group (group key includes the override hash). */
+  faceColors?: Record<string, string>;
 }) {
   const meshRef = useRef<THREE.InstancedMesh>(null!);
   const blocksRef = useRef(blocks);
@@ -117,7 +139,21 @@ function TypedInstances({
   if (maxCount !== capacity) setCapacity(maxCount);
 
   const pipe = isPipeType(cubeType);
-  const geometry = getCachedGeometry(cubeType, hiddenFaces);
+  // Geometry is freshly built (no cache) when the group has face-color overrides
+  // — caching by override hash would unbounded-grow the cache.
+  const geometry = useMemo(
+    () => (faceColors
+      ? createBlockGeometry(cubeType, hiddenFaces, undefined, faceColors)
+      : getCachedGeometry(cubeType, hiddenFaces)),
+    [cubeType, hiddenFaces, faceColors],
+  );
+  useEffect(() => {
+    // Dispose the per-group geometry on unmount/recreation only if it's not
+    // owned by the shared cache.
+    return () => {
+      if (faceColors) geometry.dispose();
+    };
+  }, [geometry, faceColors]);
   const fullBoxGeometry = pipe ? getCachedFullBox(cubeType) : null;
   const material = useMemo(
     () => new THREE.MeshLambertMaterial({
@@ -243,6 +279,10 @@ function TypedInstances({
       // Slab tool: never face-adjacent — the placement target is the gap
       // between pipes on the ground plane, handled by GridPlane.
       store.setHoveredGridPos(null);
+    } else if (store.mode === "edit" && armed === "paint") {
+      // Paint tool: hover does nothing yet (face-level hover preview is
+      // out of scope for v1). Clicks paint the face under the cursor.
+      store.setHoveredGridPos(null);
     } else {
       // Place mode: check if we can replace the hovered block itself
       const hovered = b[e.instanceId];
@@ -346,6 +386,38 @@ function TypedInstances({
       // Slab tool: clicking an existing block is a no-op — slabs only go in
       // the gap between 4 pipes on the ground plane.
       if (armed === "slab") return;
+      if (armed === "paint") {
+        if (!e.face) return;
+        const block = b[e.instanceId];
+        const faceIdx = faceIndexFromNormal(e.face.normal);
+        let key = String(faceIdx);
+        if (isPipeType(block.type)) {
+          // Strip both possible band-style suffixes ("H" for Hadamard, "Y" for Y-twist)
+          // before reading the open-axis position.
+          const base = block.type.length > 3 ? block.type.slice(0, 3) : block.type;
+          const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
+          const threeOpen = TQEC_TO_THREE_AXIS[tqecOpen];
+          // Open-axis faces have no rendered geometry — ignore the click.
+          if ((faceIdx >> 1) === threeOpen) return;
+          const isHad = block.type.endsWith("H");
+          const isYTwist = block.type.endsWith("Y") && block.type.length === 4;
+          if (isHad || isYTwist) {
+            const [cx, cy, cz] = tqecToThree(block.pos, block.type);
+            const local: [number, number, number] = [
+              e.point.x - cx,
+              e.point.y - cy,
+              e.point.z - cz,
+            ];
+            const t = local[threeOpen];
+            const strip = isHad
+              ? (t < -H_BAND_HALF_HEIGHT ? "below" : t > H_BAND_HALF_HEIGHT ? "above" : "band")
+              : (t < 0 ? "below" : "above");
+            key = `${faceIdx}:${strip}`;
+          }
+        }
+        store.paintFace(block.pos, key, store.paintColor);
+        return;
+      }
       // Place mode: try replacing the clicked block if the selected type
       // is valid at the clicked block's position
       const clicked = b[e.instanceId];
@@ -403,6 +475,7 @@ export function BlockInstances() {
       type: BlockType;
       hiddenFaces: FaceMask;
       dimmed: boolean;
+      faceColors?: Record<string, string>;
       blocks: Block[];
     };
     const map = new Map<string, Group>();
@@ -411,7 +484,8 @@ export function BlockInstances() {
       const dimmed =
         flowVizMode ||
         (viewMode.kind === "iso" && !posInActiveSlice(viewMode, block.pos));
-      const key = `${block.type}:${hf}:${dimmed ? 1 : 0}`;
+      const fcKey = faceColorsKey(block.faceColors);
+      const key = `${block.type}:${hf}:${dimmed ? 1 : 0}:${fcKey}`;
       const existing = map.get(key);
       if (existing) {
         existing.blocks.push(block);
@@ -420,6 +494,7 @@ export function BlockInstances() {
           type: block.type,
           hiddenFaces: hf,
           dimmed,
+          faceColors: block.faceColors,
           blocks: [block],
         });
       }
@@ -437,6 +512,7 @@ export function BlockInstances() {
           blocks={group.blocks}
           allBlocks={blocks}
           dimmed={group.dimmed}
+          faceColors={group.faceColors}
         />
       ))}
     </>

--- a/gui/src/components/EditModeHints.tsx
+++ b/gui/src/components/EditModeHints.tsx
@@ -61,6 +61,11 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
         `Step in ${viewMode.axis.toUpperCase()} direction`,
       ]);
     }
+  } else if (armedTool === "paint") {
+    hints.push(
+      ["Click face", "Paint with selected color"],
+      [`Hold ${bindingToLabel(b.holdToDelete)}`, "Click-to-delete"],
+    );
   } else {
     const placeLabel =
       armedTool === "port" ? "Place port"

--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -108,6 +108,11 @@ export function GridPlane() {
       }
       return;
     }
+    // Paint tool: targets faces of existing blocks, never the empty plane.
+    if (store.armedTool === "paint") {
+      setHoveredGridPos(null);
+      return;
+    }
     // Slab tool: XY-plane only — snap to the gap centre between 4 pipes
     // (both x and y at 3k+1). Iso views are not supported for slabs in v1.
     if (store.armedTool === "slab") {
@@ -199,6 +204,8 @@ export function GridPlane() {
       addBlock(pos);
       return;
     }
+    // Paint tool: empty-plane click is a no-op.
+    if (store.armedTool === "paint") return;
     const forPipe = store.pipeVariant !== null;
     const pos = snapForViewMode(viewMode, e.point, forPipe);
     addBlock(pos);

--- a/gui/src/components/OpenPipeGhosts.tsx
+++ b/gui/src/components/OpenPipeGhosts.tsx
@@ -78,6 +78,12 @@ function InteractiveGhost({ pos, threePos }: { pos: Position3D; threePos: [numbe
       return;
     }
 
+    // Paint tool: ports have no paintable geometry. No ghost preview, no fall-through to placement.
+    if (store.armedTool === "paint") {
+      store.setHoveredGridPos(null);
+      return;
+    }
+
     if (store.armedTool === "pipe" && store.pipeVariant) {
       // Pipe placement adjacent to a port: use the hovered face normal to compute
       // which adjacent pipe slot to target, mirroring BlockInstances' face logic.
@@ -135,6 +141,8 @@ function InteractiveGhost({ pos, threePos }: { pos: Position3D; threePos: [numbe
     }
     // Port tool: clicking a port is a no-op (it's already a port).
     if (store.armedTool === "port") return;
+    // Paint tool: clicking a port is a no-op (no paintable geometry).
+    if (store.armedTool === "paint") return;
     if (store.armedTool === "pipe" && store.pipeVariant) {
       if (!e.face) return;
       const resolved = resolvePipeTypeFromFace(pos, PORT_SENTINEL_TYPE, e.face.normal, store.pipeVariant);

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useBlockStore, type BuildStep } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { useKeybindStore, type Mode as KeybindMode, type NavStyle } from "../stores/keybindStore";
-import { CUBE_TYPES, FREE_BUILD_PIPE_VARIANTS, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey, X_HEX, Z_HEX, Y_HEX, H_HEX, Y_DEFECT_HEX, SLAB_HEX } from "../types";
+import { CUBE_TYPES, FREE_BUILD_PIPE_VARIANTS, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey, X_HEX, Z_HEX, H_HEX } from "../types";
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
@@ -85,8 +85,15 @@ const blockBtnStyle = (active: boolean, disabled?: boolean) => ({
 // Paint-tool color picker popover
 // ---------------------------------------------------------------------------
 
-const PAINT_PRESETS: ReadonlyArray<string> = [
-  X_HEX, Z_HEX, Y_HEX, H_HEX, Y_DEFECT_HEX, SLAB_HEX, "#ffffff", "#000000",
+// Three-color palette: X (red), Z (blue), and Hadamard (yellow). A "color
+// switch without a Hadamard" auto-promotes pipes to Y-twist; for cubes, two
+// adjacent X/Z faces auto-render a magenta Y-defect edge (see
+// `createYDefectEdges`). No custom-hex picker — the basis intent must be
+// unambiguous.
+const PAINT_PRESETS: ReadonlyArray<{ hex: string; label: string }> = [
+  { hex: X_HEX, label: "X (red)" },
+  { hex: Z_HEX, label: "Z (blue)" },
+  { hex: H_HEX, label: "Hadamard (yellow)" },
 ];
 
 function PaintPickerPopover({
@@ -122,41 +129,28 @@ function PaintPickerPopover({
         boxShadow: "0 2px 6px rgba(0,0,0,0.15)",
         zIndex: 10,
         display: "flex",
-        flexDirection: "column",
-        gap: 6,
-        minWidth: 152,
+        gap: 4,
       }}
     >
-      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 28px)", gap: 4 }}>
-        {PAINT_PRESETS.map((hex) => {
-          const active = hex.toLowerCase() === color.toLowerCase();
-          return (
-            <button
-              key={hex}
-              onClick={() => onPick(hex)}
-              title={hex}
-              style={{
-                width: 28,
-                height: 28,
-                background: hex,
-                border: active ? "2px solid #4a9eff" : "1px solid #888",
-                borderRadius: 3,
-                cursor: "pointer",
-                padding: 0,
-              }}
-            />
-          );
-        })}
-      </div>
-      <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, fontFamily: "sans-serif" }}>
-        <span>Custom</span>
-        <input
-          type="color"
-          value={color}
-          onChange={(e) => onPick(e.target.value)}
-          style={{ width: 36, height: 24, padding: 0, border: "1px solid #888", borderRadius: 3, background: "none" }}
-        />
-      </label>
+      {PAINT_PRESETS.map(({ hex, label }) => {
+        const active = hex.toLowerCase() === color.toLowerCase();
+        return (
+          <button
+            key={hex}
+            onClick={() => onPick(hex)}
+            title={label}
+            style={{
+              width: 28,
+              height: 28,
+              background: hex,
+              border: active ? "2px solid #4a9eff" : "1px solid #888",
+              borderRadius: 3,
+              cursor: "pointer",
+              padding: 0,
+            }}
+          />
+        );
+      })}
     </div>
   );
 }

--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useBlockStore, type BuildStep } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { useKeybindStore, type Mode as KeybindMode, type NavStyle } from "../stores/keybindStore";
-import { CUBE_TYPES, FREE_BUILD_PIPE_VARIANTS, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
+import { CUBE_TYPES, FREE_BUILD_PIPE_VARIANTS, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey, X_HEX, Z_HEX, Y_HEX, H_HEX, Y_DEFECT_HEX, SLAB_HEX } from "../types";
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
@@ -82,6 +82,86 @@ const blockBtnStyle = (active: boolean, disabled?: boolean) => ({
 });
 
 // ---------------------------------------------------------------------------
+// Paint-tool color picker popover
+// ---------------------------------------------------------------------------
+
+const PAINT_PRESETS: ReadonlyArray<string> = [
+  X_HEX, Z_HEX, Y_HEX, H_HEX, Y_DEFECT_HEX, SLAB_HEX, "#ffffff", "#000000",
+];
+
+function PaintPickerPopover({
+  color,
+  onPick,
+  onClose,
+}: {
+  color: string;
+  onPick: (hex: string) => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    const onDocPointerDown = (e: PointerEvent) => {
+      if (!ref.current) return;
+      if (e.target instanceof Node && ref.current.contains(e.target)) return;
+      onClose();
+    };
+    document.addEventListener("pointerdown", onDocPointerDown);
+    return () => document.removeEventListener("pointerdown", onDocPointerDown);
+  }, [onClose]);
+  return (
+    <div
+      ref={ref}
+      style={{
+        position: "absolute",
+        top: "calc(100% + 4px)",
+        left: 0,
+        background: "#fff",
+        border: "1px solid #ccc",
+        borderRadius: 4,
+        padding: 6,
+        boxShadow: "0 2px 6px rgba(0,0,0,0.15)",
+        zIndex: 10,
+        display: "flex",
+        flexDirection: "column",
+        gap: 6,
+        minWidth: 152,
+      }}
+    >
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 28px)", gap: 4 }}>
+        {PAINT_PRESETS.map((hex) => {
+          const active = hex.toLowerCase() === color.toLowerCase();
+          return (
+            <button
+              key={hex}
+              onClick={() => onPick(hex)}
+              title={hex}
+              style={{
+                width: 28,
+                height: 28,
+                background: hex,
+                border: active ? "2px solid #4a9eff" : "1px solid #888",
+                borderRadius: 3,
+                cursor: "pointer",
+                padding: 0,
+              }}
+            />
+          );
+        })}
+      </div>
+      <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, fontFamily: "sans-serif" }}>
+        <span>Custom</span>
+        <input
+          type="color"
+          value={color}
+          onChange={(e) => onPick(e.target.value)}
+          style={{ width: 36, height: 24, padding: 0, border: "1px solid #888", borderRadius: 3, background: "none" }}
+        />
+      </label>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Toolbar component
 // ---------------------------------------------------------------------------
 
@@ -115,6 +195,10 @@ export function Toolbar({
   const setPipeVariant = useBlockStore((s) => s.setPipeVariant);
   const setPlacePort = useBlockStore((s) => s.setPlacePort);
   const setArmedSlab = useBlockStore((s) => s.setArmedSlab);
+  const setArmedPaint = useBlockStore((s) => s.setArmedPaint);
+  const paintColor = useBlockStore((s) => s.paintColor);
+  const setPaintColor = useBlockStore((s) => s.setPaintColor);
+  const [paintPickerOpen, setPaintPickerOpen] = useState(false);
   const setPaletteDragging = useBlockStore((s) => s.setPaletteDragging);
   const cycleBlock = useBlockStore((s) => s.cycleBlock);
   const cyclePipe = useBlockStore((s) => s.cyclePipe);
@@ -747,7 +831,7 @@ export function Toolbar({
         </div>
       </div>
 
-      {/* Free-build-only group: Slab */}
+      {/* Free-build-only group: Slab + Paint */}
       {freeBuild && mode === "edit" && (
         <>
           <div style={{ width: 1, background: "#ddd" }} />
@@ -769,6 +853,41 @@ export function Toolbar({
                   <SlabIcon />
                 </div>
               </button>
+              <div style={{ position: "relative", display: "flex" }}>
+                <button
+                  key="paint"
+                  onClick={() => {
+                    if (armedTool === "paint") {
+                      setPaintPickerOpen((o) => !o);
+                    } else {
+                      setArmedPaint(true);
+                      setPaintPickerOpen(true);
+                    }
+                  }}
+                  title="Paint a face: click a cube/pipe/slab face to recolor it"
+                  style={blockBtnStyle(armedTool === "paint")}
+                >
+                  Paint
+                  <div style={previewWrapStyle}>
+                    <div
+                      style={{
+                        width: 22,
+                        height: 22,
+                        background: paintColor,
+                        border: "1px solid #888",
+                        borderRadius: 2,
+                      }}
+                    />
+                  </div>
+                </button>
+                {paintPickerOpen && armedTool === "paint" && (
+                  <PaintPickerPopover
+                    color={paintColor}
+                    onPick={(c) => setPaintColor(c)}
+                    onClose={() => setPaintPickerOpen(false)}
+                  />
+                )}
+              </div>
             </div>
           </div>
         </>

--- a/gui/src/components/YDefectOverlay.tsx
+++ b/gui/src/components/YDefectOverlay.tsx
@@ -20,19 +20,36 @@ type CylinderInstance = {
 
 const templateCache = new Map<string, CylinderInstance[]>();
 
-function getCachedTemplate(blockType: BlockType, hiddenFaces: FaceMask): CylinderInstance[] {
+function buildTemplate(
+  blockType: BlockType,
+  hiddenFaces: FaceMask,
+  faceColors?: Record<string, string>,
+): CylinderInstance[] {
+  const group = createYDefectCylinderGroup(blockType, hiddenFaces, yDefectMaterial, undefined, faceColors);
+  return group.children.map((child) => {
+    const mesh = child as THREE.Mesh;
+    return {
+      geometry: mesh.geometry as THREE.CylinderGeometry,
+      position: mesh.position.clone(),
+      quaternion: mesh.quaternion.clone(),
+    };
+  });
+}
+
+function getTemplate(
+  blockType: BlockType,
+  hiddenFaces: FaceMask,
+  faceColors?: Record<string, string>,
+): CylinderInstance[] {
+  // Painted blocks bypass the shared cache: their effective Y-defect topology
+  // depends on the override map, which can vary per instance.
+  if (faceColors && Object.keys(faceColors).length > 0) {
+    return buildTemplate(blockType, hiddenFaces, faceColors);
+  }
   const key = `${blockType}:${hiddenFaces}`;
   let arr = templateCache.get(key);
   if (!arr) {
-    const group = createYDefectCylinderGroup(blockType, hiddenFaces, yDefectMaterial);
-    arr = group.children.map((child) => {
-      const mesh = child as THREE.Mesh;
-      return {
-        geometry: mesh.geometry as THREE.CylinderGeometry,
-        position: mesh.position.clone(),
-        quaternion: mesh.quaternion.clone(),
-      };
-    });
+    arr = buildTemplate(blockType, hiddenFaces);
     templateCache.set(key, arr);
   }
   return arr;
@@ -53,7 +70,7 @@ export function YDefectOverlay() {
     for (const block of blocks.values()) {
       const k = posKey(block.pos);
       const hf = hiddenFaces.get(k) ?? 0;
-      const cylinders = getCachedTemplate(block.type, hf);
+      const cylinders = getTemplate(block.type, hf, block.faceColors);
       if (cylinders.length === 0) continue;
       const zo = block.type === "Y" ? yBlockZOffset(block.pos, blocks) : 0;
       out.push({ key: k, worldPos: tqecToThree(block.pos, block.type, zo), cylinders });

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -48,7 +48,7 @@ import {
 import { rotateBlockAroundZ } from "../utils/blockRotation";
 
 export type Mode = "edit" | "build";
-export type ArmedTool = "pointer" | "cube" | "pipe" | "port" | "paste" | "slab";
+export type ArmedTool = "pointer" | "cube" | "pipe" | "port" | "paste" | "slab" | "paint";
 
 const MAX_HISTORY = 100;
 
@@ -224,6 +224,18 @@ interface BlockStore {
   setPipeVariant: (variant: PipeVariant) => void;
   setPlacePort: (on: boolean) => void;
   setArmedSlab: (on: boolean) => void;
+  /** Toggle the free-build face-paint tool. */
+  setArmedPaint: (on: boolean) => void;
+  /** Active hex color (`"#rrggbb"`) used by the next paint click. */
+  paintColor: string;
+  setPaintColor: (hex: string) => void;
+  /**
+   * Apply the current paint color to a single face of the block at `pos`.
+   * `faceKey` is `"0".."5"` for cubes/Y/slabs/non-Hadamard pipes, or
+   * `"<faceIdx>:below"|"band"|"above"` for Hadamard pipes (per-strip).
+   * Pushes a `replace` undo command so undo/redo round-trips through Block.
+   */
+  paintFace: (pos: Position3D, faceKey: string, color: string) => void;
   /** Cycle the armed placeable by ±1 within PLACEABLE_ORDER (Drag / Drop mode only). */
   cycleArmedType: (dir: -1 | 1) => void;
   /**
@@ -524,7 +536,8 @@ function mergeBlocksWithDelta(
     if (!isValidPos(newPos, b.type)) continue;
     const newKey = posKey(newPos);
     if (mergedBlocks.has(newKey)) continue;
-    const newBlock: Block = { pos: newPos, type: b.type };
+    // Spread to preserve free-build face-paint overrides through paste/insert.
+    const newBlock: Block = { ...b, pos: newPos };
     mergedBlocks.set(newKey, newBlock);
     entries.push({ key: newKey, block: newBlock });
   }
@@ -657,8 +670,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   freeBuild: false,
   toggleFreeBuild: () => set((s) => {
     const next = !s.freeBuild;
-    // Disarm slab when leaving free-build, since the toolbar button hides.
-    if (!next && s.armedTool === "slab") {
+    // Disarm slab and paint when leaving free-build, since their toolbar buttons hide.
+    if (!next && (s.armedTool === "slab" || s.armedTool === "paint")) {
       return { freeBuild: next, armedTool: "pointer" as ArmedTool };
     }
     // Disarm Y-twist pipe variants when leaving free-build (toolbar buttons hide).
@@ -667,6 +680,9 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     }
     return { freeBuild: next };
   }),
+
+  paintColor: "#ff7f7f",
+  setPaintColor: (hex) => set({ paintColor: hex }),
 
   showGrid: true,
   showHints: true,
@@ -796,6 +812,24 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
   setPipeVariant: (variant) => set({ pipeVariant: variant, cubeType: PIPE_VARIANT_CANONICAL[variant], armedTool: "pipe", portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null }),
   setPlacePort: (on) => set({ armedTool: on ? "port" : "pointer", pipeVariant: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, ...(on ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null } : {}) }),
   setArmedSlab: (on) => set({ armedTool: on ? "slab" : "pointer", pipeVariant: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, ...(on ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null } : {}) }),
+  setArmedPaint: (on) => set({ armedTool: on ? "paint" : "pointer", pipeVariant: null, portWarning: null, hoveredGridPos: null, hoveredBlockType: null, hoveredInvalid: false, hoveredInvalidReason: null, hoveredReplace: false, ...(on ? { selectedKeys: new Set<string>(), selectedPortPositions: new Set<string>(), selectionPivot: null } : {}) }),
+  paintFace: (pos, faceKey, color) => set((state) => {
+    const key = posKey(pos);
+    const oldBlock = state.blocks.get(key);
+    if (!oldBlock) return state;
+    const nextOverrides: Record<string, string> = { ...(oldBlock.faceColors ?? {}) };
+    nextOverrides[faceKey] = color;
+    const newBlock: Block = { ...oldBlock, faceColors: nextOverrides };
+    const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, oldBlock);
+    const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, key, newBlock);
+    const cmd: UndoCommand = { kind: "replace", key, oldBlock, newBlock };
+    return {
+      blocks,
+      hiddenFaces,
+      history: [...state.history, cmd].slice(-MAX_HISTORY),
+      future: [],
+    };
+  }),
   cycleArmedType: (dir) => {
     const s = get();
     if (s.mode !== "edit") return;
@@ -890,7 +924,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
           const newType = VARIANT_AXIS_MAP[nextVariant][openAxis];
           let { blocks, hiddenFaces } = { blocks: s.blocks, hiddenFaces: s.hiddenFaces };
           ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, pipeKey, pipeBlock));
-          ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pipeKey, { pos: pipeBlock.pos, type: newType }));
+          // Spread preserves free-build face-paint overrides through pipe variant cycling.
+          ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pipeKey, { ...pipeBlock, type: newType }));
 
           const cmd: UndoCommand = { kind: "pipe-cycle", pipeKey, oldType, newType };
           return {
@@ -1001,7 +1036,10 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (existingBlock) {
           ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, key, existingBlock));
         }
-        newBlock = { pos, type: nextOpt.type };
+        // Spread preserves free-build face-paint overrides through type-cycle.
+        newBlock = existingBlock
+          ? { ...existingBlock, pos, type: nextOpt.type }
+          : { pos, type: nextOpt.type };
         ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, key, newBlock));
         // Placing a cube clears any explicit port marker at this position
         // (mirrors addBlock's behaviour when a cube lands on a user-placed port).
@@ -2325,7 +2363,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (!block) continue;
         const newType = flipBlockType(block.type);
         if (newType === block.type) continue;
-        entries.push({ key, oldBlock: block, newBlock: { pos: block.pos, type: newType } });
+        // Spread preserves free-build face-paint overrides through F-flip.
+        entries.push({ key, oldBlock: block, newBlock: { ...block, type: newType } });
       }
       if (entries.length === 0) return state;
 
@@ -2584,7 +2623,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (!old) continue;
         const newPos: Position3D = { x: old.pos.x + delta.x, y: old.pos.y + delta.y, z: old.pos.z + delta.z };
         if (!isValidPos(newPos, old.type)) return state;
-        entries.push({ oldKey, oldBlock: old, newKey: posKey(newPos), newBlock: { pos: newPos, type: old.type } });
+        // Spread to preserve free-build face-paint overrides through drag/nudge.
+        entries.push({ oldKey, oldBlock: old, newKey: posKey(newPos), newBlock: { ...old, pos: newPos } });
       }
       if (entries.length === 0) return state;
 
@@ -3420,7 +3460,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
       // Toggle pipe
       ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, pipeKey, pipeBlock));
-      const newPipeBlock: Block = { pos: pipeBlock.pos, type: newPipeType };
+      // Spread preserves free-build face-paint overrides through R-key pipe cycling.
+      const newPipeBlock: Block = { ...pipeBlock, type: newPipeType };
       ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pipeKey, newPipeBlock));
 
       // Refresh undetermined info for the two neighbour cubes (their option set

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -44,6 +44,7 @@ import {
   flipBlockType,
   PLACEABLE_ORDER,
   currentPlaceableIndex,
+  H_HEX,
 } from "../types";
 import { rotateBlockAroundZ } from "../utils/blockRotation";
 
@@ -817,9 +818,28 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
     const key = posKey(pos);
     const oldBlock = state.blocks.get(key);
     if (!oldBlock) return state;
-    const nextOverrides: Record<string, string> = { ...(oldBlock.faceColors ?? {}) };
+    let nextOverrides: Record<string, string> = { ...(oldBlock.faceColors ?? {}) };
     nextOverrides[faceKey] = color;
-    const newBlock: Block = { ...oldBlock, faceColors: nextOverrides };
+
+    // Auto-promote: a Hadamard pipe whose yellow band is painted away from H_HEX
+    // no longer mediates the X↔Z basis switch on its walls — the geometric
+    // equivalent is a Y-twist (magenta seam, no band strip). Convert the type
+    // and drop the now-orphaned ":band" overrides since Y-twist has no band.
+    let newType: BlockType = oldBlock.type;
+    const isHadBand = isPipeType(oldBlock.type)
+      && oldBlock.type.endsWith("H")
+      && faceKey.endsWith(":band")
+      && color.toLowerCase() !== H_HEX.toLowerCase();
+    if (isHadBand) {
+      newType = (oldBlock.type.slice(0, -1) + "Y") as BlockType;
+      const stripped: Record<string, string> = {};
+      for (const [k, v] of Object.entries(nextOverrides)) {
+        if (!k.endsWith(":band")) stripped[k] = v;
+      }
+      nextOverrides = stripped;
+    }
+
+    const newBlock: Block = { ...oldBlock, type: newType, faceColors: nextOverrides };
     const removed = doRemove(state.blocks, state.spatialIndex, state.hiddenFaces, key, oldBlock);
     const { blocks, hiddenFaces } = doAdd(removed.blocks, state.spatialIndex, removed.hiddenFaces, key, newBlock);
     const cmd: UndoCommand = { kind: "replace", key, oldBlock, newBlock };

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -109,11 +109,11 @@ export const PLACEABLE_ORDER: ReadonlyArray<Placeable> = [
  * pointer tool is armed (no placeable selected).
  */
 export function currentPlaceableIndex(
-  armedTool: "pointer" | "cube" | "pipe" | "port" | "paste" | "slab",
+  armedTool: "pointer" | "cube" | "pipe" | "port" | "paste" | "slab" | "paint",
   cubeType: BlockType,
   pipeVariant: PipeVariant | null,
 ): number {
-  if (armedTool === "pointer" || armedTool === "paste") return -1;
+  if (armedTool === "pointer" || armedTool === "paste" || armedTool === "paint") return -1;
   if (armedTool === "port") return 0;
   if (armedTool === "slab") return PLACEABLE_ORDER.findIndex((p) => p.kind === "slab");
   if (armedTool === "pipe") {
@@ -126,6 +126,15 @@ export function currentPlaceableIndex(
 export interface Block {
   pos: Position3D;
   type: BlockType;
+  /**
+   * Free-build face-paint overrides. Keys are Three.js face indices (`"0"`..`"5"`)
+   * for cubes / Y / slabs / non-colour-flip pipes; for Hadamard and Y-twist
+   * pipes the key is `"<faceIdx>:below"` | `"<faceIdx>:above"` (with
+   * `"<faceIdx>:band"` also valid for Hadamard's yellow band) so each strip on
+   * a wall can be painted independently. Values are hex color strings
+   * (`"#rrggbb"`).
+   */
+  faceColors?: Record<string, string>;
 }
 
 export type PortIO = "in" | "out";
@@ -162,7 +171,7 @@ export const H_HEX = "#ffff65";
 export const Y_DEFECT_HEX = "#ff39c2";
 export const SLAB_HEX = "#cccccc";
 
-const H_BAND_HALF_HEIGHT = 0.08;
+export const H_BAND_HALF_HEIGHT = 0.08;
 /** Inset so pipe walls are never coplanar with adjacent blocks/pipes. */
 const WALL_EPS = 0.001;
 const FACE_MASK_EPS = 1e-9;
@@ -385,9 +394,21 @@ function hasPositiveOverlap(a0: number, a1: number, b0: number, b1: number): boo
 }
 
 /** TQEC axis index → Three.js axis index: TQEC [X,Y,Z] → Three.js [0,2,1]. */
-const TQEC_TO_THREE_AXIS = [0, 2, 1] as const;
+export const TQEC_TO_THREE_AXIS = [0, 2, 1] as const;
 /** Inverse (same mapping since it's a self-inverse permutation). */
 const THREE_TO_TQEC_AXIS = [0, 2, 1] as const;
+
+/**
+ * Map a Three.js face normal to its box-face index in the canonical
+ * [+X, -X, +Y, -Y, +Z, -Z] order. Used by the free-build paint tool to
+ * identify which face of a block was clicked from raycast results.
+ */
+export function faceIndexFromNormal(n: THREE.Vector3): 0 | 1 | 2 | 3 | 4 | 5 {
+  const ax = Math.abs(n.x), ay = Math.abs(n.y), az = Math.abs(n.z);
+  if (ax >= ay && ax >= az) return n.x > 0 ? 0 : 1;
+  if (ay >= az) return n.y > 0 ? 2 : 3;
+  return n.z > 0 ? 4 : 5;
+}
 
 /**
  * Unified pipe geometry constructor. Builds a pipe open along one Three.js axis.
@@ -415,8 +436,10 @@ function createPipeGeometry(
   bandStyle: BandStyle,
   hiddenFaces: FaceMask = 0,
   hBandHalfHeight?: number,
+  overrides?: Record<string, string>,
 ): THREE.BufferGeometry {
   const closedAxes = [0, 1, 2].filter(a => a !== openAxis) as [number, number];
+  const tmpColor = new THREE.Color();
 
   if (bandStyle === "none") {
     const e = WALL_EPS;
@@ -436,8 +459,10 @@ function createPipeGeometry(
 
     for (let face = 0; face < 6; face++) {
       if (hiddenFaces & FACE_BIT_BY_INDEX[face]) continue;
-      const c = faceColors[face];
+      let c = faceColors[face];
       if (!c) continue;
+      const ov = overrides?.[String(face)];
+      if (ov) c = tmpColor.set(ov);
       for (let v = 0; v < 4; v++) {
         const idx = (face * 4 + v) * 3;
         colors[idx] = c.r;
@@ -524,20 +549,29 @@ function createPipeGeometry(
         return [make(t0, -ocDir), make(t1, -ocDir), make(t1, ocDir), make(t0, ocDir)];
       };
 
-      // Hadamard: three strips along the open axis (below band, yellow band, above).
-      // Y-twist: two strips meeting at the open-axis midline (no yellow strip).
+      // Hadamard: three strips (below / yellow band / above).
+      // Y-twist: two strips meeting at the open-axis midline (no band strip).
+      // Free-build paint overrides apply per-strip with keys "<face>:below" / ":band" / ":above";
+      // the band key is only meaningful for Hadamard.
+      const faceIdx = ca * 2 + (sign > 0 ? 0 : 1);
+      const ovBelow = overrides?.[`${faceIdx}:below`];
+      const ovAbove = overrides?.[`${faceIdx}:above`];
+      const belowColor = ovBelow ? new THREE.Color(ovBelow) : wallColors[i];
+      const aboveColor = ovAbove ? new THREE.Color(ovAbove) : wallColorsAbove[i];
       if (isHadamard) {
+        const ovBand = overrides?.[`${faceIdx}:band`];
+        const bandColor = ovBand ? new THREE.Color(ovBand) : H_COLOR;
         const [b0, b1, b2, b3] = quad(-1, -bh);
-        addQuad(b0, b1, b2, b3, n, wallColors[i]);
+        addQuad(b0, b1, b2, b3, n, belowColor);
         const [m0, m1, m2, m3] = quad(-bh, bh);
-        addQuad(m0, m1, m2, m3, n, H_COLOR);
+        addQuad(m0, m1, m2, m3, n, bandColor);
         const [a0, a1, a2, a3] = quad(bh, 1);
-        addQuad(a0, a1, a2, a3, n, wallColorsAbove[i]);
+        addQuad(a0, a1, a2, a3, n, aboveColor);
       } else {
         const [b0, b1, b2, b3] = quad(-1, 0);
-        addQuad(b0, b1, b2, b3, n, wallColors[i]);
+        addQuad(b0, b1, b2, b3, n, belowColor);
         const [a0, a1, a2, a3] = quad(0, 1);
-        addQuad(a0, a1, a2, a3, n, wallColorsAbove[i]);
+        addQuad(a0, a1, a2, a3, n, aboveColor);
       }
     }
   }
@@ -558,7 +592,7 @@ function createPipeGeometry(
  * are stripped. The 2-unit horizontal extent fills the inner gap between the
  * 4 pipes that form a square in TQEC X/Y.
  */
-function createSlabGeometry(): THREE.BufferGeometry {
+function createSlabGeometry(overrides?: Record<string, string>): THREE.BufferGeometry {
   const e = WALL_EPS;
   const geo = new THREE.BoxGeometry(2 - 2 * e, 1 - 2 * e, 2 - 2 * e);
   const colors = new Float32Array(24 * 3);
@@ -566,6 +600,18 @@ function createSlabGeometry(): THREE.BufferGeometry {
     colors[i * 3] = SLAB_COLOR.r;
     colors[i * 3 + 1] = SLAB_COLOR.g;
     colors[i * 3 + 2] = SLAB_COLOR.b;
+  }
+  const tmpColor = new THREE.Color();
+  for (const face of [2, 3]) {
+    const ov = overrides?.[String(face)];
+    if (!ov) continue;
+    tmpColor.set(ov);
+    for (let v = 0; v < 4; v++) {
+      const idx = (face * 4 + v) * 3;
+      colors[idx] = tmpColor.r;
+      colors[idx + 1] = tmpColor.g;
+      colors[idx + 2] = tmpColor.b;
+    }
   }
   // Keep only +Y (face 2) and -Y (face 3) — Three.js box face order is
   // +X, -X, +Y, -Y, +Z, -Z. Drop side faces so the slab reads as two plates.
@@ -586,8 +632,13 @@ function createSlabGeometry(): THREE.BufferGeometry {
  * Pipe types are parsed from the type name: each character gives the basis
  * for that TQEC axis ('X', 'Z', or 'O' for open). Hadamard variants end in 'H'.
  */
-export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask = 0, hBandHalfHeight?: number): THREE.BufferGeometry {
-  if (isSlabType(blockType)) return createSlabGeometry();
+export function createBlockGeometry(
+  blockType: BlockType,
+  hiddenFaces: FaceMask = 0,
+  hBandHalfHeight?: number,
+  overrides?: Record<string, string>,
+): THREE.BufferGeometry {
+  if (isSlabType(blockType)) return createSlabGeometry(overrides);
   if (isPipeType(blockType)) {
     const bandStyle: BandStyle =
       blockType.endsWith("H") ? "hadamard" :
@@ -604,8 +655,10 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
     if (bandStyle !== "none" && tqecOpenAxis === 1) {
       wallColors = [wallColors[1], wallColors[0]];
     }
-    return createPipeGeometry(threeOpenAxis, wallColors, bandStyle, hiddenFaces, hBandHalfHeight);
+    return createPipeGeometry(threeOpenAxis, wallColors, bandStyle, hiddenFaces, hBandHalfHeight, overrides);
   }
+
+  const tmpColor = new THREE.Color();
 
   if (blockType === "Y") {
     // YHalfCube: 1×1×0.5 in TQEC → 1 (X) × 0.5 (Y) × 1 (Z) in Three.js, all green
@@ -613,12 +666,16 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
     const colors = new Float32Array(24 * 3);
     const oldIndex = geo.index!;
     const newIndices: number[] = [];
-    for (let i = 0; i < 24; i++) {
-      colors[i * 3] = Y_COLOR.r;
-      colors[i * 3 + 1] = Y_COLOR.g;
-      colors[i * 3 + 2] = Y_COLOR.b;
-    }
     for (let face = 0; face < 6; face++) {
+      let c: THREE.Color = Y_COLOR;
+      const ov = overrides?.[String(face)];
+      if (ov) c = tmpColor.set(ov);
+      for (let v = 0; v < 4; v++) {
+        const idx = (face * 4 + v) * 3;
+        colors[idx] = c.r;
+        colors[idx + 1] = c.g;
+        colors[idx + 2] = c.b;
+      }
       if (hiddenFaces & FACE_BIT_BY_INDEX[face]) continue;
       for (let i = 0; i < 6; i++) {
         newIndices.push(oldIndex.getX(face * 6 + i));
@@ -645,7 +702,9 @@ export function createBlockGeometry(blockType: BlockType, hiddenFaces: FaceMask 
   const newIndices: number[] = [];
 
   for (let face = 0; face < 6; face++) {
-    const c = faceColors[face];
+    let c = faceColors[face];
+    const ov = overrides?.[String(face)];
+    if (ov) c = tmpColor.set(ov);
     if (hiddenFaces & FACE_BIT_BY_INDEX[face]) continue;
     for (let v = 0; v < 4; v++) {
       const idx = (face * 4 + v) * 3;

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -833,7 +833,24 @@ export function createBlockEdges(blockType: BlockType, hiddenFaces: FaceMask = 0
  *
  * An edge is skipped if both adjacent faces are hidden.
  */
-export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask = 0): THREE.BufferGeometry {
+/**
+ * Map a paint hex to its TQEC basis. Only X_HEX and Z_HEX carry a basis;
+ * H_HEX (yellow / Hadamard mediator) and any other hex return null, meaning
+ * "no basis" — adjacent faces with a null basis on either side never form a
+ * Y-defect edge, since yellow mediates the X↔Z transition.
+ */
+function paintHexToBasis(hex: string): "X" | "Z" | null {
+  const h = hex.toLowerCase();
+  if (h === X_HEX.toLowerCase()) return "X";
+  if (h === Z_HEX.toLowerCase()) return "Z";
+  return null;
+}
+
+export function createYDefectEdges(
+  blockType: BlockType,
+  hiddenFaces: FaceMask = 0,
+  faceColors?: Record<string, string>,
+): THREE.BufferGeometry {
   const empty = () => {
     const g = new THREE.BufferGeometry();
     g.setAttribute("position", new THREE.BufferAttribute(new Float32Array(0), 3));
@@ -909,6 +926,20 @@ export function createYDefectEdges(blockType: BlockType, hiddenFaces: FaceMask =
     faceBasis[FACE_POS_Z] = yCh; faceBasis[FACE_NEG_Z] = yCh;
   }
 
+  // Free-build paint overrides take precedence over type-derived basis.
+  // Only whole-face overrides ("0".."5") matter here: per-strip keys
+  // (`<face>:below|band|above`) modify intra-wall colour but don't change the
+  // face's "basis" for cube-edge Y-defect computation. X_HEX / Z_HEX swap the
+  // basis; any other hex (H_HEX yellow, or anything off-palette) clears it
+  // (null = mediator / no basis = no Y-defect edge contribution).
+  if (faceColors) {
+    for (let face = 0; face < 6; face++) {
+      const hex = faceColors[String(face)];
+      if (!hex) continue;
+      faceBasis[FACE_BIT_BY_INDEX[face]] = paintHexToBasis(hex);
+    }
+  }
+
   const linePoints: number[] = [];
   for (const { i, j, faceA, faceB } of edgeFacePairs) {
     const ba = faceBasis[faceA];
@@ -974,9 +1005,10 @@ export function createYDefectCylinderGroup(
   hiddenFaces: FaceMask = 0,
   material: THREE.Material,
   radius: number = Y_DEFECT_CYLINDER_RADIUS,
+  faceColors?: Record<string, string>,
 ): THREE.Group {
   const group = new THREE.Group();
-  const edges = createYDefectEdges(blockType, hiddenFaces);
+  const edges = createYDefectEdges(blockType, hiddenFaces, faceColors);
   const positions = edges.getAttribute("position").array as Float32Array;
   edges.dispose();
 

--- a/gui/src/utils/blockRotation.ts
+++ b/gui/src/utils/blockRotation.ts
@@ -1,5 +1,5 @@
 import type { Block, Position3D } from "../types";
-import { isPipeType, isSlabType, SLAB_TYPE } from "../types";
+import { isPipeType, isSlabType, SLAB_TYPE, TQEC_TO_THREE_AXIS } from "../types";
 
 // ---------------------------------------------------------------------------
 // Hadamard direction equivalences (same as tqec's adjust_hadamards_direction).
@@ -207,5 +207,89 @@ export function rotateBlockAroundZ(
 
   const newPos = rotatePositionAroundZ(block.pos, pivot, direction, needsCoordCanon);
 
-  return { pos: newPos, type: newType as Block["type"] };
+  const newFaceColors = block.faceColors
+    ? rotateFaceColorsAroundZ(block.faceColors, block.type, direction)
+    : undefined;
+
+  const result: Block = { pos: newPos, type: newType as Block["type"] };
+  if (newFaceColors) result.faceColors = newFaceColors;
+  return result;
+}
+
+/**
+ * Z-axis 90° rotation permutes Three.js face indices on the X/Z axes
+ * (TQEC X↔Y, which `TQEC_TO_THREE_AXIS=[0,2,1]` maps to Three.js X↔Z).
+ * Y faces (indices 2, 3) are invariant.
+ *
+ * Three.js face order: 0=+X 1=-X 2=+Y 3=-Y 4=+Z 5=-Z.
+ *
+ * CCW (TQEC X→Y, Y→-X) maps to Three.js (+X→-Z, -X→+Z, +Z→+X, -Z→-X):
+ *   0→5, 1→4, 4→0, 5→1
+ * CW: inverse — 0→4, 1→5, 4→1, 5→0.
+ */
+const FACE_PERM_CCW = [5, 4, 2, 3, 0, 1] as const;
+const FACE_PERM_CW = [4, 5, 2, 3, 1, 0] as const;
+
+/**
+ * Rotate Hadamard strip suffix under a Z-rotation.
+ *
+ * `createPipeGeometry` uses `:below` for the strip at the negative end of the
+ * pipe's Three.js open axis and `:above` for the positive end. Under a
+ * Three.js Y-axis 90° rotation (= TQEC Z-rotation), a horizontal pipe's open
+ * axis swaps between Three.js X and Three.js Z, and one of those swaps also
+ * inverts the open-axis sign — so the physical "below" end can land at the
+ * new pipe's "above" end. Vertical pipes (Three.js openAxis=1) are
+ * rotation-invariant. The flip pattern (worked out by tracing object-space
+ * points through `(x,z) → (z,-x)` for CCW and the inverse for CW):
+ *
+ *   CCW: flips iff original Three.js openAxis === 0 (X-open in TQEC).
+ *   CW:  flips iff original Three.js openAxis === 2 (Z-open / Y-open in TQEC).
+ */
+function flipHStrip(strip: string, threeOpenAxis: 0 | 1 | 2, direction: RotationDirection): string {
+  if (strip === "band" || threeOpenAxis === 1) return strip;
+  const flip = direction === "ccw" ? threeOpenAxis === 0 : threeOpenAxis === 2;
+  if (!flip) return strip;
+  return strip === "below" ? "above" : strip === "above" ? "below" : strip;
+}
+
+function rotateFaceColorsAroundZ(
+  faceColors: Record<string, string>,
+  blockType: Block["type"],
+  direction: RotationDirection,
+): Record<string, string> | undefined {
+  const perm = direction === "ccw" ? FACE_PERM_CCW : FACE_PERM_CW;
+  let threeOpenAxis: 0 | 1 | 2 | null = null;
+  // Hadamard ("H") and Y-twist ("Y") pipes have per-strip face keys whose
+  // below/above suffix is sign-relative to the open-axis end of the pipe.
+  const isHadamard = isPipeType(blockType) && blockType.endsWith("H");
+  const isYTwist = isPipeType(blockType) && blockType.endsWith("Y") && blockType.length === 4;
+  if (isHadamard || isYTwist) {
+    const base = blockType.length > 3 ? blockType.slice(0, 3) : blockType;
+    const tqecOpen = base.indexOf("O") as 0 | 1 | 2;
+    threeOpenAxis = TQEC_TO_THREE_AXIS[tqecOpen] as 0 | 1 | 2;
+  }
+  const out: Record<string, string> = {};
+  for (const [key, hex] of Object.entries(faceColors)) {
+    const colon = key.indexOf(":");
+    if (colon === -1) {
+      const idx = Number(key);
+      if (Number.isInteger(idx) && idx >= 0 && idx < 6) {
+        out[String(perm[idx])] = hex;
+      } else {
+        out[key] = hex;
+      }
+    } else {
+      const idx = Number(key.slice(0, colon));
+      const strip = key.slice(colon + 1);
+      const newStrip = threeOpenAxis !== null
+        ? flipHStrip(strip, threeOpenAxis, direction)
+        : strip;
+      if (Number.isInteger(idx) && idx >= 0 && idx < 6) {
+        out[`${perm[idx]}:${newStrip}`] = hex;
+      } else {
+        out[key] = hex;
+      }
+    }
+  }
+  return Object.keys(out).length ? out : undefined;
 }


### PR DESCRIPTION
## Summary
- Adds a **Paint** tool to free-build mode: click any face of a cube, pipe, or slab to recolor it with a chosen hex color (preset palette + native color picker).
- Hadamard pipe walls split into below / band / above strips, each paintable independently.
- Overrides live on `Block.faceColors` and survive copy/paste, drag/nudge, F-flip, R/toolbar type-cycle, rotate, and the localStorage autosave; `.dae` export still drops them (visual-only metadata).

## Test plan
- [ ] Free-build on → Paint button appears in toolbar; off → it hides.
- [ ] Paint a face of a cube, pipe, slab, and Hadamard strip — only that face/strip changes.
- [ ] Paint mode no-op on empty grid clicks and on port-endpoint clicks (no stray block placement).
- [ ] Copy/paste, drag/nudge, F-flip, R-cycle, and rotate all preserve painted faces.
- [ ] Reload survives the painted state via localStorage.

🧙 Built with [WOZCODE](https://wozcode.com)