### PR TITLE
Cube cycle: offer types reachable via local pipe retype + Hadamard toggle

### DIFF
--- a/gui/src/components/Toolbar.tsx
+++ b/gui/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useBlockStore, type BuildStep } from "../stores/blockStore";
 import { useValidationStore } from "../stores/validationStore";
 import { useKeybindStore, type Mode as KeybindMode, type NavStyle } from "../stores/keybindStore";
-import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
+import { CUBE_TYPES, PIPE_VARIANTS, VARIANT_AXIS_MAP, isPipeType, pipeAxisFromPos, posKey, determineCubeOptions, determineCubeOptionsWithPipeRetype, hasYCubePipeAxisConflict, PIPE_TYPE_TO_VARIANT, traversedPipeKey } from "../types";
 import type { BlockType, CubeType, IsoAxis, PipeType, PipeVariant, Position3D } from "../types";
 import { downloadDae } from "../utils/daeExport";
 import { triggerDaeImport } from "../utils/daeImport";
@@ -195,10 +195,7 @@ export function Toolbar({
     if (pipeCount > 1) return "";
     const opts: string[] = pipeCount === 0
       ? [...CUBE_TYPES]
-      : (() => {
-          const result = determineCubeOptions(cursor, s.blocks);
-          return result.determined ? [result.type] : [...result.options];
-        })();
+      : determineCubeOptionsWithPipeRetype(cursor, s.blocks);
     // Y is a leaf: only valid with at most one attached (Z-open) pipe.
     if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", cursor, s.blocks)) opts.push("Y");
     return opts.join(",");
@@ -246,8 +243,7 @@ export function Toolbar({
         }
       }
     }
-    const result = determineCubeOptions(pos, s.blocks);
-    const opts: string[] = result.determined ? [result.type] : [...result.options];
+    const opts: string[] = determineCubeOptionsWithPipeRetype(pos, s.blocks);
     // Y is a leaf: only valid with at most one attached (Z-open) pipe.
     if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", pos, s.blocks)) opts.push("Y");
     return `${currentType};${pipeCount < 2 ? "1" : "0"};${opts.join(",")}`;

--- a/gui/src/stores/blockStore.test.ts
+++ b/gui/src/stores/blockStore.test.ts
@@ -1235,8 +1235,10 @@ describe("blockStore", () => {
     });
 
     it("free-build cube cycle accepts a CUBE_TYPE that color rules would reject", () => {
-      // OXZ pipe at (1,0,0) constrains the cube at (0,0,0) to Y=X, Z=Z (only
-      // ZXZ and XXZ pass). XZX has Y=Z and is rejected without freeBuild.
+      // OXZ pipe at (1,0,0). Cube candidate XZZ has identical Y/Z chars (Z,Z),
+      // so inferPipeType(XZZ, 0) = "OZZ" — not a valid PIPE_TYPE. The wider gate
+      // therefore rejects XZZ even though pipes could otherwise retype. freeBuild
+      // bypasses this and lets the user place XZZ anyway.
       useBlockStore.setState({ cubeType: "ZXZ" });
       useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
       useBlockStore.setState({ pipeVariant: "XZ" });
@@ -1248,12 +1250,12 @@ describe("blockStore", () => {
         selectedKeys: new Set(["0,0,0"]),
         freeBuild: false,
       });
-      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZX" });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZZ" });
       expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("ZXZ");
 
       useBlockStore.setState({ freeBuild: true });
-      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZX" });
-      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZX");
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZZ" });
+      expect(useBlockStore.getState().blocks.get("0,0,0")?.type).toBe("XZZ");
     });
 
     it("free-build cube cycle includes the port option even with two attached pipes", () => {
@@ -1284,6 +1286,278 @@ describe("blockStore", () => {
       expect(s.portPositions.has("3,0,0")).toBe(true);
       expect(s.selectedKeys.has("3,0,0")).toBe(false);
       expect(s.selectedPortPositions.has("3,0,0")).toBe(true);
+    });
+  });
+
+  describe("cycleSelectedType — wider gate retypes adjacent pipes", () => {
+    function setupColinearPortFarEnds() {
+      // Middle cube ZZX with two OZX pipes; both far-ends are ports (no cubes).
+      useBlockStore.setState({ cubeType: "ZZX" });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" }); // OZX on X-axis
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 4, y: 0, z: 0 });
+      useBlockStore.setState({
+        mode: "edit",
+        armedTool: "pointer",
+        selectedKeys: new Set(["3,0,0"]),
+        selectedPortPositions: new Set(),
+        freeBuild: false,
+      });
+    }
+
+    it("retypes adjacent pipes when cycling to a wider-set cube type", () => {
+      setupColinearPortFarEnds();
+      // XXZ would require T[1]=X, T[2]=Z — narrow would reject (pipes are OZX).
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XXZ" });
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("3,0,0")?.type).toBe("XXZ");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OXZ");
+      expect(s.blocks.get("4,0,0")?.type).toBe("OXZ");
+    });
+
+    it("undo restores cube AND retyped pipes", () => {
+      setupColinearPortFarEnds();
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XXZ" });
+      useBlockStore.getState().undo();
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("3,0,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OZX");
+      expect(s.blocks.get("4,0,0")?.type).toBe("OZX");
+    });
+
+    it("redo re-applies cube AND retyped pipes", () => {
+      setupColinearPortFarEnds();
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XXZ" });
+      useBlockStore.getState().undo();
+      useBlockStore.getState().redo();
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("3,0,0")?.type).toBe("XXZ");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OXZ");
+      expect(s.blocks.get("4,0,0")?.type).toBe("OXZ");
+    });
+
+    it("no-op when target type is not in the wider set (inferPipeType null)", () => {
+      // Place ZZX at (0,0,0) and (3,0,0), connect with OZX pipe. Target XZZ
+      // has same Y/Z chars (Z,Z); infer axis 0 = OZZ which is not a valid
+      // PIPE_TYPE. The wider gate excludes XZZ; the cycle is a no-op.
+      useBlockStore.setState({ cubeType: "ZZX" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.setState({
+        mode: "edit",
+        armedTool: "pointer",
+        selectedKeys: new Set(["0,0,0"]),
+        selectedPortPositions: new Set(),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZZ" });
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("0,0,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OZX");
+    });
+
+    it("frees a corner cube of a 4-cube square via H-toggle on perpendicular pipes", () => {
+      // The user's scenario: ZZX corner with two perpendicular non-H pipes
+      // and ZZX far-end corners. Cycling the corner to XXZ requires both
+      // pipes to take Hadamard. After cycle: cube=XXZ, pipe1=OXZH, pipe2=XOZH.
+      // Far-end corners (still ZZX) remain consistent because Hadamard swaps
+      // closed-axis chars at the far end — the swap matches ZZX.
+      useBlockStore.setState({ cubeType: "ZZX" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 3, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 1, z: 0 });
+
+      useBlockStore.setState({
+        mode: "edit",
+        armedTool: "pointer",
+        selectedKeys: new Set(["0,0,0"]),
+        selectedPortPositions: new Set(),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XXZ" });
+
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("0,0,0")?.type).toBe("XXZ");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OXZH");
+      expect(s.blocks.get("0,1,0")?.type).toBe("XOZH");
+      expect(s.blocks.get("3,0,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("0,3,0")?.type).toBe("ZZX");
+    });
+
+    it("cycles a corner of an 8-cube square frame (corners + edges, like the user's picture)", () => {
+      // Square frame: 4 corner cubes at (0,0,0), (6,0,0), (0,6,0), (6,6,0)
+      // and 4 edge cubes at (3,0,0), (0,3,0), (6,3,0), (3,6,0).
+      // 8 OZX/ZOX pipes connecting them.
+      useBlockStore.setState({ cubeType: "ZZX" });
+      // Corners
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 6, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 6, z: 0 });
+      useBlockStore.getState().addBlock({ x: 6, y: 6, z: 0 });
+      // Edges
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 3, z: 0 });
+      useBlockStore.getState().addBlock({ x: 6, y: 3, z: 0 });
+      useBlockStore.getState().addBlock({ x: 3, y: 6, z: 0 });
+      // X-axis pipes
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 4, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 1, y: 6, z: 0 });
+      useBlockStore.getState().addBlock({ x: 4, y: 6, z: 0 });
+      // Y-axis pipes (variant ZX on axis 1 = ZOX)
+      useBlockStore.getState().addBlock({ x: 0, y: 1, z: 0 });
+      useBlockStore.getState().addBlock({ x: 0, y: 4, z: 0 });
+      useBlockStore.getState().addBlock({ x: 6, y: 1, z: 0 });
+      useBlockStore.getState().addBlock({ x: 6, y: 4, z: 0 });
+      expect(useBlockStore.getState().blocks.size).toBe(16);
+
+      useBlockStore.setState({
+        mode: "edit",
+        armedTool: "pointer",
+        selectedKeys: new Set(["0,0,0"]),
+        selectedPortPositions: new Set(),
+        freeBuild: false,
+      });
+      // Cycle corner (0,0,0) forward — wider set is {ZZX, XXZ}; from ZZX
+      // we should land on XXZ with H added to both perpendicular pipes.
+      useBlockStore.getState().cycleSelectedType(1);
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("0,0,0")?.type).toBe("XXZ");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OXZH");
+      expect(s.blocks.get("0,1,0")?.type).toBe("XOZH");
+      // Other 7 cubes unchanged.
+      expect(s.blocks.get("3,0,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("6,0,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("0,3,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("0,6,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("6,6,0")?.type).toBe("ZZX");
+    });
+
+    it("Y target keeps adjacent pipe unchanged (Y is structural, not retypable)", () => {
+      // XZZ with a Z-axis pipe (XZO). Cycling to Y must leave the pipe alone.
+      useBlockStore.setState({ cubeType: "XZZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "XZ" });
+      useBlockStore.getState().addBlock({ x: 0, y: 0, z: 1 });
+      expect(useBlockStore.getState().blocks.get("0,0,1")?.type).toBe("XZO");
+      useBlockStore.setState({
+        mode: "edit",
+        armedTool: "pointer",
+        selectedKeys: new Set(["0,0,0"]),
+        selectedPortPositions: new Set(),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "Y" });
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("0,0,0")?.type).toBe("Y");
+      expect(s.blocks.get("0,0,1")?.type).toBe("XZO");
+    });
+
+    it("preserves Hadamard suffix when retyping pipes (cycleSelectedType)", () => {
+      // ZZX at (3,0,0); two pipes — left non-H, right H.
+      useBlockStore.setState({ cubeType: "ZZX" });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZXH" });
+      useBlockStore.getState().addBlock({ x: 4, y: 0, z: 0 });
+      expect(useBlockStore.getState().blocks.get("1,0,0")?.type).toBe("OZX");
+      expect(useBlockStore.getState().blocks.get("4,0,0")?.type).toBe("OZXH");
+
+      useBlockStore.setState({
+        mode: "edit",
+        armedTool: "pointer",
+        selectedKeys: new Set(["3,0,0"]),
+        selectedPortPositions: new Set(),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XXZ" });
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("3,0,0")?.type).toBe("XXZ");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OXZ");
+      expect(s.blocks.get("4,0,0")?.type).toBe("OXZH");
+    });
+
+    it("undo of port→cube transition restores selectedPortPositions (regression)", () => {
+      // Place an explicit port marker, select it, cycle to a cube, undo.
+      useBlockStore.getState().addPortAt({ x: 0, y: 0, z: 0 });
+      expect(useBlockStore.getState().portPositions.has("0,0,0")).toBe(true);
+      useBlockStore.setState({
+        mode: "edit",
+        armedTool: "pointer",
+        selectedKeys: new Set(),
+        selectedPortPositions: new Set(["0,0,0"]),
+        freeBuild: false,
+      });
+      useBlockStore.getState().cycleSelectedType(1, { kind: "cube", type: "XZZ" });
+      let s = useBlockStore.getState();
+      expect(s.blocks.get("0,0,0")?.type).toBe("XZZ");
+      expect(s.selectedKeys.has("0,0,0")).toBe(true);
+      expect(s.selectedPortPositions.has("0,0,0")).toBe(false);
+
+      useBlockStore.getState().undo();
+      s = useBlockStore.getState();
+      expect(s.blocks.has("0,0,0")).toBe(false);
+      expect(s.portPositions.has("0,0,0")).toBe(true);
+      expect(s.selectedPortPositions.has("0,0,0")).toBe(true);
+      expect(s.selectedKeys.has("0,0,0")).toBe(false);
+    });
+  });
+
+  describe("cycleBlock — wider gate retypes adjacent pipes", () => {
+    it("cycles cursor cube to a wider-set type and retypes adjacent pipes", () => {
+      useBlockStore.setState({ cubeType: "ZZX" });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 4, y: 0, z: 0 });
+
+      useBlockStore.setState({
+        mode: "build",
+        buildCursor: { x: 3, y: 0, z: 0 },
+        buildHistory: [],
+        freeBuild: false,
+      });
+
+      useBlockStore.getState().cycleBlock("XXZ");
+      const s = useBlockStore.getState();
+      expect(s.blocks.get("3,0,0")?.type).toBe("XXZ");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OXZ");
+      expect(s.blocks.get("4,0,0")?.type).toBe("OXZ");
+    });
+
+    it("cycleBlock undo+redo round-trips both cube and pipe retypes", () => {
+      useBlockStore.setState({ cubeType: "ZZX" });
+      useBlockStore.getState().addBlock({ x: 3, y: 0, z: 0 });
+      useBlockStore.setState({ pipeVariant: "ZX" });
+      useBlockStore.getState().addBlock({ x: 1, y: 0, z: 0 });
+      useBlockStore.getState().addBlock({ x: 4, y: 0, z: 0 });
+      useBlockStore.setState({
+        mode: "build",
+        buildCursor: { x: 3, y: 0, z: 0 },
+        buildHistory: [],
+        freeBuild: false,
+      });
+
+      useBlockStore.getState().cycleBlock("XXZ");
+      useBlockStore.getState().undo();
+      let s = useBlockStore.getState();
+      expect(s.blocks.get("3,0,0")?.type).toBe("ZZX");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OZX");
+      expect(s.blocks.get("4,0,0")?.type).toBe("OZX");
+
+      useBlockStore.getState().redo();
+      s = useBlockStore.getState();
+      expect(s.blocks.get("3,0,0")?.type).toBe("XXZ");
+      expect(s.blocks.get("1,0,0")?.type).toBe("OXZ");
+      expect(s.blocks.get("4,0,0")?.type).toBe("OXZ");
     });
   });
 

