### PR TITLE
fix: allow editing blocks above the ground plane from below

### DIFF
--- a/gui/src/components/GridPlane.tsx
+++ b/gui/src/components/GridPlane.tsx
@@ -62,18 +62,14 @@ export function GridPlane() {
   });
 
   const handlePointerMove = (e: ThreeEvent<PointerEvent>) => {
-    // Pass-through (pointer/paste only): when a block/port is also under the
-    // cursor, return early without stopProp so the block's onPointerMove sets
-    // hoveredGridPos. Done before any setHoveredGridPos call so we don't write
-    // the plane cell and let the block immediately overwrite it (one-frame
-    // flash on stacked hits).
+    // Pass-through: when a block/port is also under the cursor, return early
+    // without stopProp so the block's onPointerMove sets hoveredGridPos. This
+    // matters whenever the GridPlane is closer to the camera than the block —
+    // looking down at sub-ground (z<0) blocks, or looking up from below at
+    // above-ground (z>0) blocks (so pipes can attach to their bottom faces).
     if (mode === "edit") {
       const s = useBlockStore.getState();
-      if (
-        !s.xHeld &&
-        (s.armedTool === "pointer" || s.armedTool === "paste") &&
-        shouldPassThroughGridPlane(e.intersections, meshRef.current)
-      ) {
+      if (!s.xHeld && shouldPassThroughGridPlane(e.intersections, meshRef.current)) {
         return;
       }
     }
@@ -139,28 +135,28 @@ export function GridPlane() {
     if (e.delta > 2) { e.stopPropagation(); return; } // ignore drags
     if (mode !== "edit") { e.stopPropagation(); return; }
 
+    // Pass-through: when the click ray also hits a block or port ghost,
+    // let that handler own the event. Lets sub-ground (z<0) blocks be
+    // selected/edited from above and above-ground (z>0) blocks be
+    // selected/edited (and pipes attached to their bottom faces) from below.
+    //
+    // NOTE: this couples GridPlane's click policy (deselect, place-on-grid,
+    // port-on-grid, paste-commit) to every other clickable scene mesh. Any
+    // future clickable mesh must either opt out of raycast (the
+    // raycast={noRaycast} convention used by decoratives) or call
+    // e.stopPropagation() in its own onClick. Otherwise clicks falling
+    // through that mesh would be silently dropped.
+    if (shouldPassThroughGridPlane(e.intersections, meshRef.current)) return;
+    e.stopPropagation();
+
     const store = useBlockStore.getState();
     // X-held delete on empty grid is a no-op.
-    if (store.xHeld) { e.stopPropagation(); return; }
+    if (store.xHeld) return;
 
     if (store.armedTool === "pointer") {
-      // Pass-through: when the click ray also hits a block or port ghost
-      // further along, let that handler own the event so sub-ground blocks
-      // (TQEC z<0) can be selected from above.
-      //
-      // NOTE: this couples deselect-on-empty-click policy to GridPlane. Any
-      // future clickable scene mesh must either opt out of raycast (the
-      // raycast={noRaycast} convention used by decoratives) or call
-      // e.stopPropagation() in its own onClick. Otherwise deselection would
-      // silently stop working through that mesh.
-      if (shouldPassThroughGridPlane(e.intersections, meshRef.current)) return;
-      e.stopPropagation();
       store.clearSelection();
       return;
     }
-    // Paste / port / placement: the plane is the intended target, so we
-    // always consume the click here.
-    e.stopPropagation();
     // Paste tool: commit the clipboard at the snapped hover cell, then
     // return to pointer (commitPaste sets armedTool="pointer").
     if (store.armedTool === "paste") {


### PR DESCRIPTION
## Summary

Mirror image of #236. The invisible `GridPlane` at Three.js y=0 raycasts as the closest hit when the camera is below looking up, so clicks meant for a cube's bottom face (or any cube at z>0) were snapping to the y=0 plane instead. Existing pass-through only deferred to other meshes for the `pointer` and `paste` tools.

Drops the `armedTool` gate so `GridPlane` defers to any non-plane mesh along the ray, in edit mode. With this:

- Pipe placement on a cube's bottom face now attaches the pipe below the cube (uses `face.normal = (0,-1,0)` → `getAdjacentPos` picks `z = srcPos.z - dstSize[2]`).
- Selecting cubes at z>0 from below works (was already covered by pointer-mode pass-through).
- X-held delete and port-tool conversion now work from below too — incidental fixes that fell out of generalizing pass-through.
- Empty-grid clicks still hit only the plane, so place-on-grid and deselect-on-empty-click are unchanged.

## Pre-Landing Review

12 lines net behavior change in one file (`GridPlane.tsx`). Traced every mode × camera-direction permutation and every other clickable-mesh interaction:

| Mode | Camera below | Behavior |
|---|---|---|
| Pointer + cube z>0 | works | unchanged |
| Pointer + empty grid | clearSelection | unchanged |
| Pipe placement + cube bottom | **fixed** | attaches pipe to bottom face |
| Pipe placement + empty grid | snaps to grid | unchanged |
| Paste + cube | `commitPaste()` (uses hoveredGridPos) | unchanged |
| Port tool + cube | **fixed** | converts cube to port |
| X-held + cube | **fixed** | deletes cube |
| Build mode | separate `<mesh>` branch | unaffected |

One INFORMATIONAL finding auto-fixed: broadened the deselect-coupling comment to cover all coupled handlers (placement/paste/port/delete), since pass-through is no longer pointer-only.

## Test plan

- [x] `npx vitest run` — 450/450 passing
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint src/components/GridPlane.tsx` clean
- [x] `gridPlanePassthrough.test.ts` (5 tests) — helper unchanged, behavior change is in caller logic

Browser dogfood not possible from headless WebGL. Please rotate below the floor and try:
1. Pipe placement on a cube's bottom face
2. Selecting a cube whose TQEC z>0
3. X-held click on a cube above the floor
4. Port tool on a cube above the floor

🧙 Built with [WOZCODE](https://wozcode.com)