### PR TITLE
Change default nave style to pan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ a four-digit version: `MAJOR.MINOR.PATCH.MICRO`.
 
 ## [Unreleased]
 
+### Changed
+- **Default camera navigation is now "Drag to pan"** (was "Drag to orbit").
+  Left-drag pans; middle/right-drag or <kbd>Shift</kbd>+drag orbits. Existing
+  users are reset to the new default once on upgrade (persist v16 → v17); anyone
+  who prefers orbit can re-pick "Drag to orbit" in Settings.
+
 ## [0.2.3.1] - 2026-05-11
 
 ### Fixed

--- a/gui/src/components/HelpPanel.tsx
+++ b/gui/src/components/HelpPanel.tsx
@@ -89,11 +89,12 @@ export function HelpPanel({ onClose }: { onClose: () => void }) {
         <ul style={{ margin: 0, paddingLeft: 18 }}>
           <li>Use <b>Undo</b>/<b>Redo</b> or Ctrl/Cmd+Z and Ctrl/Cmd+Shift+Z.</li>
           <li>
-            <b>Camera</b> — drag to orbit, middle/right-drag (or
-            <kbd>Shift</kbd>+drag) to pan, scroll to zoom. To make pan primary,
-            switch to “Drag to pan” in Settings; the gestures swap (drag pans,
-            middle/right-drag and <kbd>Shift</kbd>/<kbd>Alt</kbd>+drag orbit).
-            Use the <b>Iso ▾</b> menu to snap to an axis-locked orthographic view.
+            <b>Camera</b> — drag to pan, middle/right-drag (or
+            <kbd>Shift</kbd>+drag) to orbit, scroll to zoom. To make orbit
+            primary, switch to “Drag to orbit” in Settings; the gestures swap
+            (drag orbits, middle/right-drag and <kbd>Shift</kbd>/<kbd>Alt</kbd>+drag
+            pan). Use the <b>Iso-Plane View</b> button to snap to an axis-locked
+            orthographic view.
           </li>
           <li>
             <b>Shortcuts</b> — every key binding is listed and rebindable in

--- a/gui/src/stores/keybindStore.test.ts
+++ b/gui/src/stores/keybindStore.test.ts
@@ -7,20 +7,20 @@ function freshState() {
   return useKeybindStore.getState();
 }
 
-describe("keybindMigrate (v15 → v16 navStyle reset)", () => {
-  it("drops persisted navStyle when fromVersion < 16", () => {
-    const out = keybindMigrate({ navStyle: "pan", bindings: {} }, 15) as Record<string, unknown>;
+describe("keybindMigrate (navStyle reset on default flip)", () => {
+  it("drops persisted navStyle when fromVersion < 17", () => {
+    const out = keybindMigrate({ navStyle: "rotate", bindings: {} }, 16) as Record<string, unknown>;
     expect(out.navStyle).toBeUndefined();
     // Other fields survive.
     expect(out.bindings).toEqual({});
   });
 
-  it("preserves persisted navStyle when fromVersion >= 16", () => {
-    const out = keybindMigrate({ navStyle: "pan" }, 16) as Record<string, unknown>;
-    expect(out.navStyle).toBe("pan");
+  it("preserves persisted navStyle when fromVersion >= 17", () => {
+    const out = keybindMigrate({ navStyle: "rotate" }, 17) as Record<string, unknown>;
+    expect(out.navStyle).toBe("rotate");
   });
 
-  it("treats unversioned (fromVersion = 0) records as v15 — drops navStyle", () => {
+  it("treats unversioned (fromVersion = 0) records as pre-v17 — drops navStyle", () => {
     const out = keybindMigrate({ navStyle: "pan" }, 0) as Record<string, unknown>;
     expect(out.navStyle).toBeUndefined();
   });
@@ -47,20 +47,20 @@ describe("keybindMigrate (v15 → v16 navStyle reset)", () => {
 });
 
 describe("keybindMerge (post-migration rehydrate)", () => {
-  it("post-v16-migration: a v15 user with navStyle:'pan' lands on the new 'rotate' default", () => {
-    const migrated = keybindMigrate({ navStyle: "pan", bindings: {} }, 15);
+  it("post-v17-migration: a pre-v17 user with navStyle:'rotate' lands on the new 'pan' default", () => {
+    const migrated = keybindMigrate({ navStyle: "rotate", bindings: {} }, 16);
     const merged = keybindMerge(migrated, freshState());
-    expect(merged.navStyle).toBe("rotate");
+    expect(merged.navStyle).toBe("pan");
   });
 
   it("preserves an explicit user choice when navStyle is still present", () => {
-    const merged = keybindMerge({ navStyle: "pan" }, freshState());
-    expect(merged.navStyle).toBe("pan");
+    const merged = keybindMerge({ navStyle: "rotate" }, freshState());
+    expect(merged.navStyle).toBe("rotate");
   });
 
   it("falls back to the current default for invalid navStyle values", () => {
     const merged = keybindMerge({ navStyle: "wobble" } as unknown as object, freshState());
-    expect(merged.navStyle).toBe("rotate");
+    expect(merged.navStyle).toBe("pan");
   });
 
   it("preserves persisted boolean toggles even when navStyle is missing", () => {

--- a/gui/src/stores/keybindStore.ts
+++ b/gui/src/stores/keybindStore.ts
@@ -270,16 +270,18 @@ function cloneDefaults(): BindingsByMode {
 
 // Exported for unit testing. The `persist` config below is the only runtime caller.
 //
-// v16 (2026-05-07): the camera default flipped from "pan" → "rotate". Zustand
-// persist had already written the old default into every prior user's
-// localStorage, so the new default would otherwise never reach them. On
-// migration we drop the persisted navStyle so `keybindMerge` falls back to
-// the current default; users who explicitly preferred pan can re-pick it.
+// The camera default has been flipped twice. Each flip drops the persisted
+// navStyle on migration so `keybindMerge` falls back to the new code default;
+// Zustand persist had already written the old default into every prior user's
+// localStorage, so the new one would otherwise never reach them. Users who
+// explicitly preferred the old style can re-pick it.
+//   v16 (2026-05-07): "pan" → "rotate".
+//   v17 (2026-07-03): "rotate" → "pan".
 export function keybindMigrate(persisted: unknown, fromVersion: number): unknown {
   const p = (persisted ?? {}) as Partial<KeybindState> & Record<string, unknown>;
-  // Treat NaN / non-numeric / undefined as "older than v16" — corrupted or
-  // hand-edited records get the same one-time reset as anyone on v15.
-  if (!Number.isFinite(fromVersion) || (fromVersion as number) < 16) {
+  // Treat NaN / non-numeric / undefined as "older than v17" — corrupted or
+  // hand-edited records get the same one-time reset as anyone pre-v17.
+  if (!Number.isFinite(fromVersion) || (fromVersion as number) < 17) {
     delete p.navStyle;
   }
   return p;
@@ -322,7 +324,7 @@ export const useKeybindStore = create<KeybindState>()(
       bindings: cloneDefaults(),
       cameraFollowsBuild: false,
       axisAbsoluteWasd: false,
-      navStyle: "rotate",
+      navStyle: "pan",
 
       setBinding: (mode, action, binding) =>
         set((state) => {
@@ -357,7 +359,7 @@ export const useKeybindStore = create<KeybindState>()(
     }),
     {
       name: "piper-draw-keybinds",
-      version: 16,
+      version: 17,
       migrate: (persisted, fromVersion) => keybindMigrate(persisted, fromVersion) as KeybindState,
       merge: (persisted, current) => keybindMerge(persisted, current as KeybindState),
     },


### PR DESCRIPTION
<!--
  Target branch: dev (see CONTRIBUTING.md). Main is for releases.
-->

## Summary

The drag-to-rotate navigating style is unintuitive and new users need to either immediately get used to it or figure out if and how it can be changed.

## Test plan

- [x] `make test` (or `npm run test` from `gui/`) passes locally
- [x] Manually exercised the change in the GUI (where applicable)

## Architecture

- [x] Updated `ARCHITECTURE.md` if module boundaries changed (e.g. helpers moved
      between `utils/` ↔ `stores/`, a hot file split, a new directory added under
      `gui/src/`, or what a store owns changed). If this PR genuinely does not
      affect the architecture map, include `[arch-noop]` in the commit message
      to bypass the CI check.