--- a/gui/src/stores/blockStore.ts
+++ b/gui/src/stores/blockStore.ts
@@ -27,6 +27,8 @@ import {
   computePipePos,
   inferPipeType,
   determineCubeOptions,
+  determineCubeOptionsWithPipeRetype,
+  computePipeRetypes,
   cameraAzimuthForDirection,
   canonicalCubeForPort,
   countAttachedPipes,
@@ -108,7 +110,8 @@ type UndoCommand =
   | { kind: "cube-cycle"; cubeKey: string; cubePos: Position3D;
       oldPlacedType: CubeType | "Y" | null; newPlacedType: CubeType | "Y" | null;
       oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }>;
-      oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo }
+      oldUndetermined?: UndeterminedCubeInfo; newUndetermined?: UndeterminedCubeInfo;
+      undeterminedNeighbors?: Array<{ key: string; oldInfo?: UndeterminedCubeInfo; newInfo?: UndeterminedCubeInfo }> }
   | { kind: "replace"; key: string; oldBlock: Block; newBlock: Block }
   | { kind: "add-port"; key: string }
   | { kind: "remove-port"; key: string }
@@ -119,7 +122,11 @@ type UndoCommand =
       prevSelectedKeys: string[]; nextSelectedKeys: string[] }
   | { kind: "edit-type-cycle"; key: string; pos: Position3D;
       oldBlock: Block | null; newBlock: Block | null;
-      oldPortMarker: boolean; newPortMarker: boolean };
+      oldPortMarker: boolean; newPortMarker: boolean;
+      oldPipes?: Array<{ key: string; oldType: PipeType; newType: PipeType }>;
+      prevSelectedKeys: string[]; nextSelectedKeys: string[];
+      prevSelectedPortPositions: string[]; nextSelectedPortPositions: string[];
+      undeterminedNeighbors?: Array<{ key: string; oldInfo?: UndeterminedCubeInfo; newInfo?: UndeterminedCubeInfo }> };
 
 interface BlockStore {
   blocks: Map<string, Block>;
@@ -928,8 +935,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         cubeOpts = new Set<CubeType | "Y">([...CUBE_TYPES, "Y"]);
         portAllowed = true;
       } else {
-        const result = determineCubeOptions(pos, s.blocks);
-        cubeOpts = new Set<CubeType | "Y">(result.determined ? [result.type] : result.options);
+        cubeOpts = new Set<CubeType | "Y">(determineCubeOptionsWithPipeRetype(pos, s.blocks));
         // Y is a leaf: only valid with at most one attached (Z-open) pipe.
         if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", pos, s.blocks)) cubeOpts.add("Y");
         portAllowed = pipeCount < 2;
@@ -988,6 +994,72 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         newPortMarker = false;
       }
 
