### PR TITLE
Add X/Y axis rotations and 180° flips to edit mode

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -47,6 +47,7 @@ import {
   type KeyBinding,
 } from "./stores/keybindStore";
 import { useValidationStore } from "./stores/validationStore";
+import type { RotationAxis, RotationOperation } from "./utils/blockRotation";
 import { wasdToBuildDirection, tqecToThree, posKey, blockTqecSize, type Block, type IsoAxis, type ViewMode } from "./types";
 import { cameraGroundPoint } from "./utils/groundPlane";
 import { animateCamera } from "./utils/cameraAnim";
@@ -74,6 +75,25 @@ import {
 } from "./utils/isoView";
 
 const GRID_SNAP = 3;
+
+type RotationActionName =
+  | "rotateCcw" | "rotateCw"
+  | "rotateXCcw" | "rotateXCw"
+  | "rotateYCcw" | "rotateYCw"
+  | "flipX" | "flipY" | "flipZ";
+
+/** Edit-mode keybind actions that map to a (axis, operation) for rotateSelected. */
+const ROTATION_ACTIONS: Record<RotationActionName, { axis: RotationAxis; operation: RotationOperation }> = {
+  rotateCcw:  { axis: "z", operation: "ccw" },
+  rotateCw:   { axis: "z", operation: "cw" },
+  rotateXCcw: { axis: "x", operation: "ccw" },
+  rotateXCw:  { axis: "x", operation: "cw" },
+  rotateYCcw: { axis: "y", operation: "ccw" },
+  rotateYCw:  { axis: "y", operation: "cw" },
+  flipX:      { axis: "x", operation: "flip" },
+  flipY:      { axis: "y", operation: "flip" },
+  flipZ:      { axis: "z", operation: "flip" },
+};
 
 const AUTOSAVE_KEY = "piper-draw:autosave:v1";
 const AUTOSAVE_META_KEY = "piper-draw:autosave:meta:v1";
@@ -849,14 +869,23 @@ export default function App() {
           }
           return;
         case "rotateCcw":
