### PR TITLE
docs: document Share link in README and in-app help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ a four-digit version: `MAJOR.MINOR.PATCH.MICRO`.
 
 ## [Unreleased]
 
+### Added
+- Document the **Share link** feature (File ▾ menu) in the README and in-app help.
+
 ## [0.1.0.0] - 2026-04-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Select two or more blocks and press `G` to bundle them into a group. Grouped blo
 
 ### Files
 - **Import** / **Export** round-trip through Collada (`.dae`) files.
+- **Share link** — copy a self-contained URL with the scene compressed into the hash fragment; opening the link restores the exact diagram. Capped at 6 KB; for larger scenes, use Export instead.
 - **Templates** — load a bundled example diagram (CNOT, CZ, move + rotation, three CNOTs, Steane encoding) as a starting point, or insert one into the current scene.
 
 ### Bundled templates

--- a/gui/src/components/HelpPanel.tsx
+++ b/gui/src/components/HelpPanel.tsx
@@ -153,6 +153,7 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
         <h4 style={{ margin: "14px 0 4px", fontSize: 13 }}>Files</h4>
         <ul style={{ margin: 0, paddingLeft: 18 }}>
           <li><b>Import</b>/<b>Export</b> round-trip through Collada (.dae) files.</li>
+          <li><b>Share link</b> copies a URL with the scene packed into the hash; opening it restores the diagram. Capped at 6 KB — use Export for larger scenes.</li>
         </ul>
 
         <p style={{ margin: "14px 0 0", fontSize: 12, color: "#666" }}>


### PR DESCRIPTION
## Summary
- Add a **Share link** bullet to the Files section of `README.md` describing the URL-hash share and the 6 KB cap.
- Mirror the same bullet in the in-app help (`HelpPanel.tsx` Files section) so users hitting `?` discover the feature.
- Log the documentation addition under `[Unreleased]` in `CHANGELOG.md` (the Share feature itself shipped in #231).

## Test plan
- [ ] Open `?` help in the app and confirm the Share link bullet renders under Files.
- [ ] Skim the rendered README on GitHub for the new bullet.

🧙 Built with [WOZCODE](https://wozcode.com)