+      // Retype adjacent pipes when target is a real cube (not Y / port) and not freeBuild.
+      // The wider gate already vetted feasibility; computePipeRetypes returns the actual
+      // updates (preserving Hadamard) or null on far-end conflict.
+      const pipeUpdates: Array<{ key: string; oldType: PipeType; newType: PipeType }> = [];
+      if (newBlock && nextOpt.kind === "cube" && nextOpt.type !== "Y" && !s.freeBuild) {
+        const retypes = computePipeRetypes(blocks, pos, nextOpt.type as CubeType);
+        if (retypes === null) {
+          // Defense-in-depth: revert spatial-index mutations from the just-applied
+          // cube placement and bail. (Shouldn't fire — wider gate vetted feasibility.)
+          doRemove(blocks, s.spatialIndex, hiddenFaces, key, newBlock);
+          if (existingBlock) {
+            doAdd(blocks, s.spatialIndex, hiddenFaces, key, existingBlock);
+          }
+          return s;
+        }
+        for (const pu of retypes) {
+          const pipeBlock = blocks.get(pu.key)!;
+          ({ blocks, hiddenFaces } = doRemove(blocks, s.spatialIndex, hiddenFaces, pu.key, pipeBlock));
+          ({ blocks, hiddenFaces } = doAdd(blocks, s.spatialIndex, hiddenFaces, pu.key, { pos: pipeBlock.pos, type: pu.newType }));
+          pipeUpdates.push(pu);
+        }
+      }
+
+      // Refresh undeterminedCubes for far-end neighbours of retyped pipes (mirrors
+      // the pipe-cycle pattern at line ~1519 and the cube-cycle path in cycleBlock).
+      const newUndetermined = new Map(s.undeterminedCubes);
+      const undeterminedNeighbors: Array<{ key: string; oldInfo?: UndeterminedCubeInfo; newInfo?: UndeterminedCubeInfo }> = [];
+      const seenNeighbors = new Set<string>();
+      for (const pu of pipeUpdates) {
+        const pipe = blocks.get(pu.key);
+        if (!pipe || !isPipeType(pipe.type)) continue;
+        const base = pipe.type.replace("H", "");
+        const openAxis = base.indexOf("O");
+        const pc: [number, number, number] = [pipe.pos.x, pipe.pos.y, pipe.pos.z];
+        for (const endOffset of [-1, 2]) {
+          const nc: [number, number, number] = [pc[0], pc[1], pc[2]];
+          nc[openAxis] += endOffset;
+          const nKey = posKey({ x: nc[0], y: nc[1], z: nc[2] });
+          if (nKey === key) continue;
+          if (seenNeighbors.has(nKey)) continue;
+          seenNeighbors.add(nKey);
+          const neighborBlock = blocks.get(nKey);
+          if (!neighborBlock || isPipeType(neighborBlock.type) || neighborBlock.type === "Y") continue;
+          const oldInfo = s.undeterminedCubes.get(nKey);
+          const opts = determineCubeOptions(neighborBlock.pos, blocks);
+          let newInfo: UndeterminedCubeInfo | undefined;
+          if (opts.determined) {
+            newInfo = undefined;
+          } else if (opts.options.length > 0) {
+            const idx = Math.max(0, opts.options.indexOf(neighborBlock.type as CubeType));
+            newInfo = { options: [...opts.options], currentIndex: idx };
+          } else {
+            newInfo = oldInfo;
+          }
+          const sameInfo =
+            (!oldInfo && !newInfo) ||
+            (!!oldInfo && !!newInfo &&
+              oldInfo.options.join(",") === newInfo.options.join(",") &&
+              oldInfo.currentIndex === newInfo.currentIndex);
+          if (sameInfo) continue;
+          undeterminedNeighbors.push({ key: nKey, oldInfo, newInfo });
+          if (newInfo) newUndetermined.set(nKey, newInfo);
+          else newUndetermined.delete(nKey);
+        }
+      }
+
       const newPorts = new Set(s.portPositions);
       if (newPortMarker) newPorts.add(key); else newPorts.delete(key);
 