-        case "rotateCw": {
+        case "rotateCw":
+        case "rotateXCcw":
+        case "rotateXCw":
+        case "rotateYCcw":
+        case "rotateYCw":
+        case "flipX":
+        case "flipY":
+        case "flipZ": {
           if (store.selectedKeys.size === 0) return;
           e.preventDefault();
+          const { axis, operation } = ROTATION_ACTIONS[action as RotationActionName];
           const hovered = store.hoveredGridPos;
           const pivotOverride = hovered && store.selectedKeys.has(posKey(hovered)) ? hovered : null;
-          const result = store.rotateSelected(action === "rotateCw" ? "cw" : "ccw", pivotOverride);
+          const result = store.rotateSelected(axis, operation, pivotOverride);
           if (!result.ok) {
-            useValidationStore.getState().reportEphemeralError(`Rotation aborted: ${result.reason}`);
+            const verb = operation === "flip" ? "Flip" : "Rotation";
+            useValidationStore.getState().reportEphemeralError(`${verb} aborted: ${result.reason}`);
           }
           return;
         }

--- a/gui/src/components/EditModeHints.tsx
+++ b/gui/src/components/EditModeHints.tsx
@@ -42,7 +42,15 @@ export function EditModeHints({ onCustomize }: { onCustomize: () => void }) {
       ["Ctrl+Shift+Drag", "Marquee select"],
       [bindingToLabel(b.selectAll), "Select all"],
       [bindingToLabel(b.flipColors), "Flip colors"],
-      [bindingToLabel(b.rotateCcw), "Rotate"],
+    );
+    if (hasSelection) {
+      const rotateKeys = `${bindingToLabel(b.rotateCcw)}/${bindingToLabel(b.rotateXCcw)}/${bindingToLabel(b.rotateYCcw)}`;
+      const flipKeys = `${bindingToLabel(b.flipX)}/${bindingToLabel(b.flipY)}/${bindingToLabel(b.flipZ)}`;
+      hints.push([rotateKeys, "Rotate"], [flipKeys, "Flip"]);
+    } else {
+      hints.push([bindingToLabel(b.rotateCcw), "Rotate"]);
+    }
+    hints.push(
       [`Hold ${bindingToLabel(b.holdToDelete)}`, "Click-to-delete"],
       [bindingToLabel(b.deleteSelection), "Delete selected"],
       [bindingToLabel(b.clearSelection), "Clear selection"],

--- a/gui/src/components/HelpPanel.tsx
+++ b/gui/src/components/HelpPanel.tsx
@@ -93,6 +93,11 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
             to rotate, drag to pan. Use the <b>Iso ▾</b> menu in the toolbar
             to snap to an axis-locked orthographic view.
           </li>
+          <li>
+            <b>Shortcuts</b> — every key binding is listed and rebindable in
+            the Customize panel; click <b>Customize</b> at the end of the hint
+            bar (or press <kbd>?</kbd>).
+          </li>
         </ul>
 
         <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Modes</h4>

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -593,7 +593,7 @@ describe("blockStore", () => {
       useBlockStore.setState({ cubeType: "XZZ" });
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result).toEqual({ ok: true });
       expect(useBlockStore.getState().blocks.size).toBe(1);
       const b = useBlockStore.getState().blocks.get("0,0,0");
@@ -607,7 +607,7 @@ describe("blockStore", () => {
       useBlockStore.setState({ pipeVariant: "ZX" });
       useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result).toEqual({ ok: true });
       const blocks = useBlockStore.getState().blocks;
       // bbox center (1.5, 0, 0) → snaps to (3, 0, 0). Rotating CCW around (3,0,0):
@@ -624,8 +624,8 @@ describe("blockStore", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
-      useBlockStore.getState().rotateSelected("ccw");
-      useBlockStore.getState().rotateSelected("cw");
+      useBlockStore.getState().rotateSelected("z", "ccw");
+      useBlockStore.getState().rotateSelected("z", "cw");
       const blocks = useBlockStore.getState().blocks;
       expect(blocks.size).toBe(2);
       expect(blocks.get("0,0,0")?.type).toBe("XZZ");
@@ -640,7 +640,7 @@ describe("blockStore", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().addBlock({ x: 3, y: 3, z: 0 });
       useBlockStore.getState().selectAll();
-      for (let i = 0; i < 4; i++) useBlockStore.getState().rotateSelected("ccw");
+      for (let i = 0; i < 4; i++) useBlockStore.getState().rotateSelected("z", "ccw");
       const blocks = useBlockStore.getState().blocks;
       expect(blocks.size).toBe(2);
       expect(blocks.get("0,0,0")?.type).toBe("XZZ");
@@ -652,7 +652,7 @@ describe("blockStore", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().addBlock({ x: 3, y: 3, z: 0 });
       useBlockStore.getState().selectAll();
-      useBlockStore.getState().rotateSelected("ccw");
+      useBlockStore.getState().rotateSelected("z", "ccw");
       expect(useBlockStore.getState().selectionPivot).not.toBeNull();
       useBlockStore.getState().clearSelection();
       expect(useBlockStore.getState().selectionPivot).toBeNull();
@@ -678,7 +678,7 @@ describe("blockStore", () => {
       s.selectBlock({ x: 0, y: 0, z: 0 }, false);
       s.selectBlock({ x: 3, y: 0, z: 0 }, true);
       const blocksBefore = new Map(useBlockStore.getState().blocks);
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result.ok).toBe(false);
       // State unchanged
       const blocksAfter = useBlockStore.getState().blocks;
@@ -690,7 +690,7 @@ describe("blockStore", () => {
       useBlockStore.setState({ cubeType: "Y" });
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result).toEqual({ ok: true });
       const blocks = useBlockStore.getState().blocks;
       // Single-block selection uses its own pos as pivot → stays in place.
@@ -702,7 +702,7 @@ describe("blockStore", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
-      useBlockStore.getState().rotateSelected("ccw");
+      useBlockStore.getState().rotateSelected("z", "ccw");
       useBlockStore.getState().undo();
       const blocks = useBlockStore.getState().blocks;
       expect(blocks.size).toBe(2);
@@ -715,7 +715,7 @@ describe("blockStore", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
-      useBlockStore.getState().rotateSelected("ccw");
+      useBlockStore.getState().rotateSelected("z", "ccw");
       const afterRotate = new Map(useBlockStore.getState().blocks);
       useBlockStore.getState().undo();
       useBlockStore.getState().redo();
@@ -730,7 +730,7 @@ describe("blockStore", () => {
       useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
       // Use (0,0,0) as override pivot; (3,0,0) should rotate to (0,3,0).
-      const result = useBlockStore.getState().rotateSelected("ccw", { x: 0, y: 0, z: 0 });
+      const result = useBlockStore.getState().rotateSelected("z", "ccw", { x: 0, y: 0, z: 0 });
       expect(result).toEqual({ ok: true });
       const blocks = useBlockStore.getState().blocks;
       expect(blocks.has("0,0,0")).toBe(true);
@@ -741,7 +741,7 @@ describe("blockStore", () => {
       useBlockStore.setState({ cubeType: "XZZ" });
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.getState().selectAll();
-      useBlockStore.getState().rotateSelected("ccw");
+      useBlockStore.getState().rotateSelected("z", "ccw");
       // Single cube pivots on itself — new key is the same.
       expect(useBlockStore.getState().selectedKeys.has("0,0,0")).toBe(true);
     });
@@ -749,7 +749,7 @@ describe("blockStore", () => {
     it("is a no-op when nothing is selected", () => {
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       const histBefore = useBlockStore.getState().history.length;
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result).toEqual({ ok: true });
       expect(useBlockStore.getState().history.length).toBe(histBefore);
     });
@@ -766,7 +766,7 @@ describe("blockStore", () => {
       const blocksBefore = new Map(useBlockStore.getState().blocks);
 
       useBlockStore.getState().selectBlock({ x: 0, y: 0, z: 0 }, false);
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result.ok).toBe(false);
 
       // State unchanged
@@ -783,7 +783,7 @@ describe("blockStore", () => {
       useBlockStore.setState({ pipeVariant: null });
 
       useBlockStore.getState().selectBlock({ x: 0, y: 0, z: 0 }, false);
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result).toEqual({ ok: true });
       expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
     });
@@ -797,7 +797,7 @@ describe("blockStore", () => {
 
       useBlockStore.getState().selectBlock({ x: 0, y: 0, z: 0 }, false);
       useBlockStore.getState().selectBlock({ x: 1, y: 0, z: 0 }, true);
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result).toEqual({ ok: true });
     });
 
@@ -813,12 +813,139 @@ describe("blockStore", () => {
       const blocksBefore = new Map(useBlockStore.getState().blocks);
 
       useBlockStore.getState().selectBlock({ x: 1, y: 0, z: 0 }, false);
-      const result = useBlockStore.getState().rotateSelected("ccw");
+      const result = useBlockStore.getState().rotateSelected("z", "ccw");
       expect(result.ok).toBe(false);
 
       const blocksAfter = useBlockStore.getState().blocks;
       expect(blocksAfter.size).toBe(blocksBefore.size);
       for (const [k, v] of blocksBefore) expect(blocksAfter.get(k)).toEqual(v);
+    });
+
+    it("rotates a single cube around X axis with type transform", () => {
+      useBlockStore.setState({ cubeType: "XZX" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      const result = useBlockStore.getState().rotateSelected("x", "ccw");
+      expect(result).toEqual({ ok: true });
+      // Single-block selection pivots on itself; type rotates: XZX → XXZ.
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XXZ");
+    });
+
+    it("rotates a single cube around Y axis with type transform", () => {
+      useBlockStore.setState({ cubeType: "XZZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      const result = useBlockStore.getState().rotateSelected("y", "ccw");
+      expect(result).toEqual({ ok: true });
+      // XZZ rotated CCW around Y: X → -Z, Z → X → "ZZX".
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZZX");
+    });
+
+    it("flips a multi-cube selection 180° around X axis (Y/Z negate)", () => {
+      useBlockStore.setState({ cubeType: "XZZ", freeBuild: true });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 3, z: 0 });
+      useBlockStore.getState().selectAll();
+      const result = useBlockStore.getState().rotateSelected("x", "flip");
+      expect(result).toEqual({ ok: true });
+      const blocks = useBlockStore.getState().blocks;
+      // bbox center on Y is (0, 1.5, 0) → snaps to (0, 3, 0). Flipping Y around 3:
+      // (0,0,0) → (0, 6, 0); (0, 3, 0) → (0, 3, 0).
+      expect(blocks.has("0,6,0")).toBe(true);
+      expect(blocks.has("0,3,0")).toBe(true);
+    });
+
+    it("two flips around any axis is identity", () => {
+      useBlockStore.setState({ cubeType: "XZZ", freeBuild: true });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 3, y: 3, z: 3 });
+      useBlockStore.getState().selectAll();
+      useBlockStore.getState().rotateSelected("x", "flip");
+      useBlockStore.getState().rotateSelected("x", "flip");
+      const blocks = useBlockStore.getState().blocks;
+      expect(blocks.has("0,0,0")).toBe(true);
+      expect(blocks.has("3,3,3")).toBe(true);
+    });
+
+    it("rejects X rotation of a Y block with a clear error", () => {
+      useBlockStore.setState({ cubeType: "Y" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      const result = useBlockStore.getState().rotateSelected("x", "ccw");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toMatch(/can only rotate around the Z axis/);
+    });
+
+    it("allows Z flip of a Y block (Z direction preserved)", () => {
+      useBlockStore.setState({ cubeType: "Y" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().selectAll();
+      const result = useBlockStore.getState().rotateSelected("z", "flip");
+      expect(result).toEqual({ ok: true });
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("Y");
+    });
+
+    it("rejects rotating a Z-open pipe around X axis when adjacent to a Y block", () => {
+      // Setup: Y block at (0,0,0) with a Z-open pipe at (0,0,1).
+      useBlockStore.setState({ cubeType: "Y" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 1 });
+      useBlockStore.setState({ pipeVariant: null });
+      // Select only the pipe and rotate it around X axis. The pipe lands at
+      // (0,-2,0) as a Y-axis pipe — and the Y block at (0,0,0) is at one of
+      // the pipe's endpoints. Color rules can't catch this (Y blocks are
+      // excluded from cube-color validation), so the new Y-neighbor check is
+      // the ONLY pass that rejects this rotation. Asserting `result.reason`
+      // proves the new code path fires.
+      useBlockStore.getState().selectBlock({ x: 0, y: 0, z: 1 }, false);
+      const result = useBlockStore.getState().rotateSelected("x", "ccw");
+      expect(result.ok).toBe(false);
+      if (!result.ok) expect(result.reason).toMatch(/Z-open pipes/);
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("Y");
+      expect(useBlockStore.getState().blocks.get("0,0,1")).toBeDefined();
+    });
+
+    it("four CCW rotations around X axis is identity (multi-block at the store level)", () => {
+      useBlockStore.setState({ cubeType: "XZZ", freeBuild: true });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 3, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 3 });
+      useBlockStore.getState().selectAll();
+      for (let i = 0; i < 4; i++) useBlockStore.getState().rotateSelected("x", "ccw");
+      const blocks = useBlockStore.getState().blocks;
+      expect(blocks.size).toBe(3);
+      expect(blocks.has("0,0,0")).toBe(true);
+      expect(blocks.has("0,3,0")).toBe(true);
+      expect(blocks.has("0,0,3")).toBe(true);
+    });
+
+    it("four CCW rotations around Y axis is identity (multi-block at the store level)", () => {
+      useBlockStore.setState({ cubeType: "XZZ", freeBuild: true });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 3 });
+      useBlockStore.getState().selectAll();
+      for (let i = 0; i < 4; i++) useBlockStore.getState().rotateSelected("y", "ccw");
+      const blocks = useBlockStore.getState().blocks;
+      expect(blocks.size).toBe(3);
+      expect(blocks.has("0,0,0")).toBe(true);
+      expect(blocks.has("3,0,0")).toBe(true);
+      expect(blocks.has("0,0,3")).toBe(true);
+    });
+
+    it("recomputes pivot when rotation axis changes", () => {
+      useBlockStore.setState({ cubeType: "XZZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 3, y: 3, z: 3 });
+      useBlockStore.getState().selectAll();
+      useBlockStore.getState().rotateSelected("z", "ccw");
+      const pivotAfterZ = useBlockStore.getState().selectionPivot;
+      expect(pivotAfterZ?.axis).toBe("z");
+      // Switch axis → pivot recomputes (axis updates to "x").
+      useBlockStore.getState().rotateSelected("x", "ccw");
+      const pivotAfterX = useBlockStore.getState().selectionPivot;
+      expect(pivotAfterX?.axis).toBe("x");
     });
   });
 

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -42,7 +42,7 @@ import {
   PLACEABLE_ORDER,
   currentPlaceableIndex,
 } from "../types";
-import { rotateBlockAroundZ } from "../utils/blockRotation";
+import { rotateBlockAroundAxis, type RotationAxis, type RotationOperation } from "../utils/blockRotation";
 
 export type Mode = "edit" | "build";
 export type ArmedTool = "pointer" | "cube" | "pipe" | "port" | "paste";
@@ -171,8 +171,10 @@ interface BlockStore {
   portPositions: Set<string>;
   /** Pivot used by rotateSelected, cached across subsequent rotations of the same
    * selection so that 4×CCW returns to identity even when the selection bbox is
-   * not cube-grid-aligned. Cleared whenever the selection itself changes. */
-  selectionPivot: Position3D | null;
+   * not cube-grid-aligned. Cleared whenever the selection itself changes. The
+   * axis is stored alongside so that switching rotation axis recomputes the
+   * pivot rather than reusing a stale one. */
+  selectionPivot: { pos: Position3D; axis: RotationAxis } | null;
 
   /** Clipboard populated by `copySelection`. Entries are normalized so the
    * selection's bounding-box min corner sits at (0,0,0). In-memory only —
@@ -288,7 +290,7 @@ interface BlockStore {
   clearSelection: () => void;
   deleteSelected: () => void;
   flipSelected: () => void;
-  rotateSelected: (direction: "cw" | "ccw", pivotOverride?: Position3D | null) => { ok: true } | { ok: false; reason: string };
+  rotateSelected: (axis: RotationAxis, operation: RotationOperation, pivotOverride?: Position3D | null) => { ok: true } | { ok: false; reason: string };
   selectAll: () => void;
   selectBlocks: (keys: string[], additive: boolean, portKeys?: string[]) => void;
   togglePortSelection: (pos: Position3D, additive: boolean) => void;
@@ -2367,27 +2369,27 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       };
     }),
 
-  rotateSelected: (direction, pivotOverride) => {
+  rotateSelected: (axis, operation, pivotOverride) => {
     const state = get();
     if (state.selectedKeys.size === 0) return { ok: true };
 
     // Determine pivot. Priority:
-    //   1. Explicit override (user hovered a selected block while pressing R).
-    //   2. Cached selectionPivot from a prior rotation of the same selection —
-    //      this is what makes 4×CCW return to identity even when the selection
-    //      bbox isn't cube-grid-aligned (bbox swaps X/Y spans on rotation, so
-    //      recomputing each time would drift).
-    //   3. Single-block selection: that block's position.
-    //   4. Multi-block selection: bbox XY center, snapped to the cube grid.
+    //   1. Explicit override (user hovered a selected block while pressing the rotate key).
+    //   2. Cached selectionPivot from a prior rotation of the same selection AND
+    //      same axis. Reusing across axes would inherit a z-coord that wasn't
+    //      meaningful for Z-only rotation (and still isn't for X/Y) — recompute
+    //      when axis changes.
+    //   3. Single-block selection: that block's position, snapped to cube grid.
+    //   4. Multi-block selection: bbox center on all 3 axes, snapped to cube grid.
     let pivot: Position3D;
     if (pivotOverride) {
       pivot = {
         x: Math.round(pivotOverride.x / 3) * 3,
         y: Math.round(pivotOverride.y / 3) * 3,
-        z: pivotOverride.z,
+        z: Math.round(pivotOverride.z / 3) * 3,
       };
-    } else if (state.selectionPivot) {
-      pivot = state.selectionPivot;
+    } else if (state.selectionPivot && state.selectionPivot.axis === axis) {
+      pivot = state.selectionPivot.pos;
     } else if (state.selectedKeys.size === 1) {
       const onlyKey = state.selectedKeys.values().next().value as string;
       const onlyBlock = state.blocks.get(onlyKey);
@@ -2395,24 +2397,25 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       pivot = {
         x: Math.round(onlyBlock.pos.x / 3) * 3,
         y: Math.round(onlyBlock.pos.y / 3) * 3,
-        z: onlyBlock.pos.z,
+        z: Math.round(onlyBlock.pos.z / 3) * 3,
       };
     } else {
-      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-      let zSample = 0;
+      let minX = Infinity, minY = Infinity, minZ = Infinity;
+      let maxX = -Infinity, maxY = -Infinity, maxZ = -Infinity;
       for (const key of state.selectedKeys) {
         const block = state.blocks.get(key);
         if (!block) continue;
         if (block.pos.x < minX) minX = block.pos.x;
         if (block.pos.y < minY) minY = block.pos.y;
+        if (block.pos.z < minZ) minZ = block.pos.z;
         if (block.pos.x > maxX) maxX = block.pos.x;
         if (block.pos.y > maxY) maxY = block.pos.y;
-        zSample = block.pos.z;
+        if (block.pos.z > maxZ) maxZ = block.pos.z;
       }
       pivot = {
         x: Math.round(((minX + maxX) / 2) / 3) * 3,
         y: Math.round(((minY + maxY) / 2) / 3) * 3,
-        z: zSample,
+        z: Math.round(((minZ + maxZ) / 2) / 3) * 3,
       };
     }
 
@@ -2423,49 +2426,50 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       for (const oldKey of state.selectedKeys) {
         const oldBlock = state.blocks.get(oldKey);
         if (!oldBlock) continue;
-        const newBlock = rotateBlockAroundZ(oldBlock, pivot, direction);
+        const newBlock = rotateBlockAroundAxis(oldBlock, pivot, axis, operation);
         if (!isValidPos(newBlock.pos, newBlock.type)) {
-          return { ok: false, reason: "Rotation produced an invalid grid position" };
+          return { ok: false, reason: "Result has an invalid grid position" };
         }
         const newKey = posKey(newBlock.pos);
         if (newKeys.has(newKey)) {
-          return { ok: false, reason: "Rotation produced overlapping positions" };
+          return { ok: false, reason: "Result has overlapping positions" };
         }
         newKeys.add(newKey);
         entries.push({ oldKey, oldBlock, newKey, newBlock });
       }
     } catch (e) {
-      return { ok: false, reason: e instanceof Error ? e.message : "Rotation failed" };
+      return { ok: false, reason: e instanceof Error ? e.message : "Operation failed" };
     }
 
     // Collision: any new key not in the old selection that already has a block
     for (const newKey of newKeys) {
       if (state.selectedKeys.has(newKey)) continue;
       if (state.blocks.has(newKey)) {
-        return { ok: false, reason: "Rotation would overlap an existing block" };
+        return { ok: false, reason: "Result would overlap an existing block" };
       }
     }
 
-    // TQEC validity: cube types must remain compatible with adjacent pipes.
-    // Skipped under "Ignore color rules" (freeBuild), matching moveSelection
-    // and placement paths (GridPlane, BlockInstances, OpenPipeGhosts).
-    if (!state.freeBuild) {
-      const tentative = new Map(state.blocks);
-      for (const entry of entries) tentative.delete(entry.oldKey);
-      for (const entry of entries) tentative.set(entry.newKey, entry.newBlock);
+    // Build the post-operation tentative map once for adjacency validation.
+    const tentative = new Map(state.blocks);
+    for (const entry of entries) tentative.delete(entry.oldKey);
+    for (const entry of entries) tentative.set(entry.newKey, entry.newBlock);
 
-      // Cubes to re-validate: every rotated cube, plus any cube adjacent to a
-      // rotated pipe's new position (catches the mirror case where a pipe lands
-      // next to an unselected cube and breaks its constraints).
+    // TQEC validity: cube types must remain compatible with adjacent pipes,
+    // and Y blocks must only neighbor Z-open pipes. Skipped under
+    // "Ignore color rules" (freeBuild), matching moveSelection and placement
+    // paths (GridPlane, BlockInstances, OpenPipeGhosts).
+    if (!state.freeBuild) {
+      // Cubes to re-validate for color rules: every rotated cube, plus any
+      // cube adjacent to a rotated pipe's new position.
       const toCheck = new Map<string, Block>();
       for (const entry of entries) {
         const b = entry.newBlock;
         if (isPipeType(b.type)) {
           const base = b.type.replace("H", "");
-          const axis = base.indexOf("O") as 0 | 1 | 2;
+          const pipeOpenAxis = base.indexOf("O") as 0 | 1 | 2;
           const nc: [number, number, number] = [b.pos.x, b.pos.y, b.pos.z];
           for (const pipeToCubeOffset of [-1, 2]) {
-            nc[axis] = [b.pos.x, b.pos.y, b.pos.z][axis] + pipeToCubeOffset;
+            nc[pipeOpenAxis] = [b.pos.x, b.pos.y, b.pos.z][pipeOpenAxis] + pipeToCubeOffset;
             const key = posKey({ x: nc[0], y: nc[1], z: nc[2] });
             const neighbor = tentative.get(key);
             if (neighbor && !isPipeType(neighbor.type) && neighbor.type !== "Y") {
@@ -2482,7 +2486,17 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         const type = cube.type as CubeType;
         const ok = opts.determined ? opts.type === type : opts.options.includes(type);
         if (!ok) {
-          return { ok: false, reason: "Rotation would break color rules between adjacent blocks" };
+          return { ok: false, reason: "Color rules between adjacent blocks would break" };
+        }
+      }
+
+      // Y-block adjacency check: a Y block must only sit next to Z-open pipes.
+      // hasYCubePipeAxisConflict is symmetric — passing a Y block checks its
+      // pipe neighbors; passing a pipe checks for Y blocks at its endpoints.
+      // Iterating over rotated entries catches both directions.
+      for (const entry of entries) {
+        if (hasYCubePipeAxisConflict(entry.newBlock.type, entry.newBlock.pos, tentative)) {
+          return { ok: false, reason: "Y block can only attach to Z-open pipes (top/bottom)" };
         }
       }
     }
@@ -2505,6 +2519,8 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
 
       const prevSelectedKeys = Array.from(s.selectedKeys);
       const nextSelectedKeys = entries.map((e) => e.newKey);
+      // The "rotate-selection" UndoCommand kind covers any axis and 180° flips —
+      // entries[] fully encodes the transformation.
       const cmd: UndoCommand = {
         kind: "rotate-selection",
         entries,
@@ -2517,7 +2533,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         history: [...s.history, cmd].slice(-MAX_HISTORY),
         future: [],
         selectedKeys: new Set(nextSelectedKeys),
-        selectionPivot: pivot,
+        selectionPivot: { pos: pivot, axis },
         hoveredGridPos: null,
         undeterminedCubes: newUndetermined,
       };
@@ -2629,6 +2645,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         history: [...state.history, cmd].slice(-MAX_HISTORY),
         future: [],
         selectedKeys: newSelected,
+        selectionPivot: null,
         hoveredGridPos: null,
         undeterminedCubes: newUndetermined,
       };

--- a/gui/src/stores/keybindStore.ts
+++ b/gui/src/stores/keybindStore.ts
@@ -25,6 +25,13 @@ export type EditAction =
   | "holdToDelete"
   | "rotateCcw"
   | "rotateCw"
+  | "rotateXCcw"
+  | "rotateXCw"
+  | "rotateYCcw"
+  | "rotateYCw"
+  | "flipX"
+  | "flipY"
+  | "flipZ"
   | "undo"
   | "redo"
   | "stepForward"
@@ -59,6 +66,8 @@ export const ACTIONS: { [M in Mode]: readonly ActionForMode[M][] } = {
   edit: [
     "selectAll", "deleteSelection", "clearSelection", "flipColors", "holdToDelete",
     "rotateCcw", "rotateCw",
+    "rotateXCcw", "rotateXCw", "rotateYCcw", "rotateYCw",
+    "flipX", "flipY", "flipZ",
     "undo", "redo", "stepForward", "stepBack", "nudgeUp", "nudgeDown",
     "cyclePrev", "cycleNext",
     "copy", "paste",
@@ -87,6 +96,13 @@ export const ACTION_LABELS: { [M in Mode]: Record<ActionForMode[M], string> } = 
     holdToDelete: "Hold to delete on click",
     rotateCcw: "Rotate CCW (Z)",
     rotateCw: "Rotate CW (Z)",
+    rotateXCcw: "Rotate CCW (X)",
+    rotateXCw: "Rotate CW (X)",
+    rotateYCcw: "Rotate CCW (Y)",
+    rotateYCw: "Rotate CW (Y)",
+    flipX: "Flip 180° (X)",
+    flipY: "Flip 180° (Y)",
+    flipZ: "Flip 180° (Z)",
     undo: "Undo",
     redo: "Redo",
     stepForward: "Step forward (iso)",
@@ -122,6 +138,13 @@ export const DEFAULT_BINDINGS: { [M in Mode]: Record<ActionForMode[M], KeyBindin
     holdToDelete: { key: "x" },
     rotateCcw: { key: "r" },
     rotateCw: { key: "r", shift: true },
+    rotateXCcw: { key: "e" },
+    rotateXCw: { key: "e", shift: true },
+    rotateYCcw: { key: "y" },
+    rotateYCw: { key: "y", shift: true },
+    flipX: { key: "b" },
+    flipY: { key: "n" },
+    flipZ: { key: "m" },
     undo: { key: "z", ctrl: true },
     redo: { key: "z", ctrl: true, shift: true },
     stepForward: { key: "arrowup" },
@@ -275,8 +298,13 @@ export const useKeybindStore = create<KeybindState>()(
     }),
     {
       name: "piper-draw-keybinds",
-      version: 13,
-      migrate: () => ({ bindings: cloneDefaults() }),
+      version: 15,
+      // Pass-through: schema is additive across versions (new EditActions only
+      // get appended). The `merge` step below starts from `cloneDefaults()` and
+      // walks the action list, picking up any persisted user bindings for
+      // existing actions while letting new actions fall back to defaults — no
+      // need to wipe state on migration.
+      migrate: (persisted) => persisted as KeybindState,
       merge: (persisted, current) => {
         const p = persisted as Partial<KeybindState>;
         const cur = current as KeybindState;

--- a/gui/src/utils/blockRotation.test.ts
+++ b/gui/src/utils/blockRotation.test.ts
@@ -1,9 +1,19 @@
 import { describe, expect, it } from "vitest";
 import {
+  MATRICES,
+  ROT_X_180,
+  ROT_X_CCW,
+  ROT_X_CW,
+  ROT_Y_180,
+  ROT_Y_CCW,
+  ROT_Y_CW,
+  ROT_Z_180,
   ROT_Z_CCW,
   ROT_Z_CW,
+  rotateBlockAroundAxis,
   rotateBlockAroundZ,
   rotateBlockKind,
+  rotatePositionAroundAxis,
   rotatePositionAroundZ,
 } from "./blockRotation";
 import type { Block, Position3D } from "../types";
@@ -132,6 +142,248 @@ describe("ROT_Z_CCW / ROT_Z_CW", () => {
     for (let i = 0; i < 3; i++) {
       for (let j = 0; j < 3; j++) {
         expect(ROT_Z_CCW[i][j]).toBe(ROT_Z_CW[j][i]);
+      }
+    }
+  });
+});
+
+describe("rotateBlockKind — 90° X rotation", () => {
+  it("rotates cube types correctly under X CCW (Y/Z columns swap)", () => {
+    expect(rotateBlockKind("XZX", ROT_X_CCW)).toBe("XXZ");
+    expect(rotateBlockKind("XXZ", ROT_X_CCW)).toBe("XZX");
+    expect(rotateBlockKind("ZXZ", ROT_X_CCW)).toBe("ZZX");
+    expect(rotateBlockKind("ZZX", ROT_X_CCW)).toBe("ZXZ");
+    // Symmetric cubes are X-rotation invariant.
+    expect(rotateBlockKind("XZZ", ROT_X_CCW)).toBe("XZZ");
+    expect(rotateBlockKind("ZXX", ROT_X_CCW)).toBe("ZXX");
+  });
+
+  it("swaps O between Y- and Z-axis positions for pipes under X rotation", () => {
+    expect(rotateBlockKind("ZOX", ROT_X_CCW)).toBe("ZXO");
+    expect(rotateBlockKind("ZXO", ROT_X_CCW)).toBe("ZOX");
+    // X-axis pipes stay X-open (just basis chars permute).
+    expect(rotateBlockKind("OZX", ROT_X_CCW)).toBe("OXZ");
+    expect(rotateBlockKind("OXZ", ROT_X_CCW)).toBe("OZX");
+  });
+
+  it("preserves the Hadamard suffix under X rotation", () => {
+    expect(rotateBlockKind("OZXH", ROT_X_CCW)).toBe("OXZH");
+    expect(rotateBlockKind("ZOXH", ROT_X_CCW)).toBe("ZXOH");
+  });
+
+  it("rejects Y blocks under X rotation", () => {
+    expect(() => rotateBlockKind("Y", ROT_X_CCW)).toThrow(/can only rotate around the Z axis/);
+    expect(() => rotateBlockKind("Y", ROT_X_CW)).toThrow(/can only rotate around the Z axis/);
+  });
+});
+
+describe("rotateBlockKind — 90° Y rotation", () => {
+  it("rotates cube types correctly under Y CCW (X/Z columns swap)", () => {
+    expect(rotateBlockKind("XZZ", ROT_Y_CCW)).toBe("ZZX");
+    expect(rotateBlockKind("ZZX", ROT_Y_CCW)).toBe("XZZ");
+    expect(rotateBlockKind("ZXX", ROT_Y_CCW)).toBe("XXZ");
+    expect(rotateBlockKind("XXZ", ROT_Y_CCW)).toBe("ZXX");
+    // Symmetric cubes are Y-rotation invariant.
+    expect(rotateBlockKind("ZXZ", ROT_Y_CCW)).toBe("ZXZ");
+    expect(rotateBlockKind("XZX", ROT_Y_CCW)).toBe("XZX");
+  });
+
+  it("swaps O between X- and Z-axis positions for pipes under Y rotation", () => {
+    expect(rotateBlockKind("OZX", ROT_Y_CCW)).toBe("XZO");
+    expect(rotateBlockKind("XZO", ROT_Y_CCW)).toBe("OZX");
+    // Y-axis pipes stay Y-open under Y rotation.
+    expect(rotateBlockKind("ZOX", ROT_Y_CCW)).toBe("XOZ");
+    expect(rotateBlockKind("XOZ", ROT_Y_CCW)).toBe("ZOX");
+  });
+
+  it("preserves the Hadamard suffix under Y rotation", () => {
+    expect(rotateBlockKind("OZXH", ROT_Y_CCW)).toBe("XZOH");
+    expect(rotateBlockKind("ZOXH", ROT_Y_CCW)).toBe("XOZH");
+  });
+
+  it("rejects Y blocks under Y rotation", () => {
+    expect(() => rotateBlockKind("Y", ROT_Y_CCW)).toThrow(/can only rotate around the Z axis/);
+    expect(() => rotateBlockKind("Y", ROT_Y_CW)).toThrow(/can only rotate around the Z axis/);
+  });
+});
+
+describe("rotateBlockKind — 180° flips", () => {
+  it("preserves cube type strings under flip on any axis", () => {
+    // 180° matrices use abs values; basis chars are unchanged at each index.
+    for (const cube of ["XZZ", "ZXZ", "ZXX", "XXZ", "ZZX", "XZX"]) {
+      expect(rotateBlockKind(cube, ROT_X_180)).toBe(cube);
+      expect(rotateBlockKind(cube, ROT_Y_180)).toBe(cube);
+      expect(rotateBlockKind(cube, ROT_Z_180)).toBe(cube);
+    }
+  });
+
+  it("preserves pipe type strings under same-axis flip", () => {
+    // Flipping a pipe around its own open axis preserves its type.
+    expect(rotateBlockKind("OZX", ROT_X_180)).toBe("OZX");
+    expect(rotateBlockKind("ZOX", ROT_Y_180)).toBe("ZOX");
+    expect(rotateBlockKind("ZXO", ROT_Z_180)).toBe("ZXO");
+  });
+
+  it("allows Y blocks under Z flip (Z direction preserved)", () => {
+    expect(rotateBlockKind("Y", ROT_Z_180)).toBe("Y");
+  });
+
+  it("rejects Y blocks under X flip and Y flip (Z direction inverted)", () => {
+    expect(() => rotateBlockKind("Y", ROT_X_180)).toThrow(/can only rotate around the Z axis/);
+    expect(() => rotateBlockKind("Y", ROT_Y_180)).toThrow(/can only rotate around the Z axis/);
+  });
+});
+
+describe("rotatePositionAroundAxis", () => {
+  it("X CCW: Y → Z, Z → -Y, X fixed", () => {
+    expect(rotatePositionAroundAxis({ x: 3, y: 0, z: 0 }, origin, "x", "ccw", false)).toEqual({ x: 3, y: 0, z: 0 });
+    expect(rotatePositionAroundAxis({ x: 0, y: 3, z: 0 }, origin, "x", "ccw", false)).toEqual({ x: 0, y: 0, z: 3 });
+    expect(rotatePositionAroundAxis({ x: 0, y: 0, z: 3 }, origin, "x", "ccw", false)).toEqual({ x: 0, y: -3, z: 0 });
+  });
+
+  it("Y CCW: Z → X, X → -Z, Y fixed", () => {
+    expect(rotatePositionAroundAxis({ x: 0, y: 3, z: 0 }, origin, "y", "ccw", false)).toEqual({ x: 0, y: 3, z: 0 });
+    expect(rotatePositionAroundAxis({ x: 0, y: 0, z: 3 }, origin, "y", "ccw", false)).toEqual({ x: 3, y: 0, z: 0 });
+    expect(rotatePositionAroundAxis({ x: 3, y: 0, z: 0 }, origin, "y", "ccw", false)).toEqual({ x: 0, y: 0, z: -3 });
+  });
+
+  it("four CCW around X = identity for cube positions", () => {
+    let p: Position3D = { x: 3, y: 6, z: 9 };
+    for (let i = 0; i < 4; i++) p = rotatePositionAroundAxis(p, origin, "x", "ccw", false);
+    expect(p).toEqual({ x: 3, y: 6, z: 9 });
+  });
+
+  it("four CCW around Y = identity for cube positions", () => {
+    let p: Position3D = { x: 3, y: 6, z: 9 };
+    for (let i = 0; i < 4; i++) p = rotatePositionAroundAxis(p, origin, "y", "ccw", false);
+    expect(p).toEqual({ x: 3, y: 6, z: 9 });
+  });
+
+  it("canonicalizes pipe Y-coord under X CCW (z=1 → y=-1 → y=-2)", () => {
+    // Z-axis pipe at (0, 0, 1) → X CCW about origin → (0, -1, 0). y=-1 ≡ 2 mod 3 → canonicalize to -2.
+    expect(rotatePositionAroundAxis({ x: 0, y: 0, z: 1 }, origin, "x", "ccw", true)).toEqual({ x: 0, y: -2, z: 0 });
+  });
+
+  it("does not canonicalize cube positions (only pipes)", () => {
+    expect(rotatePositionAroundAxis({ x: 0, y: 0, z: 1 }, origin, "x", "ccw", false)).toEqual({ x: 0, y: -1, z: 0 });
+  });
+
+  it("canonicalizes pipe X-coord under Y CCW (x=1 → z=-1 → z=-2)", () => {
+    // X-axis pipe at (1, 0, 0) → Y CCW about origin → (0, 0, -1). z=-1 ≡ 2 mod 3 → canonicalize to -2.
+    expect(rotatePositionAroundAxis({ x: 1, y: 0, z: 0 }, origin, "y", "ccw", true)).toEqual({ x: 0, y: 0, z: -2 });
+  });
+
+  it("180° flip around X: leaves X fixed, negates Y and Z", () => {
+    expect(rotatePositionAroundAxis({ x: 3, y: 6, z: 9 }, origin, "x", "flip", false)).toEqual({ x: 3, y: -6, z: -9 });
+  });
+
+  it("180° flip canonicalizes both non-axis pipe coords when needed", () => {
+    // Pipe at (3, 1, 0) flipped around X about origin → (3, -1, 0). y=-1 ≡ 2 mod 3 → canonicalize to -2.
+    expect(rotatePositionAroundAxis({ x: 3, y: 1, z: 0 }, origin, "x", "flip", true)).toEqual({ x: 3, y: -2, z: 0 });
+  });
+
+  it("two flips around any axis = identity", () => {
+    const p: Position3D = { x: 6, y: 3, z: 9 };
+    for (const axis of ["x", "y", "z"] as const) {
+      const once = rotatePositionAroundAxis(p, origin, axis, "flip", false);
+      const twice = rotatePositionAroundAxis(once, origin, axis, "flip", false);
+      expect(twice).toEqual(p);
+    }
+  });
+});
+
+describe("rotateBlockAroundAxis", () => {
+  it("rotates a cube around X with type and position both transformed", () => {
+    const block: Block = { pos: { x: 0, y: 3, z: 0 }, type: "XZX" };
+    const rotated = rotateBlockAroundAxis(block, origin, "x", "ccw");
+    expect(rotated.pos).toEqual({ x: 0, y: 0, z: 3 });
+    expect(rotated.type).toBe("XXZ");
+  });
+
+  it("four CCW rotations around X = identity for a cube + pipe pair", () => {
+    const cube: Block = { pos: { x: 0, y: 3, z: 0 }, type: "XZZ" };
+    const pipe: Block = { pos: { x: 0, y: 1, z: 0 }, type: "ZOX" };
+    const rotate4 = (b: Block, axis: "x" | "y" | "z"): Block => {
+      let cur = b;
+      for (let i = 0; i < 4; i++) cur = rotateBlockAroundAxis(cur, origin, axis, "ccw");
+      return cur;
+    };
+    expect(rotate4(cube, "x")).toEqual(cube);
+    expect(rotate4(pipe, "x")).toEqual(pipe);
+  });
+
+  it("two flips around any axis = identity for a cube + pipe pair", () => {
+    const cube: Block = { pos: { x: 3, y: 6, z: 9 }, type: "XZZ" };
+    const pipe: Block = { pos: { x: 1, y: 0, z: 0 }, type: "OZX" };
+    for (const axis of ["x", "y", "z"] as const) {
+      const onceCube = rotateBlockAroundAxis(cube, origin, axis, "flip");
+      const twiceCube = rotateBlockAroundAxis(onceCube, origin, axis, "flip");
+      expect(twiceCube).toEqual(cube);
+      const oncePipe = rotateBlockAroundAxis(pipe, origin, axis, "flip");
+      const twicePipe = rotateBlockAroundAxis(oncePipe, origin, axis, "flip");
+      expect(twicePipe).toEqual(pipe);
+    }
+  });
+
+  it("flips Hadamard direction under X flip (ZOXH at -Y → XOZH at +Y)", () => {
+    // ZOXH is a Y-axis Hadamard pipe. X flip negates Y, so the pipe now points in
+    // -Y; rotateBlockKind first produces ZOXH (abs-magnitude), then
+    // adjustHadamardDirection swaps to its +Y equivalent XOZH.
+    const pipe: Block = { pos: { x: 0, y: 1, z: 0 }, type: "ZOXH" };
+    const rotated = rotateBlockAroundAxis(pipe, origin, "x", "flip");
+    expect(rotated.type).toBe("XOZH");
+  });
+
+  it("flips Hadamard direction under Y flip (ZXOH at +Z → XZOH at -Z)", () => {
+    // ZXOH is a Z-axis Hadamard pipe. Y flip negates Z, so the new pipe points
+    // -Z and adjustHadamardDirection swaps via HDM_INVERSE: ZXOH → XZOH.
+    const pipe: Block = { pos: { x: 0, y: 0, z: 1 }, type: "ZXOH" };
+    const rotated = rotateBlockAroundAxis(pipe, origin, "y", "flip");
+    expect(rotated.type).toBe("XZOH");
+  });
+
+  it("flips Hadamard direction under Z flip (OZXH at +X → OXZH at -X)", () => {
+    // OZXH is an X-axis Hadamard pipe. Z flip negates X (Z stays positive), so
+    // the new pipe points -X and adjustHadamardDirection swaps via HDM_INVERSE:
+    // OZXH → OXZH.
+    const pipe: Block = { pos: { x: 1, y: 0, z: 0 }, type: "OZXH" };
+    const rotated = rotateBlockAroundAxis(pipe, origin, "z", "flip");
+    expect(rotated.type).toBe("OXZH");
+  });
+
+  it("rejects rotation of Y blocks around X / Y axes", () => {
+    const y: Block = { pos: { x: 0, y: 0, z: 0 }, type: "Y" };
+    expect(() => rotateBlockAroundAxis(y, origin, "x", "ccw")).toThrow(/can only rotate around the Z axis/);
+    expect(() => rotateBlockAroundAxis(y, origin, "y", "cw")).toThrow(/can only rotate around the Z axis/);
+    expect(() => rotateBlockAroundAxis(y, origin, "x", "flip")).toThrow(/can only rotate around the Z axis/);
+    expect(() => rotateBlockAroundAxis(y, origin, "y", "flip")).toThrow(/can only rotate around the Z axis/);
+  });
+
+  it("allows Y blocks under Z rotation and Z flip", () => {
+    const y: Block = { pos: { x: 0, y: 3, z: 0 }, type: "Y" };
+    expect(rotateBlockAroundAxis(y, origin, "z", "ccw").type).toBe("Y");
+    expect(rotateBlockAroundAxis(y, origin, "z", "flip").type).toBe("Y");
+  });
+});
+
+describe("MATRICES table", () => {
+  it("has every (axis, operation) entry", () => {
+    for (const axis of ["x", "y", "z"] as const) {
+      for (const op of ["ccw", "cw", "flip"] as const) {
+        expect(MATRICES[axis][op]).toBeDefined();
+        expect(MATRICES[axis][op].length).toBe(3);
+      }
+    }
+  });
+
+  it("ccw and cw matrices are inverses (transposes)", () => {
+    for (const axis of ["x", "y", "z"] as const) {
+      const ccw = MATRICES[axis].ccw;
+      const cw = MATRICES[axis].cw;
+      for (let i = 0; i < 3; i++) {
+        for (let j = 0; j < 3; j++) {
+          expect(ccw[i][j]).toBe(cw[j][i]);
+        }
       }
     }
   });

--- a/gui/src/utils/blockRotation.ts
+++ b/gui/src/utils/blockRotation.ts
@@ -69,7 +69,7 @@ export function rotateBlockKind(kindStr: string, rot: number[][]): string {
   if (rotatedName.includes("!")) {
     if (!rotatedName.endsWith("!") || axesDirs["Z"] < 0) {
       throw new Error(
-        `Invalid rotation for ${kindStr} block: cultivation and Y blocks only allow rotation around Z axis.`,
+        `${kindStr} blocks can only rotate around the Z axis.`,
       );
     }
     return kindStr;
@@ -96,7 +96,7 @@ export function pipeDirectionIndex(kindStr: string): number {
 }
 
 // ---------------------------------------------------------------------------
-// Z-axis rotation primitives (90° only)
+// Rotation primitives (X / Y / Z, 90° CCW/CW and 180° flips)
 // ---------------------------------------------------------------------------
 
 /** 90° counter-clockwise rotation around +Z. */
@@ -113,7 +113,67 @@ export const ROT_Z_CW: number[][] = [
   [0, 0, 1],
 ];
 
+/** 180° rotation around Z axis (same as two CCW). */
+export const ROT_Z_180: number[][] = [
+  [-1, 0, 0],
+  [0, -1, 0],
+  [0, 0, 1],
+];
+
+/** 90° CCW rotation around +X (right-hand rule: +Y → +Z). */
+export const ROT_X_CCW: number[][] = [
+  [1, 0, 0],
+  [0, 0, -1],
+  [0, 1, 0],
+];
+
+/** 90° CW rotation around +X (+Z → +Y). */
+export const ROT_X_CW: number[][] = [
+  [1, 0, 0],
+  [0, 0, 1],
+  [0, -1, 0],
+];
+
+/** 180° rotation around X axis. */
+export const ROT_X_180: number[][] = [
+  [1, 0, 0],
+  [0, -1, 0],
+  [0, 0, -1],
+];
+
+/** 90° CCW rotation around +Y (right-hand rule: +Z → +X). */
+export const ROT_Y_CCW: number[][] = [
+  [0, 0, 1],
+  [0, 1, 0],
+  [-1, 0, 0],
+];
+
+/** 90° CW rotation around +Y (+X → +Z). */
+export const ROT_Y_CW: number[][] = [
+  [0, 0, -1],
+  [0, 1, 0],
+  [1, 0, 0],
+];
+
+/** 180° rotation around Y axis. */
+export const ROT_Y_180: number[][] = [
+  [-1, 0, 0],
+  [0, 1, 0],
+  [0, 0, -1],
+];
+
+export type RotationAxis = "x" | "y" | "z";
+export type RotationOperation = "ccw" | "cw" | "flip";
+
+/** Backwards-compatible alias for the original Z-only rotation API. */
 export type RotationDirection = "cw" | "ccw";
+
+/** Lookup table: axis × operation → 3x3 matrix. */
+export const MATRICES: Record<RotationAxis, Record<RotationOperation, number[][]>> = {
+  x: { ccw: ROT_X_CCW, cw: ROT_X_CW, flip: ROT_X_180 },
+  y: { ccw: ROT_Y_CCW, cw: ROT_Y_CW, flip: ROT_Y_180 },
+  z: { ccw: ROT_Z_CCW, cw: ROT_Z_CW, flip: ROT_Z_180 },
+};
 
 function posMod(n: number, m: number): number {
   return ((n % m) + m) % m;
@@ -122,7 +182,7 @@ function posMod(n: number, m: number): number {
 /**
  * Canonicalize a grid coordinate so that pipe slots stay at `c ≡ 1 (mod 3)`.
  *
- * A 90° rotation around a cube-valid pivot can produce coordinates where a
+ * A rotation around a cube-valid pivot can produce coordinates where a
  * pipe's slot axis lands at `c ≡ 2 (mod 3)` — still physically between the
  * same two cubes, but stored non-canonically. Shifting by -1 moves it to the
  * canonical `≡ 1 (mod 3)` representation without crossing into a different
@@ -132,53 +192,60 @@ function canonicalizePipeCoord(c: number): number {
   return posMod(c, 3) === 2 ? c - 1 : c;
 }
 
-/** Rotate a grid position around `pivot` by 90° around +Z (CCW or CW). */
-export function rotatePositionAroundZ(
-  pos: Position3D,
-  pivot: Position3D,
-  direction: RotationDirection,
-  isPipe: boolean,
-): Position3D {
-  const dx = pos.x - pivot.x;
-  const dy = pos.y - pivot.y;
-  let nx: number, ny: number;
-  if (direction === "ccw") {
-    // (x, y) -> (-y, x) relative to pivot
-    nx = pivot.x - dy;
-    ny = pivot.y + dx;
-  } else {
-    // (x, y) -> (y, -x) relative to pivot
-    nx = pivot.x + dy;
-    ny = pivot.y - dx;
-  }
-  if (isPipe) {
-    nx = canonicalizePipeCoord(nx);
-    ny = canonicalizePipeCoord(ny);
-  }
-  return { x: nx, y: ny, z: pos.z };
+function applyMatrix(m: number[][], v: [number, number, number]): [number, number, number] {
+  return [
+    m[0][0] * v[0] + m[0][1] * v[1] + m[0][2] * v[2],
+    m[1][0] * v[0] + m[1][1] * v[1] + m[1][2] * v[2],
+    m[2][0] * v[0] + m[2][1] * v[1] + m[2][2] * v[2],
+  ];
 }
 
 /**
- * Rotate a block (position + type) 90° around +Z about `pivot`.
- *
- * Throws if the block's type cannot be rotated (e.g. a Y block with a pivot
- * that would move it off its own column — impossible for pure Z rotation, so
- * not actually reachable here, but the underlying rotateBlockKind throws on
- * bad matrices in general).
+ * Rotate a grid position around `pivot` by `operation` (90° CCW/CW or 180°)
+ * about the named `axis`. Pipes get their two non-axis coords canonicalized
+ * back to `c ≡ 1 (mod 3)` after the rotation.
  */
-export function rotateBlockAroundZ(
+export function rotatePositionAroundAxis(
+  pos: Position3D,
+  pivot: Position3D,
+  axis: RotationAxis,
+  operation: RotationOperation,
+  isPipe: boolean,
+): Position3D {
+  const m = MATRICES[axis][operation];
+  const [nx, ny, nz] = applyMatrix(m, [pos.x - pivot.x, pos.y - pivot.y, pos.z - pivot.z]);
+  let resX = pivot.x + nx;
+  let resY = pivot.y + ny;
+  let resZ = pivot.z + nz;
+  if (isPipe) {
+    if (axis !== "x") resX = canonicalizePipeCoord(resX);
+    if (axis !== "y") resY = canonicalizePipeCoord(resY);
+    if (axis !== "z") resZ = canonicalizePipeCoord(resZ);
+  }
+  return { x: resX, y: resY, z: resZ };
+}
+
+/**
+ * Rotate a block (position + type) about `pivot` around the named `axis` by
+ * `operation` (90° CCW/CW or 180°).
+ *
+ * Throws via `rotateBlockKind` when the rotation is invalid for the block
+ * type (e.g. a Y block under any non-Z-preserving rotation).
+ */
+export function rotateBlockAroundAxis(
   block: Block,
   pivot: Position3D,
-  direction: RotationDirection,
+  axis: RotationAxis,
+  operation: RotationOperation,
 ): Block {
-  const rot = direction === "ccw" ? ROT_Z_CCW : ROT_Z_CW;
+  const rot = MATRICES[axis][operation];
   const isPipe = isPipeType(block.type);
 
   let newType = rotateBlockKind(block.type, rot);
 
   // Hadamard pipes: after rotation, if the pipe now points in the negative
-  // direction along its axis, swap to the canonical equivalent so rendering
-  // stays consistent. Mirrors daeImport.ts behavior.
+  // direction along its open axis, swap to the canonical equivalent so
+  // rendering stays consistent. Mirrors daeImport.ts behavior.
   if (isPipe && newType.endsWith("H")) {
     const axesDirs = getAxesDirections(rot);
     const dirIdx = pipeDirectionIndex(newType);
@@ -188,7 +255,26 @@ export function rotateBlockAroundZ(
     }
   }
 
-  const newPos = rotatePositionAroundZ(block.pos, pivot, direction, isPipe);
+  const newPos = rotatePositionAroundAxis(block.pos, pivot, axis, operation, isPipe);
 
   return { pos: newPos, type: newType as Block["type"] };
+}
+
+/** Backwards-compatible alias: rotate a position 90° around +Z. */
+export function rotatePositionAroundZ(
+  pos: Position3D,
+  pivot: Position3D,
+  direction: RotationDirection,
+  isPipe: boolean,
+): Position3D {
+  return rotatePositionAroundAxis(pos, pivot, "z", direction, isPipe);
+}
+
+/** Backwards-compatible alias: rotate a block 90° around +Z. */
+export function rotateBlockAroundZ(
+  block: Block,
+  pivot: Position3D,
+  direction: RotationDirection,
+): Block {
+  return rotateBlockAroundAxis(block, pivot, "z", direction);
 }


### PR DESCRIPTION
## Summary

Generalizes the rotation engine to support 90° rotations around X and Y (in addition to the existing Z) plus 180° flips on all three axes; new edit-mode keybindings are `E` / `Shift+E` (rotate X), `Y` / `Shift+Y` (rotate Y), and `B` / `N` / `M` (flip X/Y/Z), with `R` / `Shift+R` unchanged. Y-block adjacency is now validated after every rotation so a flip or rotation that would leave a Y block next to a non-Z-open pipe is rejected with a clear toast. Side improvements while in here: `moveSelection` now resets `selectionPivot` (drag-after-rotate was reusing a stale pivot); the keybind store's `migrate` is a pass-through (`merge` already handles new actions), so user customizations and prefs like `cameraFollowsBuild` / `navStyle` survive the version bump; the Y-rotation rejection message no longer leaks "cultivation" jargon to end users; and the edit-mode hint bar exposes the new shortcuts only when a selection is active.

## Test plan

- [x] `pnpm test` — 447 passing (added 47 unit tests covering X/Y/Z matrices, Hadamard direction adjustment under all three flip axes, and Y-block rejection paths; 8 new integration tests covering multi-axis 4×CCW identity, the indirect Y-block neighbor case, and pivot cache invalidation across axis changes)
- [x] `pnpm tsc -b` clean
- [x] `pnpm build` clean
- [ ] In-browser smoke: select a block, press `R/E/Y` and `Shift+R/E/Y` for 90° rotations on each axis, `B/N/M` for 180° flips, verify Y-block + non-Z-open pipe shows the rejection toast
- [ ] Settings panel ("?" key) shows the seven new edit-mode rows under their default bindings; verify rebinding works

🧙 Built with [WOZCODE](https://wozcode.com)