### PR TITLE
chore(deps): group dependabot patch/minor PRs by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,17 @@ updates:
       interval: "weekly"
     target-branch: "dev"
     open-pull-requests-limit: 5
+    groups:
+      npm-production:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-development:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -13,6 +24,11 @@ updates:
       interval: "weekly"
     target-branch: "dev"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "pip"
     directory: "/"
@@ -20,3 +36,14 @@ updates:
       interval: "weekly"
     target-branch: "dev"
     open-pull-requests-limit: 5
+    groups:
+      pip-production:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+      pip-development:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Adds `groups:` config to `.github/dependabot.yml` so weekly patch + minor bumps land in **one PR per ecosystem** instead of one per package.
- npm and pip are split into `*-production` and `*-development` groups so prod-dep bumps stay reviewable separately from dev tooling churn.
- Major bumps are intentionally **not** grouped — they keep arriving as individual PRs so breaking changes get scrutiny.

## Motivation
Last week's batch was 5 separate PRs (#314–#318), one per package. #317 (react 19.2.5→19.2.6) failed CI because react-dom stayed at 19.2.5, hitting React's "must be the exact same version" guard. Grouping production deps prevents that class of split-PR peer-version mismatch — react and react-dom would have bumped in the same lockfile change.

## Expected effect
A typical week's 5 PRs collapses to ~2 (one prod, one dev per ecosystem).

## Test plan
- [ ] CI green on this PR
- [ ] Next weekly dependabot run produces grouped PRs (verify after merge — visible on Mondays)