@@ -1005,6 +1077,12 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         kind: "edit-type-cycle", key, pos,
         oldBlock: existingBlock, newBlock,
         oldPortMarker, newPortMarker,
+        oldPipes: pipeUpdates.length > 0 ? pipeUpdates : undefined,
+        prevSelectedKeys: [...s.selectedKeys],
+        nextSelectedKeys: [...newSelectedKeys],
+        prevSelectedPortPositions: [...s.selectedPortPositions],
+        nextSelectedPortPositions: [...newSelectedPorts],
+        undeterminedNeighbors: undeterminedNeighbors.length > 0 ? undeterminedNeighbors : undefined,
       };
       return {
         blocks,
@@ -1012,6 +1090,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         portPositions: newPorts,
         selectedKeys: newSelectedKeys,
         selectedPortPositions: newSelectedPorts,
+        undeterminedCubes: newUndetermined,
         history: [...s.history, cmd].slice(-MAX_HISTORY),
         future: [],
       };
@@ -1568,6 +1647,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         // Restore undetermined state
         if (cmd.oldUndetermined) newUndetermined.set(cmd.cubeKey, cmd.oldUndetermined);
         else newUndetermined.delete(cmd.cubeKey);
+        // Restore neighbour undetermined entries that were refreshed by the cycle
+        if (cmd.undeterminedNeighbors) {
+          for (const u of cmd.undeterminedNeighbors) {
+            if (u.oldInfo) newUndetermined.set(u.key, { ...u.oldInfo, options: [...u.oldInfo.options] });
+            else newUndetermined.delete(u.key);
+          }
+        }
         return { blocks, hiddenFaces, history: newHistory, future: [cmd, ...state.future].slice(0, MAX_HISTORY), undeterminedCubes: newUndetermined, hoveredGridPos: null };
       }
 
@@ -1591,12 +1677,33 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (cmd.oldBlock) {
           ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.key, cmd.oldBlock));
         }
+        // Revert pipe retypes
+        if (cmd.oldPipes) {
+          for (const pu of cmd.oldPipes) {
+            const pb = blocks.get(pu.key);
+            if (pb) {
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pb));
+              ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pb.pos, type: pu.oldType }));
+            }
+          }
+        }
         const newPorts = new Set(state.portPositions);
         if (cmd.oldPortMarker) newPorts.add(cmd.key); else newPorts.delete(cmd.key);
+        // Restore neighbour undetermined entries
+        const newUndetermined = new Map(state.undeterminedCubes);
+        if (cmd.undeterminedNeighbors) {
+          for (const u of cmd.undeterminedNeighbors) {
+            if (u.oldInfo) newUndetermined.set(u.key, { ...u.oldInfo, options: [...u.oldInfo.options] });
+            else newUndetermined.delete(u.key);
+          }
+        }
         return {
           blocks,
           hiddenFaces,
           portPositions: newPorts,
+          selectedKeys: new Set(cmd.prevSelectedKeys),
+          selectedPortPositions: new Set(cmd.prevSelectedPortPositions),
+          undeterminedCubes: newUndetermined,
           history: newHistory,
           future: [cmd, ...state.future].slice(0, MAX_HISTORY),
           hoveredGridPos: null,
@@ -1918,6 +2025,13 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         // Restore undetermined state
         if (cmd.newUndetermined) newUndetermined.set(cmd.cubeKey, cmd.newUndetermined);
         else newUndetermined.delete(cmd.cubeKey);
+        // Re-apply neighbour undetermined refresh from the original cycle
+        if (cmd.undeterminedNeighbors) {
+          for (const u of cmd.undeterminedNeighbors) {
+            if (u.newInfo) newUndetermined.set(u.key, { ...u.newInfo, options: [...u.newInfo.options] });
+            else newUndetermined.delete(u.key);
+          }
+        }
         return { blocks, hiddenFaces, history: [...state.history, cmd], future: newFuture, undeterminedCubes: newUndetermined, hoveredGridPos: null };
       }
 
@@ -1941,12 +2055,33 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
         if (cmd.newBlock) {
           ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cmd.key, cmd.newBlock));
         }
+        // Re-apply pipe retypes
+        if (cmd.oldPipes) {
+          for (const pu of cmd.oldPipes) {
+            const pb = blocks.get(pu.key);
+            if (pb) {
+              ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pb));
+              ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pb.pos, type: pu.newType }));
+            }
+          }
+        }
         const newPorts = new Set(state.portPositions);
         if (cmd.newPortMarker) newPorts.add(cmd.key); else newPorts.delete(cmd.key);
+        // Re-apply neighbour undetermined refresh
+        const newUndetermined = new Map(state.undeterminedCubes);
+        if (cmd.undeterminedNeighbors) {
+          for (const u of cmd.undeterminedNeighbors) {
+            if (u.newInfo) newUndetermined.set(u.key, { ...u.newInfo, options: [...u.newInfo.options] });
+            else newUndetermined.delete(u.key);
+          }
+        }
         return {
           blocks,
           hiddenFaces,
           portPositions: newPorts,
+          selectedKeys: new Set(cmd.nextSelectedKeys),
+          selectedPortPositions: new Set(cmd.nextSelectedPortPositions),
+          undeterminedCubes: newUndetermined,
           history: [...state.history, cmd],
           future: newFuture,
           hoveredGridPos: null,
@@ -3162,10 +3297,7 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       } else {
         cubeOptions = pipeCount === 0
           ? [...CUBE_TYPES]
-          : (() => {
-              const result = determineCubeOptions(cursor, state.blocks);
-              return result.determined ? [result.type] : result.options;
-            })();
+          : determineCubeOptionsWithPipeRetype(cursor, state.blocks);
         // Y is a leaf: only valid with at most one attached (Z-open) pipe.
         if (pipeCount <= 1 && !hasYCubePipeAxisConflict("Y", cursor, state.blocks)) cubeOptions.push("Y");
       }
@@ -3216,49 +3348,21 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       // Update adjacent pipes to match new cube type (skip for Y or port — neither changes pipes)
       // In free build mode, skip pipe retyping entirely — just change the cube
       if (newBlock && placeType !== "Y" && !state.freeBuild) {
-        const revert = () => {
-          ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock));
+        const retypes = computePipeRetypes(blocks, cursor, placeType as CubeType);
+        if (retypes === null) {
+          // Defense-in-depth: cubeOptions came from determineCubeOptionsWithPipeRetype,
+          // so this branch shouldn't fire. Revert spatial-index mutations and bail.
+          doRemove(blocks, state.spatialIndex, hiddenFaces, cursorKey, newBlock);
           if (existingBlock) {
-            ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, existingBlock));
+            doAdd(blocks, state.spatialIndex, hiddenFaces, cursorKey, existingBlock);
           }
-        };
-        for (let axis = 0; axis < 3; axis++) {
-          for (const pipeOffset of [1, -2]) {
-            const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
-            nCoords[axis] += pipeOffset;
-            const nKey = posKey({ x: nCoords[0], y: nCoords[1], z: nCoords[2] });
-            const neighbor = blocks.get(nKey);
-            if (!neighbor || !isPipeType(neighbor.type)) continue;
-
-            const base = neighbor.type.replace("H", "");
-            const hadamard = neighbor.type.length > 3;
-            const openAxis = base.indexOf("O");
-            if (openAxis !== axis) continue;
-
-            const newPipe = inferPipeType(placeType as CubeType, axis as 0 | 1 | 2);
-            if (!newPipe) {
-              revert();
-              return state;
-            }
-            const newPipeType = hadamard ? (newPipe + "H") as PipeType : newPipe;
-            if (newPipeType === neighbor.type) continue;
-
-            // Validate against far-end cube
-            const tmpBlocks = new Map(blocks);
-            tmpBlocks.set(nKey, { pos: neighbor.pos, type: newPipeType });
-            if (hasPipeColorConflict(newPipeType, neighbor.pos, tmpBlocks)) {
-              revert();
-              return state;
-            }
-            pipeUpdates.push({ key: nKey, oldType: neighbor.type as PipeType, newType: newPipeType });
-          }
+          return state;
         }
-
-        // Apply pipe mutations
-        for (const pu of pipeUpdates) {
+        for (const pu of retypes) {
           const pipeBlock = blocks.get(pu.key)!;
           ({ blocks, hiddenFaces } = doRemove(blocks, state.spatialIndex, hiddenFaces, pu.key, pipeBlock));
           ({ blocks, hiddenFaces } = doAdd(blocks, state.spatialIndex, hiddenFaces, pu.key, { pos: pipeBlock.pos, type: pu.newType }));
+          pipeUpdates.push(pu);
         }
       }
 
@@ -3266,11 +3370,55 @@ export const useBlockStore = create<BlockStore>((set, get) => ({
       const newUndetermined = new Map(state.undeterminedCubes);
       newUndetermined.delete(cursorKey);
 
+      // Refresh undeterminedCubes for far-end neighbours of retyped pipes
+      // (their option set may have narrowed/widened). Mirror the pipe-cycle
+      // pattern at line ~1519.
+      const undeterminedNeighbors: Array<{ key: string; oldInfo?: UndeterminedCubeInfo; newInfo?: UndeterminedCubeInfo }> = [];
+      const seenNeighbors = new Set<string>();
+      for (const pu of pipeUpdates) {
+        const pipe = blocks.get(pu.key);
+        if (!pipe || !isPipeType(pipe.type)) continue;
+        const base = pipe.type.replace("H", "");
+        const openAxis = base.indexOf("O");
+        const pc: [number, number, number] = [pipe.pos.x, pipe.pos.y, pipe.pos.z];
+        for (const endOffset of [-1, 2]) {
+          const nc: [number, number, number] = [pc[0], pc[1], pc[2]];
+          nc[openAxis] += endOffset;
+          const nKey = posKey({ x: nc[0], y: nc[1], z: nc[2] });
+          if (nKey === cursorKey) continue;
+          if (seenNeighbors.has(nKey)) continue;
+          seenNeighbors.add(nKey);
+          const neighborBlock = blocks.get(nKey);
+          if (!neighborBlock || isPipeType(neighborBlock.type) || neighborBlock.type === "Y") continue;
+          const oldInfo = state.undeterminedCubes.get(nKey);
+          const opts = determineCubeOptions(neighborBlock.pos, blocks);
+          let newInfo: UndeterminedCubeInfo | undefined;
+          if (opts.determined) {
+            newInfo = undefined;
+          } else if (opts.options.length > 0) {
+            const idx = Math.max(0, opts.options.indexOf(neighborBlock.type as CubeType));
+            newInfo = { options: [...opts.options], currentIndex: idx };
+          } else {
+            newInfo = oldInfo;
+          }
+          const sameInfo =
+            (!oldInfo && !newInfo) ||
+            (!!oldInfo && !!newInfo &&
+              oldInfo.options.join(",") === newInfo.options.join(",") &&
+              oldInfo.currentIndex === newInfo.currentIndex);
+          if (sameInfo) continue;
+          undeterminedNeighbors.push({ key: nKey, oldInfo, newInfo });
+          if (newInfo) newUndetermined.set(nKey, newInfo);
+          else newUndetermined.delete(nKey);
+        }
+      }
+
       const cmd: UndoCommand = {
         kind: "cube-cycle", cubeKey: cursorKey, cubePos: cursor,
         oldPlacedType: existingType, newPlacedType: placeType,
         oldPipes: pipeUpdates.length > 0 ? pipeUpdates : undefined,
         oldUndetermined, newUndetermined: undefined,
+        undeterminedNeighbors: undeterminedNeighbors.length > 0 ? undeterminedNeighbors : undefined,
       };
       return {
         blocks,

--- a/gui/src/types/index.test.ts
+++ b/gui/src/types/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, CUBE_TYPES, PIPE_TYPES } from "./index";
+import { createBlockGeometry, createYDefectEdges, getHiddenFaceMaskForPos, FACE_NEG_X, FACE_NEG_Y, FACE_NEG_Z, FACE_POS_X, FACE_POS_Y, FACE_POS_Z, isValidPipePos, isValidPos, isValidBlockPos, pipeAxisFromPos, resolvePipeType, getAdjacentPos, snapGroundPos, hasPipeColorConflict, hasCubeColorConflict, hasYCubePipeAxisConflict, canonicalCubeForPort, countAttachedPipes, wasdToBuildDirection, flipBlockType, defaultPortIO, getOrderedPortPositions, determineCubeOptions, determineCubeOptionsWithPipeRetype, computePipeRetypes, CUBE_TYPES, PIPE_TYPES } from "./index";
 import type { PipeType, CubeType, PortMeta } from "./index";
 import type { BlockType } from "./index";
 import { Vector3 } from "three";
@@ -657,5 +657,259 @@ describe("getOrderedPortPositions", () => {
     ]);
     const result = getOrderedPortPositions(blocks, explicitPorts, portMeta);
     expect(result.map((p) => p.x)).toEqual([0, 6, 3, 9]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wider cube-cycle helpers (allow adjacent pipes to retype)
+// ---------------------------------------------------------------------------
+
+describe("determineCubeOptionsWithPipeRetype", () => {
+  const ALL_CUBE_TYPES = [...CUBE_TYPES];
+
+  it("returns all cube types when no pipes are adjacent", () => {
+    const blocks = makeBlocks([]);
+    const opts = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    expect(opts.sort()).toEqual(ALL_CUBE_TYPES.sort());
+  });
+
+  it("widens beyond determineCubeOptions when far-end is a port", () => {
+    // Single X-open pipe at +x; far-end (3,0,0) is empty (port).
+    // Narrow gate constrains T[1]=Z, T[2]=X → [ZZX, XZX] only.
+    // Wider gate accepts any T whose inferred pipe is valid AND far-end port can host
+    // some cube — i.e., excludes only T's where inferPipeType returns null.
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" }]);
+
+    const narrow = determineCubeOptions({ x: 0, y: 0, z: 0 }, blocks);
+    const narrowList = narrow.determined ? [narrow.type] : narrow.options;
+    expect(narrowList.sort()).toEqual(["XZX", "ZZX"]);
+
+    const wider = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    expect(wider.sort()).toEqual(["XXZ", "XZX", "ZXZ", "ZZX"]);
+  });
+
+  it("excludes cube types whose inferred pipe would not be a valid PIPE_TYPE (OZZ/OXX)", () => {
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" }]);
+    const opts = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    // XZZ → OZZ (invalid), ZXX → OXX (invalid) — both must be rejected.
+    expect(opts).not.toContain("XZZ");
+    expect(opts).not.toContain("ZXX");
+  });
+
+  it("respects a fixed-cube far-end (constrains the wider set)", () => {
+    // Pipe OZX at +x with fixed far-end cube ZZX at (3,0,0).
+    // Without H toggle the narrow constraint is T[1]=Z, T[2]=X → [ZZX, XZX].
+    // With H toggle a non-H pipe can become H, so the swapped far-end
+    // constraint T[1]=X, T[2]=Z is also reachable → adds [ZXZ, XXZ].
+    // XZZ and ZXX still rejected because inferPipeType(_, 0) is null.
+    const blocks = makeBlocks([
+      { x: 1, y: 0, z: 0, type: "OZX" },
+      { x: 3, y: 0, z: 0, type: "ZZX" },
+    ]);
+    const opts = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    expect(opts.sort()).toEqual(["XXZ", "XZX", "ZXZ", "ZZX"]);
+  });
+
+  it("wider set is symmetric across all 4 corners of a 4-corner-only square", () => {
+    // 4 ZZX corners directly connected by 4 pipes (no edge cubes between).
+    // This exercises the case where the cube is at the +2 (FAR) end of some
+    // adjacent pipes — naive `inferPipeType(T, axis) + maybeH` is wrong for
+    // far-end with H, so we must enumerate all valid pipe variants on the axis.
+    const blocks = makeBlocks([
+      { x: 0, y: 0, z: 0, type: "ZZX" },
+      { x: 3, y: 0, z: 0, type: "ZZX" },
+      { x: 0, y: 3, z: 0, type: "ZZX" },
+      { x: 3, y: 3, z: 0, type: "ZZX" },
+      { x: 1, y: 0, z: 0, type: "OZX" }, // bottom edge
+      { x: 1, y: 3, z: 0, type: "OZX" }, // top edge
+      { x: 0, y: 1, z: 0, type: "ZOX" }, // left edge
+      { x: 3, y: 1, z: 0, type: "ZOX" }, // right edge
+    ]);
+    const expected = ["XXZ", "ZZX"];
+    expect(determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks).sort()).toEqual(expected);
+    expect(determineCubeOptionsWithPipeRetype({ x: 3, y: 0, z: 0 }, blocks).sort()).toEqual(expected);
+    expect(determineCubeOptionsWithPipeRetype({ x: 0, y: 3, z: 0 }, blocks).sort()).toEqual(expected);
+    expect(determineCubeOptionsWithPipeRetype({ x: 3, y: 3, z: 0 }, blocks).sort()).toEqual(expected);
+  });
+
+  it("frees a corner cube of a 4-cube square via H-toggle on perpendicular pipes", () => {
+    // The user's scenario: a square frame of ZZX corners connected by OZX
+    // (X-axis) and ZOX (Y-axis) pipes. Without H toggle the corner is pinned
+    // to ZZX. With H toggle, adding H to BOTH adjacent pipes lets the corner
+    // become XXZ (and reverse).
+    const blocks = makeBlocks([
+      // Corner under test at (0,0,0) — not placed; we only care about the
+      // wider set at this position.
+      // Pipe1 along +x and far-end corner.
+      { x: 1, y: 0, z: 0, type: "OZX" },
+      { x: 3, y: 0, z: 0, type: "ZZX" },
+      // Pipe2 along +y and far-end corner.
+      { x: 0, y: 1, z: 0, type: "ZOX" },
+      { x: 0, y: 3, z: 0, type: "ZZX" },
+    ]);
+    // Narrow gate uniquely determines ZZX here.
+    const narrow = determineCubeOptions({ x: 0, y: 0, z: 0 }, blocks);
+    expect(narrow.determined).toBe(true);
+    if (narrow.determined) expect(narrow.type).toBe("ZZX");
+
+    // Wider gate offers ZZX (current, both pipes preserved) and XXZ
+    // (both pipes toggled to H). Other types are blocked: a single H toggle
+    // creates contradicting T[2] constraints, and XZZ/ZXX/ZXZ/XZX have at
+    // least one inferPipeType null on axis 0 or axis 1.
+    const wider = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    expect(wider.sort()).toEqual(["XXZ", "ZZX"]);
+  });
+
+  it("considers H toggle when a non-H pipe alone cannot satisfy the candidate", () => {
+    // Pipe OXZ at +x, fixed far-end ZXZ.
+    // T=XZX without H toggle: inferred OZX at far-end ZXZ — no swap →
+    //   base[1]='Z' vs ZXZ[1]='X' conflict. With H toggle (OZXH): swap →
+    //   base[2]='X' vs ZXZ[1]='X' ✓ and base[1]='Z' vs ZXZ[2]='Z' ✓.
+    // So XZX is in the wider set thanks to H toggle.
+    const blocks = makeBlocks([
+      { x: 1, y: 0, z: 0, type: "OXZ" },
+      { x: 3, y: 0, z: 0, type: "ZXZ" },
+    ]);
+    expect(determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks))
+      .toContain("XZX");
+  });
+
+  it("widens beyond narrow when two colinear pipes have port far-ends (CLAUDE.md scenario)", () => {
+    // Two X-open pipes flanking (0,0,0); both far-ends are ports.
+    // Narrow: both pipes impose T[1]=Z, T[2]=X → [ZZX, XZX].
+    // Wider: pipes can retype together → all 4 valid (excludes XZZ, ZXX whose inferred pipe is invalid).
+    const blocks = makeBlocks([
+      { x: 1, y: 0, z: 0, type: "OZX" },
+      { x: -2, y: 0, z: 0, type: "OZX" },
+    ]);
+    const narrow = determineCubeOptions({ x: 0, y: 0, z: 0 }, blocks);
+    const narrowList = narrow.determined ? [narrow.type] : narrow.options;
+    expect(narrowList.sort()).toEqual(["XZX", "ZZX"]);
+
+    const wider = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    expect(wider.sort()).toEqual(["XXZ", "XZX", "ZXZ", "ZZX"]);
+  });
+
+  it("rejects cube types with no valid retype across both H states for some pipe", () => {
+    // Pipe1 (X-axis) far-end ZXZ; Pipe2 (Y-axis) far-end ZZX.
+    // Without H-toggle, no T satisfies (T[2] must be both Z and X). With
+    // H-toggle the constraints relax: XXZ works (pipe2 toggled to H) and
+    // ZZX works (pipe1 toggled to H). XZZ/ZXZ/ZXX/XZX all hit a null
+    // `inferPipeType` on one of the two axes, so they remain rejected.
+    const blocks = makeBlocks([
+      { x: 1, y: 0, z: 0, type: "OXZ" },
+      { x: 3, y: 0, z: 0, type: "ZXZ" },
+      { x: 0, y: 1, z: 0, type: "ZOX" },
+      { x: 0, y: 3, z: 0, type: "ZZX" },
+    ]);
+    const opts = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    expect(opts.sort()).toEqual(["XXZ", "ZZX"]);
+  });
+
+  it("returns CUBE_TYPES order (deterministic)", () => {
+    const blocks = makeBlocks([]);
+    const opts = determineCubeOptionsWithPipeRetype({ x: 0, y: 0, z: 0 }, blocks);
+    // Sequence must match CUBE_TYPES ordering, not arbitrary.
+    expect(opts).toEqual([...CUBE_TYPES]);
+  });
+});
+
+describe("computePipeRetypes", () => {
+  it("returns [] when there are no adjacent pipes", () => {
+    const blocks = makeBlocks([]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "XZZ");
+    expect(updates).toEqual([]);
+  });
+
+  it("returns [] when the inferred pipe equals the existing pipe", () => {
+    // Pipe OZX at +x; T=ZZX gives inferPipeType(ZZX, 0) = OZX (no change).
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" }]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "ZZX");
+    expect(updates).toEqual([]);
+  });
+
+  it("preserves Hadamard suffix on retype", () => {
+    // Pipe OZXH at +x; T=ZXZ gives base OXZ + H = OXZH (different from OZXH).
+    // Far-end is a port (no constraints), so retype succeeds.
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZXH" }]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "ZXZ");
+    expect(updates).toEqual([
+      { key: "1,0,0", oldType: "OZXH", newType: "OXZH" },
+    ]);
+  });
+
+  it("returns null when inferPipeType yields an invalid PIPE_TYPE", () => {
+    // T=XZZ has same chars on Y/Z axes (Z,Z); infer for axis 0 = OZZ which is not in PIPE_TYPES.
+    // (With H-toggle, a single pipe + fixed far-end never rejects on far-end alone — the
+    // closed-axis multiset always matches between any valid T and any valid far-end cube,
+    // so one of the two H states always validates. inferPipeType null is the only way for
+    // computePipeRetypes to return null for a single-pipe configuration.)
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" }]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "XZZ");
+    expect(updates).toBeNull();
+  });
+
+  it("returns updates for both colinear pipes when a cube cycle requires it", () => {
+    // Two OZX pipes at +x and -x; T=ZXZ requires both to become OXZ.
+    const blocks = makeBlocks([
+      { x: 1, y: 0, z: 0, type: "OZX" },
+      { x: -2, y: 0, z: 0, type: "OZX" },
+    ]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "ZXZ");
+    expect(updates).not.toBeNull();
+    expect(updates!.sort((a, b) => a.key.localeCompare(b.key))).toEqual(
+      [
+        { key: "-2,0,0", oldType: "OZX", newType: "OXZ" },
+        { key: "1,0,0", oldType: "OZX", newType: "OXZ" },
+      ].sort((a, b) => a.key.localeCompare(b.key)),
+    );
+  });
+
+  it("toggles Hadamard on perpendicular pipes to free a corner cube of a square", () => {
+    // Corner cube being cycled from ZZX to XXZ. Both perpendicular pipes
+    // currently non-H; the only way to satisfy XXZ at this corner is to
+    // toggle H on both pipes (so the swapped far-end ZZX still validates).
+    const blocks = makeBlocks([
+      { x: 1, y: 0, z: 0, type: "OZX" },
+      { x: 3, y: 0, z: 0, type: "ZZX" },
+      { x: 0, y: 1, z: 0, type: "ZOX" },
+      { x: 0, y: 3, z: 0, type: "ZZX" },
+    ]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "XXZ");
+    expect(updates).not.toBeNull();
+    expect(updates!.sort((a, b) => a.key.localeCompare(b.key))).toEqual(
+      [
+        { key: "0,1,0", oldType: "ZOX", newType: "XOZH" },
+        { key: "1,0,0", oldType: "OZX", newType: "OXZH" },
+      ].sort((a, b) => a.key.localeCompare(b.key)),
+    );
+  });
+
+  it("prefers H-preserved when both H states would validate (no unnecessary toggle)", () => {
+    // Far-end is a port (open both ways), so both OZX (preserved) and OZXH
+    // (toggled) satisfy the constraints for T=XZX. Helper should pick the
+    // preserved variant — no spurious Hadamard introduction.
+    const blocks = makeBlocks([{ x: 1, y: 0, z: 0, type: "OZX" }]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "XZX");
+    // T=XZX, axis 0: inferred = OZX. Pipe is already OZX → no change.
+    expect(updates).toEqual([]);
+  });
+
+  it("removes Hadamard when cycling back to a type that no longer needs it", () => {
+    // Inverse of the corner-square: pipes are H, target cube prefers no-H.
+    const blocks = makeBlocks([
+      { x: 1, y: 0, z: 0, type: "OXZH" },
+      { x: 3, y: 0, z: 0, type: "ZZX" },
+      { x: 0, y: 1, z: 0, type: "XOZH" },
+      { x: 0, y: 3, z: 0, type: "ZZX" },
+    ]);
+    const updates = computePipeRetypes(blocks, { x: 0, y: 0, z: 0 }, "ZZX");
+    expect(updates).not.toBeNull();
+    expect(updates!.sort((a, b) => a.key.localeCompare(b.key))).toEqual(
+      [
+        { key: "0,1,0", oldType: "XOZH", newType: "ZOX" },
+        { key: "1,0,0", oldType: "OXZH", newType: "OZX" },
+      ].sort((a, b) => a.key.localeCompare(b.key)),
+    );
   });
 });

--- a/gui/src/types/index.ts
+++ b/gui/src/types/index.ts
@@ -1337,6 +1337,153 @@ export function determineCubeOptions(
 }
 
 /**
+ * Lightweight `BlocksLookup` overlay: returns from `overrides` if present,
+ * else from `base`. Avoids `new Map(blocks)` clones in hot validation loops.
+ */
+class BlocksOverlay implements BlocksLookup {
+  private readonly base: BlocksLookup;
+  private readonly overrides: Map<string, Block>;
+  constructor(base: BlocksLookup, overrides: Map<string, Block>) {
+    this.base = base;
+    this.overrides = overrides;
+  }
+  get(key: string): Block | undefined {
+    return this.overrides.has(key) ? this.overrides.get(key) : this.base.get(key);
+  }
+}
+
+/**
+ * For a candidate cube T at one endpoint of pipe `n`, return the set of valid
+ * retyped pipe types whose other end still validates per `hasPipeColorConflict`.
+ *
+ * Enumerates all 4 pipe variants for the given open axis (2 base chars × {no H, H})
+ * and filters by overlay-validated `hasPipeColorConflict`. This is symmetric on
+ * both pipe endpoints — correctly handles cases where T is at the +2 (far) end
+ * of the pipe, where Hadamard swaps the basis chars at OUR end (not just the
+ * other end). Naive `inferPipeType(T, axis) + maybeH` is wrong for far-end
+ * with H because the chars need to be swapped first.
+ */
+function pipeRetypeCandidates(
+  cubePos: Position3D,
+  cubeKey: string,
+  T: CubeType,
+  axis: 0 | 1 | 2,
+  nPos: Position3D,
+  nKey: string,
+  blocks: BlocksLookup,
+): PipeType[] {
+  const out: PipeType[] = [];
+  for (const candidate of PIPE_TYPES) {
+    if ((candidate as string).replace("H", "").indexOf("O") !== axis) continue;
+    const overrides = new Map<string, Block>();
+    overrides.set(cubeKey, { pos: cubePos, type: T });
+    overrides.set(nKey, { pos: nPos, type: candidate });
+    const overlay = new BlocksOverlay(blocks, overrides);
+    if (!hasPipeColorConflict(candidate, nPos, overlay)) out.push(candidate);
+  }
+  return out;
+}
+
+/**
+ * Like `determineCubeOptions`, but allows the *adjacent pipes* to retype
+ * alongside the cube — including toggling Hadamard on a per-pipe basis. A
+ * candidate cube type `T` is valid iff every adjacent pipe has at least one
+ * retype variant (H or non-H) whose far end still validates per
+ * `hasPipeColorConflict`.
+ *
+ * This is the helper used by user-facing cube-cycle UI (cycleBlock,
+ * cycleSelectedType, Toolbar greying). Use the strict `determineCubeOptions`
+ * for canonicalisation (port auto-promote, .dae import) and pipe-cycle
+ * ambiguity detection — those compute "valid given existing pipes" and
+ * intentionally do not imply pipe retyping.
+ *
+ * Local-only semantic: only pipes directly adjacent to `cubePos` are
+ * considered for retyping. Far-end cubes are checked strictly. No multi-hop
+ * CSP. Returns `CubeType[]` in `CUBE_TYPES` order.
+ */
+export function determineCubeOptionsWithPipeRetype(
+  cubePos: Position3D,
+  blocks: BlocksLookup,
+): CubeType[] {
+  const cubeKey = posKey(cubePos);
+  const coords: [number, number, number] = [cubePos.x, cubePos.y, cubePos.z];
+  const result: CubeType[] = [];
+
+  for (const T of CUBE_TYPES) {
+    let ok = true;
+    for (let axis = 0; axis < 3 && ok; axis++) {
+      for (const pipeOffset of [1, -2]) {
+        const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+        nCoords[axis] += pipeOffset;
+        const nPos: Position3D = { x: nCoords[0], y: nCoords[1], z: nCoords[2] };
+        const nKey = posKey(nPos);
+        const neighbor = blocks.get(nKey);
+        if (!neighbor || !isPipeType(neighbor.type)) continue;
+
+        const base = neighbor.type.replace("H", "");
+        if (base.indexOf("O") !== axis) continue;
+
+        const candidates = pipeRetypeCandidates(
+          cubePos, cubeKey, T, axis as 0 | 1 | 2, nPos, nKey, blocks,
+        );
+        if (candidates.length === 0) { ok = false; break; }
+      }
+    }
+    if (ok) result.push(T);
+  }
+  return result;
+}
+
+/**
+ * Compute the pipe-retype updates required to make `newCubeType` consistent
+ * with adjacent pipes. Returns `null` if any adjacent pipe has no valid
+ * retype (neither H-preserved nor H-toggled). Returns `[]` when no pipe
+ * needs to change. For each pipe, prefers H-preserved when it works, falls
+ * back to H-toggled — so a non-H pipe stays non-H whenever possible.
+ *
+ * Used by both `cycleBlock` (build mode) and `cycleSelectedType` (edit mode)
+ * to keep their pipe-mutation logic in one place.
+ */
+export function computePipeRetypes(
+  blocks: BlocksLookup,
+  cubePos: Position3D,
+  newCubeType: CubeType,
+): Array<{ key: string; oldType: PipeType; newType: PipeType }> | null {
+  const cubeKey = posKey(cubePos);
+  const coords: [number, number, number] = [cubePos.x, cubePos.y, cubePos.z];
+  const updates: Array<{ key: string; oldType: PipeType; newType: PipeType }> = [];
+
+  for (let axis = 0; axis < 3; axis++) {
+    for (const pipeOffset of [1, -2]) {
+      const nCoords: [number, number, number] = [coords[0], coords[1], coords[2]];
+      nCoords[axis] += pipeOffset;
+      const nPos: Position3D = { x: nCoords[0], y: nCoords[1], z: nCoords[2] };
+      const nKey = posKey(nPos);
+      const neighbor = blocks.get(nKey);
+      if (!neighbor || !isPipeType(neighbor.type)) continue;
+
+      const oldType = neighbor.type as PipeType;
+      const oldHadamard = oldType.length > 3;
+      const base = oldType.replace("H", "");
+      if (base.indexOf("O") !== axis) continue;
+
+      const candidates = pipeRetypeCandidates(
+        cubePos, cubeKey, newCubeType, axis as 0 | 1 | 2, nPos, nKey, blocks,
+      );
+      if (candidates.length === 0) return null;
+      // Preference order: keep oldType if valid (no change); else prefer same H
+      // state as oldType (don't add/remove Hadamard if unnecessary); else any.
+      let newType: PipeType | undefined;
+      if (candidates.includes(oldType)) newType = oldType;
+      else newType = candidates.find((c) => (c.length > 3) === oldHadamard) ?? candidates[0];
+      if (newType === oldType) continue;
+      updates.push({ key: nKey, oldType, newType });
+    }
+  }
+  return updates;
+}
+
+/**
  * Return posKeys of pipes whose open-axis endpoint lies at cubePos.
  * Used by the cube → port conversion (must have ≤1) and by the cascade-delete
  * path (deleting a junction cube also removes its attached pipes).


### PR DESCRIPTION
## Summary

- Cycling a selected cube (edit-mode `←`/`→`, build-mode `C`, or toolbar click) now offers any cube type whose adjacent pipes can be retyped — including toggling Hadamard — to keep the local configuration valid; pipes auto-update on commit. Far-end cubes are checked strictly, so this stays a local retype, not a global CSP.
- Pipe-retype + Hadamard-preservation logic extracted into a shared pure helper `computePipeRetypes`, used by both `cycleBlock` and `cycleSelectedType`. The helper enumerates all valid pipe variants for the open axis and validates via `hasPipeColorConflict` (which correctly handles both pipe endpoints, including H swap when the cube is at the far end of a pipe).
- `edit-type-cycle` `UndoCommand` extended to track retyped pipes, prev/next selection sets (closes a pre-existing port↔cube selection-drift bug), and `undeterminedCubes` neighbour entries refreshed when far-end cube option sets change after retype.

## Test plan

- [x] `npm test` — 437/437 passing, including new unit tests for the helper (port/fixed-cube/Hadamard far-end, all-corners-of-a-square symmetry, prefer-H-preserved, removes-H-on-cycle-back) and store tests for cycle + undo/redo + selection regression.
- [ ] Manual: build a 4-cube `ZZX` square, click any corner → cycle to `XXZ` via toolbar or arrow keys; pipes gain Hadamards; cycle back removes them.
- [ ] Manual: build the same configuration with edge cubes (8-cube square frame); confirm corners still cycle.
- [ ] Manual: undo (`Cmd+Z`) restores cube + pipes + selection; redo re-applies all.

🧙 Built with [WOZCODE](https://wozcode.com)